### PR TITLE
New improvements in dockerfile and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,4 +29,3 @@ npm-debug.log
 .elixir_ls/
 log/
 
-my_db/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+ae_mdw-*.tar
+
+# If NPM crashes, it generates a log, let's ignore it too.
+npm-debug.log
+
+.DS_Store
+.elixir_ls/
+log/
+
+my_db/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM elixir:1.10
+# Add required files to download and compile only the dependencies
+RUN apt-get -qq update && apt-get -qq -y install curl libsodium-dev jq build-essential libgmp10 \
+    && ldconfig \
+    && rm -rf /var/lib/apt/lists/*
+# Prepare working folder
+RUN mkdir -p /home/aeternity/node 
+
+# Download, and unzip latest aeternity release archive 
+WORKDIR /home/aeternity/node
+
+RUN mkdir -p ./local/rel/aeternity/data/mnesia
+RUN curl -s https://api.github.com/repos/aeternity/aeternity/releases/latest | \
+       jq '.assets[1].browser_download_url' | \
+       xargs curl -L --output aeternity.tar.gz  && tar -C ./local/rel/aeternity -xf aeternity.tar.gz 
+
+RUN cp -r ./local/rel/aeternity/lib local/
+
+# Copy elixir files needed to build a project
+RUN mkdir  ae_mdw/
+COPY config ./ae_mdw/config
+COPY lib ./ae_mdw/lib
+COPY priv ./ae_mdw/priv
+COPY mix.exs ae_mdw
+COPY mix.lock ae_mdw
+COPY Makefile ae_mdw
+COPY docker/entrypoint.sh ae_mdw/entrypoint.sh
+
+# Start building the mdw
+WORKDIR /home/aeternity/node/ae_mdw
+RUN  mix local.hex --force && mix local.rebar --force
+
+# Fetch the application dependencies and build the application
+RUN mix deps.get
+RUN mix deps.compile
+ENV NODEROOT=/home/aeternity/node/local
+RUN mix compile
+
+RUN chmod +x entrypoint.sh
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ compile: ## Compile Elixir code
 
 .PHONY: shell
 shell: ## Launch a mix shell with all modules compiled and loaded
-	clear && iex --sname $(name) -S $(mix) phx.server
+	iex --sname $(name) -S $(mix) phx.server
 
 .PHONY: format
 format: ## Format Elixir code

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ The NODEROOT directory should contain directories: `bin`, `lib`, `plugins`, `rel
   * Install dependencies with `mix deps.get`
   * Start middleware with `make shell`
 
+## Build and start with Docker
+As the project comes with `Dockerfile` and `docker-compose.yml`, it is possible to build and run it by using Docker:
+
+  * To build docker image, execute in root folder of the project: `docker-compose build`
+  * Start middleware image interactively with `docker-compose run --service-ports middleware sh`
+
 ## HTTP endpoints
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.1'
+services:
+  middleware:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    ports:
+      - "4000:4000" #MDW's default port
+      - "4001:4001" #MDW's websocket default port
+      - "3113:3113" #Node's default internal API port
+      - "3013:3013" #Node's default external API port
+      - "3014:3014" #Node's channels default websocket port
+    entrypoint: /home/aeternity/node/ae_mdw/entrypoint.sh
+    volumes:
+      - ${PWD}/mnesia:/home/aeternity/node/local/rel/aeternity/data/mnesia

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Docker entrypoint script.
+
+exec iex --sname aeternity@localhost -S mix phx.server 


### PR DESCRIPTION
This PR adds docker and describes how to quick-start project by using docker 
By default all of these ports are exposed:
4000 - MDW HTTP API endpoints port
4001 - MDW subscriptions websocket port
3013 - AE NODE external port
3113 - AE NODE internal port
3014 - AE NODE channel websocket port
Feedback and suggestions are always appreciated!