### PR TITLE
test: small integration tests updates

### DIFF
--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -7,6 +7,7 @@ defmodule AeMdwWeb.TxController do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Format
   alias AeMdw.Db.Stream, as: DBS
+  alias AeMdw.Error.Input, as: ErrInput
   alias AeMdwWeb.Continuation, as: Cont
   alias AeMdwWeb.SwaggerParameters
   require Model
@@ -75,7 +76,7 @@ defmodule AeMdwWeb.TxController do
     do: tx_reply(conn, nil)
 
   defp tx_reply(conn, nil),
-    do: conn |> send_error(:not_found, "no such transaction")
+    do: conn |> send_error(ErrInput.NotFound, "no such transaction")
 
   defp tx_reply(conn, [model_tx]),
     do: tx_reply(conn, model_tx)

--- a/test/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/ae_mdw_web/controllers/block_controller_test.exs
@@ -89,7 +89,7 @@ defmodule AeMdwWeb.BlockControllerTest do
       mbi = 4999
       conn = get(conn, "/blocki/#{kbi}/#{mbi}")
 
-      assert json_response(conn, 400) ==
+      assert json_response(conn, 404) ==
                %{"error" => TestUtil.handle_input(fn -> get_blocki(conn.params) end)}
     end
 

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -359,7 +359,7 @@ defmodule AeMdwWeb.NameControllerTest do
       name = "no--such--name--in--the--chain.chain"
       conn = get(conn, "/name/#{name}")
 
-      assert json_response(conn, 400) == %{
+      assert json_response(conn, 404) == %{
                "error" => TestUtil.handle_input(fn -> get_name(Validate.plain_name!(name)) end)
              }
     end
@@ -368,7 +368,7 @@ defmodule AeMdwWeb.NameControllerTest do
   describe "pointers" do
     @tag :integration
     test "get pointers for valid given name", %{conn: conn} do
-      id = "wwwbeaconoidcom.chain"
+      id = "cryptodao21ae.chain"
       conn = get(conn, "/name/pointers/#{id}")
 
       assert json_response(conn, 200) ==
@@ -380,7 +380,7 @@ defmodule AeMdwWeb.NameControllerTest do
       id = "no--such--name--in--the--chain.chain"
       conn = get(conn, "/name/pointers/#{id}")
 
-      assert json_response(conn, 400) == %{
+      assert json_response(conn, 404) == %{
                "error" => TestUtil.handle_input(fn -> get_poiters(Validate.plain_name!(id)) end)
              }
     end

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -407,7 +407,7 @@ defmodule AeMdwWeb.OracleControllerTest do
     @tag :integration
     test "renders error when the access is random ", %{conn: conn} do
       limit = 2
-      page = 2
+      page = 3
       conn = get(conn, "/oracles/active?limit=#{limit}&page=#{page}")
 
       assert json_response(conn, 400) == %{"error" => "random access not supported"}

--- a/test/ae_mdw_web/controllers/util_controller_test.exs
+++ b/test/ae_mdw_web/controllers/util_controller_test.exs
@@ -14,7 +14,7 @@ defmodule AeMdwWeb.UtilControllerTest do
 
       conn = get(conn, "/status")
 
-      assert json_response(conn, 200) == %{
+      assert Map.drop(json_response(conn, 200), ["node_revision", "mdw_syncing"]) == %{
                "mdw_version" => AeMdw.MixProject.project()[:version],
                "node_version" => to_string(node_vsn),
                "mdw_height" => mdw_height,


### PR DESCRIPTION
## What

Fixes some integration test cases.

## Why

Tests not passing with middleware synced:

test txi renders errors when data is not found (AeMdwWeb.TxControllerTest)
test pointers renders error when the name is missing (AeMdwWeb.NameControllerTest)
test name renders error when no such name is present (AeMdwWeb.NameControllerTest)
test pointers get pointers for valid given name (AeMdwWeb.NameControllerTest)
test blocki renders error when mickro block index is not present (AeMdwWeb.BlockControllerTest)
test status get middleware status (AeMdwWeb.UtilControllerTest)

## Additional Notes

There is 1 remaining in OracleControllerTest related to side effects. 
```
  1) test active_oracles renders error when the access is random  (AeMdwWeb.OracleControllerTest)
     test/ae_mdw_web/controllers/oracle_controller_test.exs:408
     ** (RuntimeError) expected response with status 400, got: 200, with body:
     "{\"data\":[],\"next\":null}"
```
It passes when running only the test file:
`elixir --sname aeternity@localhost -S mix test.integration test/ae_mdw_web/controllers/oracle_controller_test.exs`