### PR TITLE
fix: don't read from cache the last 6 blocks

### DIFF
--- a/lib/ae_mdw_web/controllers/block_controller.ex
+++ b/lib/ae_mdw_web/controllers/block_controller.ex
@@ -16,7 +16,7 @@ defmodule AeMdwWeb.BlockController do
 
   @tab __MODULE__
 
-  # number of blocks behind latest that are cached
+  # number of generations congruent to last that are not cached
   @blocks_cache_threshold 6
 
   def table(), do: @tab

--- a/test/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/ae_mdw_web/controllers/block_controller_test.exs
@@ -241,6 +241,7 @@ defmodule AeMdwWeb.BlockControllerTest do
       assert Jason.encode!(response["data"]) == Jason.encode!(data)
       assert {%{"height" => ^range_begin}, _} = EtsCache.get(AeMdwWeb.BlockController.table(), range_begin)
       assert nil == EtsCache.get(AeMdwWeb.BlockController.table(), range_end)
+      assert nil == EtsCache.get(AeMdwWeb.BlockController.table(), range_end - @blocks_cache_threshold + 1)
 
       conn_next = get(conn, response["next"])
       response_next = json_response(conn_next, 200)

--- a/test/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/ae_mdw_web/controllers/block_controller_test.exs
@@ -12,6 +12,7 @@ defmodule AeMdwWeb.BlockControllerTest do
 
   import AeMdw.Db.Util
 
+  @blocks_table AeMdwWeb.BlockController.table()
   @default_limit 10
   @blocks_cache_threshold 6
 
@@ -211,8 +212,8 @@ defmodule AeMdwWeb.BlockControllerTest do
 
       assert Enum.count(response["data"]) == limit
       assert Jason.encode!(response["data"]) == Jason.encode!(data)
-      assert nil == EtsCache.get(AeMdwWeb.BlockController.table(), range_begin)
-      assert nil == EtsCache.get(AeMdwWeb.BlockController.table(), range_end)
+      assert nil == EtsCache.get(@blocks_table, range_begin)
+      assert nil == EtsCache.get(@blocks_table, range_end)
 
       # assert there's nothing next
       conn_next = get(conn, response["next"])
@@ -239,9 +240,9 @@ defmodule AeMdwWeb.BlockControllerTest do
 
       assert Enum.count(response["data"]) == limit
       assert Jason.encode!(response["data"]) == Jason.encode!(data)
-      assert {%{"height" => ^range_begin}, _} = EtsCache.get(AeMdwWeb.BlockController.table(), range_begin)
-      assert nil == EtsCache.get(AeMdwWeb.BlockController.table(), range_end)
-      assert nil == EtsCache.get(AeMdwWeb.BlockController.table(), range_end - @blocks_cache_threshold + 1)
+      assert {%{"height" => ^range_begin}, _} = EtsCache.get(@blocks_table, range_begin)
+      assert nil == EtsCache.get(@blocks_table, range_end)
+      assert nil == EtsCache.get(@blocks_table, range_end - @blocks_cache_threshold + 1)
 
       conn_next = get(conn, response["next"])
       response_next = json_response(conn_next, 200)

--- a/test/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/ae_mdw_web/controllers/block_controller_test.exs
@@ -218,19 +218,20 @@ defmodule AeMdwWeb.BlockControllerTest do
       conn_next = get(conn, response["next"])
       response_next = json_response(conn_next, 200)
 
-      assert Enum.count(response_next["data"]) == 0
+      assert Enum.empty?(response_next["data"])
     end
 
     test "get a mix of uncached and cached generations with range", %{conn: conn} do
       remaining = 3
       range_begin = (last_gen() - @blocks_cache_threshold + 1) - remaining
-      range_end = last_gen() - remaining
+      range_end = last_gen()
       range = "#{range_begin}-#{range_end}"
       limit = @blocks_cache_threshold
+
       conn = get(conn, "/blocks/#{range}?limit=#{limit}")
       response = json_response(conn, 200)
 
