### PR TITLE
fix: adjust tuple structure sent on AEX9 balances endpoints

### DIFF
--- a/test/ae_mdw_web/controllers/aex9_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex9_controller_test.exs
@@ -1,0 +1,41 @@
+defmodule AeMdwWeb.Aex9ControllerTest do
+  use AeMdwWeb.ConnCase, async: false
+
+  describe "balance_for_hash" do
+    test "gets balance for hash", %{conn: conn} do
+      mb_hash = "mh_2NkfQ9p29EQtqL6YQAuLpneTRPxEKspNYLKXeexZ664ZJo7fcw"
+      contract_id = "ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA"
+      account_id = "ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48"
+      conn = get(conn, "/aex9/balance/hash/#{mb_hash}/#{contract_id}/#{account_id}")
+
+      assert %{
+               "account_id" => "ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48",
+               "amount" => 49_999_999_999_906_850_000_000_000,
+               "block_hash" => ^mb_hash,
+               "contract_id" => ^contract_id,
+               "height" => 350_622
+             } = json_response(conn, 200)
+    end
+  end
+
+  describe "balances_for_hash" do
+    test "gets balances for hash", %{conn: conn} do
+      mb_hash = "mh_2NkfQ9p29EQtqL6YQAuLpneTRPxEKspNYLKXeexZ664ZJo7fcw"
+      contract_id = "ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA"
+      conn = get(conn, "/aex9/balances/hash/#{mb_hash}/#{contract_id}")
+
+      assert %{
+               "amounts" => %{
+                 "ak_2MHJv6JcdcfpNvu4wRDZXWzq8QSxGbhUfhMLR7vUPzRFYsDFw6" => 4_050_000_000_000,
+                 "ak_2Xu6d6W4UJBWyvBVJQRHASbQHQ1vjBA7d1XUeY8SwwgzssZVHK" => 8_100_000_000_000,
+                 "ak_CNcf2oywqbgmVg3FfKdbHQJfB959wrVwqfzSpdWVKZnep7nj4" => 81_000_000_000_000,
+                 "ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48" =>
+                   49_999_999_999_906_850_000_000_000
+               },
+               "block_hash" => ^mb_hash,
+               "contract_id" => ^contract_id,
+               "height" => 350_622
+             } = json_response(conn, 200)
+    end
+  end
+end


### PR DESCRIPTION
This was found using dialyzer, and was causing the AEX9 balance endpoints to return a 500 error.
