### PR TITLE
Link AE version files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ priv/static/frontend/
 .DS_Store
 .elixir_ls/
 log/
+REVISION
+VERSION

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ clean-backend: ## Clean backend artifacts
 	rm -rf \
 	_build \
 	deps \
+	REVISION \
+	VERSION \
 	mix.lock
 
 .PHONY: clean-frontend

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{
   "accept": {:hex, :accept, "0.3.5", "b33b127abca7cc948bbe6caa4c263369abf1347cfa9d8e699c6d214660f10cd1", [:rebar3], [], "hexpm", "11b18c220bcc2eab63b5470c038ef10eb6783bcb1fcdb11aa4137defa5ac1bb8"},
-  "ae_plugin": {:git, "https://github.com/aeternity/ae_plugin.git", "67c90a47804c204e7d781332df8f187f07dcd1ca", []},
+  "ae_plugin": {:git, "https://github.com/aeternity/ae_plugin.git", "f5438d957d871f6a32b10a2be8f6e7c4d3550534", []},
   "cors_plug": {:hex, :cors_plug, "2.0.2", "2b46083af45e4bc79632bd951550509395935d3e7973275b2b743bd63cc942ce", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "f0d0e13f71c51fd4ef8b2c7e051388e4dfb267522a83a22392c856de7e46465f"},
   "cowboy": {:hex, :cowboy, "2.8.0", "f3dc62e35797ecd9ac1b50db74611193c29815401e53bac9a5c0577bd7bc667d", [:rebar3], [{:cowlib, "~> 2.9.1", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "4643e4fba74ac96d4d152c75803de6fad0b3fa5df354c71afdd6cbeeb15fac8a"},
   "cowboy_telemetry": {:hex, :cowboy_telemetry, "0.3.1", "ebd1a1d7aff97f27c66654e78ece187abdc646992714164380d8a041eda16754", [:rebar3], [{:cowboy, "~> 2.7", [hex: :cowboy, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "3a6efd3366130eab84ca372cbd4a7d3c3a97bdfcfb4911233b035d117063f0af"},


### PR DESCRIPTION
This fix will make sure the version files are linked from ae_mdw directory when it's staring AE node.
So that the reply of:

```

$ curl -s "http://localhost:3013/v2/status" | jq '.'

```
has node_revision and node_version filled.