-      {:ok, data, has_cont?} =
+      {:ok, data, _has_cont?} =
         Cont.response_data(
           {BlockController, :blocks, %{}, conn.assigns.scope, 0},
           limit

--- a/test/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/ae_mdw_web/controllers/block_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule AeMdwWeb.BlockControllerTest do
-  use AeMdwWeb.ConnCase
+  use AeMdwWeb.ConnCase, async: false
 
   alias :aeser_api_encoder, as: Enc
   alias AeMdw.Validate
@@ -7,11 +7,13 @@ defmodule AeMdwWeb.BlockControllerTest do
   alias AeMdwWeb.{BlockController, TestUtil}
   alias AeMdwWeb.Continuation, as: Cont
   alias AeMdw.Error.Input, as: ErrInput
+  alias AeMdw.EtsCache
   require Model
 
   import AeMdw.Db.Util
 
   @default_limit 10
+  @blocks_cache_threshold 6
 
   describe "block" do
     test "get key block by hash", %{conn: conn} do
@@ -190,6 +192,65 @@ defmodule AeMdwWeb.BlockControllerTest do
         )
 
       assert Enum.count(response_next["data"]) == limit
+      assert Jason.encode!(response_next["data"]) == Jason.encode!(next_data)
+    end
+
+    test "get uncached generations with range", %{conn: conn} do
+      range_begin = last_gen() - @blocks_cache_threshold + 1
+      range_end = last_gen()
+      range = "#{range_begin}-#{range_end}"
+      limit = @blocks_cache_threshold
+      conn = get(conn, "/blocks/#{range}?limit=#{limit}")
+      response = json_response(conn, 200)
+
+      {:ok, data, _has_cont?} =
+        Cont.response_data(
+          {BlockController, :blocks, %{}, conn.assigns.scope, 0},
+          limit
+        )
+
+      assert Enum.count(response["data"]) == limit
+      assert Jason.encode!(response["data"]) == Jason.encode!(data)
+      assert nil == EtsCache.get(AeMdwWeb.BlockController.table(), range_begin)
+      assert nil == EtsCache.get(AeMdwWeb.BlockController.table(), range_end)
+
+      # assert there's nothing next
+      conn_next = get(conn, response["next"])
+      response_next = json_response(conn_next, 200)
+
+      assert Enum.count(response_next["data"]) == 0
+    end
+
+    test "get a mix of uncached and cached generations with range", %{conn: conn} do
+      remaining = 3
+      range_begin = (last_gen() - @blocks_cache_threshold + 1) - remaining
+      range_end = last_gen() - remaining
+      range = "#{range_begin}-#{range_end}"
+      limit = @blocks_cache_threshold
+      conn = get(conn, "/blocks/#{range}?limit=#{limit}")
+      response = json_response(conn, 200)
+
+      {:ok, data, has_cont?} =
+        Cont.response_data(
+          {BlockController, :blocks, %{}, conn.assigns.scope, 0},
+          limit
+        )
+
+      assert Enum.count(response["data"]) == limit
+      assert Jason.encode!(response["data"]) == Jason.encode!(data)
+      assert {%{"height" => ^range_begin}, _} = EtsCache.get(AeMdwWeb.BlockController.table(), range_begin)
+      assert nil == EtsCache.get(AeMdwWeb.BlockController.table(), range_end)
+
+      conn_next = get(conn, response["next"])
+      response_next = json_response(conn_next, 200)
+
+      {:ok, next_data, _has_cont?} =
+        Cont.response_data(
+          {BlockController, :blocks, %{}, conn.assigns.scope, limit},
+          limit
+        )
+
+      assert Enum.count(response_next["data"]) == remaining
       assert Jason.encode!(response_next["data"]) == Jason.encode!(next_data)
     end
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -20,7 +20,8 @@ defmodule AeMdwWeb.ConnCase do
   using do
     quote do
       # Import conveniences for testing with connections
-      use Phoenix.ConnTest
+      import Plug.Conn
+      import Phoenix.ConnTest
       alias AeMdwWeb.Router.Helpers, as: Routes
 
       # The default endpoint for testing


### PR DESCRIPTION
## What

Change controller of blocks endpoint to not read from cache the last 6 blocks.

The expiration of inserted blocks in the cache remains the same, based on `generations_cache_expiration_minutes` config. 

## Why

Issue [#194](https://github.com/aeternity/ae_mdw/issues/194)

https://mainnet.aeternity.art/mdw/blocks/444733-444733
https://mainnet.aeternity.io/mdw/blocks/444733-444733

count of microblocks is different

## Cause

Once inserted in the cache, a block is only updated after the expiration.

## Additional Notes

The list comprehension with `reduce` was replaced with `into` as it's a little faster and saves memory (around 50% according benchee).

fixes #194