### PR TITLE
feat: backup and restore db table

### DIFF
--- a/lib/mix/tasks/backup_db_table.ex
+++ b/lib/mix/tasks/backup_db_table.ex
@@ -1,0 +1,105 @@
+defmodule Mix.Tasks.BackupDbTable do
+  use Mix.Task
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Util
+
+  @backup_suffix "Bkp"
+  @chunk_size 10_000
+  @sync_threshold 50_000
+
+  def set_sync_threshold,
+    do: Application.put_env(:mnesia, :dump_log_write_threshold, @sync_threshold)
+
+  def run(args) do
+    set_sync_threshold()
+    :net_kernel.start([:aeternity@localhost, :shortnames])
+    :ae_plugin_utils.start_aecore()
+    :lager.set_loglevel(:epoch_sync_lager_event, :lager_console_backend, :undefined, :error)
+    :lager.set_loglevel(:lager_console_backend, :error)
+    IO.puts("================================================================================")
+
+    table = table_atom(hd(args))
+
+    if nil == table do
+      IO.puts(
+        "Table #{table} does not exist. Use table atom like Elixir.AeMdw.Db.Model.ContractLog."
+      )
+
+      System.stop(1)
+    end
+
+    backup_table = backup_table(table)
+
+    {:ok, record_name} = create_backup_table(table, backup_table)
+
+    IO.puts("backing up #{record_name} records into #{backup_table}...")
+    record_count = copy_records(table, backup_table)
+    IO.puts("backup done for #{record_count} records.")
+
+    System.stop(0)
+  end
+
+  def copy_records(source_table, dest_table) do
+    {records_chunk, select_cont} = Util.select(source_table, [{:"$1", [], [:"$1"]}], @chunk_size)
+    initial_count = sync_write_chunk(dest_table, records_chunk)
+    stream_count = sync_write_stream(dest_table, select_cont)
+    initial_count + stream_count
+  end
+
+  defp sync_write_stream(table_atom, select_cont) do
+    Stream.resource(
+      fn -> select_cont end,
+      fn cont ->
+        case Util.select(cont) do
+          {chunk, cont} ->
+            {[chunk], cont}
+
+          :"$end_of_table" ->
+            {:halt, nil}
+        end
+      end,
+      fn nil -> nil end
+    )
+    |> Stream.map(fn records_chunk ->
+      write_count = sync_write_chunk(table_atom, records_chunk)
+      IO.puts("#{write_count}")
+      write_count
+    end)
+    |> Enum.sum()
+  end
+
+  defp sync_write_chunk(table_atom, records) do
+    :mnesia.sync_dirty(fn ->
+      Enum.each(records, &(:ok = :mnesia.write(table_atom, &1, :write)))
+    end)
+
+    length(records)
+  end
+
+  def table_atom(table_str), do: Enum.find(Model.tables(), &(Atom.to_string(&1) == table_str))
+
+  def backup_table(table) do
+    table
+    |> Atom.to_string()
+    |> Kernel.<>(@backup_suffix)
+    |> String.to_atom()
+  end
+
+  def create_backup_table(table, backup_table) do
+    :mnesia.delete_table(backup_table)
+
+    record_name = Model.record(table)
+
+    {:atomic, :ok} =
+      :mnesia.create_table(backup_table,
+        record_name: record_name,
+        attributes: Model.fields(record_name),
+        local_content: true,
+        type: :ordered_set,
+        disc_copies: [Node.self()]
+      )
+
+    {:ok, record_name}
+  end
+end

--- a/lib/mix/tasks/restore_db_table.ex
+++ b/lib/mix/tasks/restore_db_table.ex
@@ -1,0 +1,34 @@
+defmodule Mix.Tasks.RestoreDbTable do
+  use Mix.Task
+
+  alias AeMdw.Db.Model
+
+  import Mix.Tasks.BackupDbTable, except: [run: 1]
+
+  def run(args) do
+    set_sync_threshold()
+    :net_kernel.start([:aeternity@localhost, :shortnames])
+    :ae_plugin_utils.start_aecore()
+    :lager.set_loglevel(:epoch_sync_lager_event, :lager_console_backend, :undefined, :error)
+    :lager.set_loglevel(:lager_console_backend, :error)
+    IO.puts("================================================================================")
+    table = table_atom(hd(args))
+
+    if nil == table do
+      IO.puts(
+        "Table #{table} does not exist. Use table atom like Elixir.AeMdw.Db.Model.ContractLog."
+      )
+
+      System.stop(1)
+    end
+
+    backup_table = backup_table(table)
+
+    IO.puts("restoring #{Model.record(table)} records from #{backup_table}...")
+    restore_count = copy_records(backup_table, table)
+    :mnesia.delete_table(backup_table)
+    IO.puts("backup restored for #{restore_count} records.")
+
+    System.stop(0)
+  end
+end

--- a/test/mix/tasks/tasks_test.exs
+++ b/test/mix/tasks/tasks_test.exs
@@ -1,0 +1,28 @@
+defmodule AeMdw.MixTasksTest do
+  use ExUnit.Case
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Util
+  alias Mix.Tasks.BackupDbTable
+
+  test "backup and restore db table" do
+    table = Model.ContractLog
+    backup_table = BackupDbTable.backup_table(table)
+    {:ok, record_name} = BackupDbTable.create_backup_table(table, backup_table)
+
+    IO.puts("testing backup for #{table} with #{record_name} records")
+
+    records_before = Util.select(table, [{:"$1", [], [:"$1"]}])
+
+    backup_count = BackupDbTable.copy_records(table, backup_table)
+    assert backup_count == length(records_before)
+
+    IO.puts("restoring ...")
+
+    restore_count = BackupDbTable.copy_records(table, backup_table)
+    assert restore_count == length(records_before)
+
+    records_after = Util.select(table, [{:"$1", [], [:"$1"]}])
+    assert records_after == records_before
+  end
+end


### PR DESCRIPTION
## What

Mix tasks to backup and restore a single db table.

## Why

Database is too big to be backed up. 
This is a task to help with development and bugfix of issues involving one or more mnesia table states.

## Validation steps

elixir --sname aeternity@localhost -S mix test test/mix/tasks/tasks_test.exs`

pick randomly other two tables from Model.tables() to run:
`mix backup_db_table [table_module]`
`mix restore_db_table [table_module]`

## Additional Notes

Avoids just copying the table directory to be implementation independent (state completly controlled by mnesia and mnesia backend).