### PR TITLE
database: automate migration

### DIFF
--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -6,6 +6,10 @@ defmodule AeMdw.Db.Model do
 
   ################################################################################
 
+  # version is like 20210826171900 in 20210826171900_reindex_remote_logs.ex
+  @migrations_defaults [index: -1, inserted_at: nil]
+  defrecord :migrations, @migrations_defaults
+
   # txs block index :
   #     index = {kb_index (0..), mb_index}, tx_index = tx_index, hash = block (header) hash
   #     if tx_index == nil -> txs not synced yet on that height
@@ -313,7 +317,7 @@ defmodule AeMdw.Db.Model do
   defrecord :id_fname_int_contract_call, @id_fname_int_contract_call_defaults
 
   # grp_id_fname_int_contract_call:
-  #    index: {create txi, id pk, fname, id pos, call txi, local idx} 
+  #    index: {create txi, id pk, fname, id pos, call txi, local idx}
   @grp_id_fname_int_contract_call_defaults [
     index: {-1, <<>>, "", -1, -1, -1},
     unused: nil
@@ -376,7 +380,8 @@ defmodule AeMdw.Db.Model do
         name_tables(),
         contract_tables(),
         oracle_tables(),
-        stat_tables()
+        stat_tables(),
+        migration_tables()
       ])
 
   def chain_tables() do
@@ -453,6 +458,10 @@ defmodule AeMdw.Db.Model do
     ]
   end
 
+  def migration_tables() do
+    [AeMdw.Db.Model.Migrations]
+  end
+
   def records(),
     do: [
       :tx,
@@ -496,12 +505,14 @@ defmodule AeMdw.Db.Model do
       :kind_int_transfer_tx,
       :target_int_transfer_tx,
       :stat,
-      :sum_stat
+      :sum_stat,
+      :migrations
     ]
 
   def fields(record),
     do: for({x, _} <- defaults(record), do: x)
 
+  def record(AeMdw.Db.Model.Migrations), do: :migrations
   def record(AeMdw.Db.Model.Tx), do: :tx
   def record(AeMdw.Db.Model.Block), do: :block
   def record(AeMdw.Db.Model.Time), do: :time
@@ -552,6 +563,7 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.Stat), do: :stat
   def record(AeMdw.Db.Model.SumStat), do: :sum_stat
 
+  def table(:migrations), do: AeMdw.Db.Model.Migrations
   def table(:tx), do: AeMdw.Db.Model.Tx
   def table(:block), do: AeMdw.Db.Model.Block
   def table(:time), do: AeMdw.Db.Model.Time
@@ -588,6 +600,7 @@ defmodule AeMdw.Db.Model do
   def table(:stat), do: AeMdw.Db.Model.Stat
   def table(:sum_stat), do: AeMdw.Db.Model.SumStat
 
+  def defaults(:migrations), do: @migrations_defaults
   def defaults(:tx), do: @tx_defaults
   def defaults(:block), do: @block_defaults
   def defaults(:time), do: @time_defaults

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -6,7 +6,7 @@ defmodule AeMdw.Db.Model do
 
   ################################################################################
 
-  # version is like 20210826171900 in 20210826171900_reindex_remote_logs.ex
+  # index is version like 20210826171900 in 20210826171900_reindex_remote_logs.ex
   @migrations_defaults [index: -1, inserted_at: nil]
   defrecord :migrations, @migrations_defaults
 

--- a/lib/ae_mdw/db/setup.ex
+++ b/lib/ae_mdw/db/setup.ex
@@ -2,6 +2,9 @@ defmodule AeMdw.Db.Setup do
   require AeMdw.Db.Model
   alias AeMdw.Db.Model
 
+  def create_table(name),
+    do: :mnesia.create_table(name, tab_def(name, mode()))
+
   def create_tables(),
     do: create_tables(mode())
 

--- a/lib/ae_mdw/db/setup.ex
+++ b/lib/ae_mdw/db/setup.ex
@@ -2,9 +2,6 @@ defmodule AeMdw.Db.Setup do
   require AeMdw.Db.Model
   alias AeMdw.Db.Model
 
-  def create_table(name),
-    do: :mnesia.create_table(name, tab_def(name, mode()))
-
   def create_tables(),
     do: create_tables(mode())
 

--- a/lib/mix/tasks/migrate_db.ex
+++ b/lib/mix/tasks/migrate_db.ex
@@ -65,7 +65,10 @@ defmodule Mix.Tasks.MigrateDb do
     |> Enum.sort_by(fn {version, _path} -> version end)
   end
 
-  @spec apply_migration!({integer(), String.t()}) :: true
+  # ignore for Code.compile_file
+  @dialyzer {:no_return, apply_migration!: 1}
+
+  @spec apply_migration!({integer(), String.t()}) :: :ok
   defp apply_migration!({version, path}) do
     [{module, _}] = Code.compile_file(path)
     Log.info("applying version #{version} with #{module}...")
@@ -76,6 +79,6 @@ defmodule Mix.Tasks.MigrateDb do
     end)
 
     Log.info("applied version #{version}")
-    true
+    :ok
   end
 end

--- a/lib/mix/tasks/migrate_db.ex
+++ b/lib/mix/tasks/migrate_db.ex
@@ -1,0 +1,77 @@
+defmodule Mix.Tasks.MigrateDb do
+  use Mix.Task
+
+  require Ex2ms
+  require Record
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Util
+  alias AeMdw.Log
+
+  import Record, only: [defrecord: 2]
+
+  # version is like 20210826171900 in 20210826171900_reindex_remote_logs.ex
+  @record_name :migrations
+  @defaults [version: -1, inserted_at: nil]
+
+  defrecord @record_name, @defaults
+
+  @fields for {k,_v} <- @defaults, do: k
+  @version_len 14
+
+  def run(_) do
+    :net_kernel.start([:aeternity@localhost, :shortnames])
+    :ae_plugin_utils.start_aecore()
+    :lager.set_loglevel(:epoch_sync_lager_event, :lager_console_backend, :undefined, :error)
+    :lager.set_loglevel(:lager_console_backend, :error)
+    Log.info("================================================================================")
+    exists? = Enum.find_value(:mnesia.system_info(:local_tables), false,
+      fn table ->
+        if table == Model.Migrations, do: true
+      end)
+
+    if not exists? do
+      :mnesia.create_table(Model.Migrations,
+        record_name: @record_name,
+        attributes: @fields,
+        local_content: true,
+        type: :ordered_set,
+        disc_copies: [Node.self()]
+      )
+    end
+
+    version_spec = Ex2ms.fun do
+      {_, version, _} -> version
+    end
+
+    max_version = Util.select(Model.Migrations, version_spec) |> Enum.max(fn -> -1 end)
+    Log.info("current migration version: #{max_version}")
+
+    "priv/migrations/*.ex"
+    |> Path.wildcard()
+    |> Enum.map(fn path ->
+      version =
+        path
+        |> Path.basename()
+        |> String.slice(0..@version_len-1)
+
+      {String.to_integer(version), path}
+    end)
+    |> Enum.sort_by(fn {version, _path} -> version end)
+    |> Enum.each(fn {int_version, path} ->
+      if int_version > max_version do
+        [{module, _}] = Code.compile_file(path)
+        Log.info("applying version #{int_version} with #{module}...")
+        {:ok, _} = apply(module, :run, [])
+        :mnesia.sync_dirty(fn ->
+          :mnesia.write(Model.Migrations, {@record_name, int_version, DateTime.utc_now()}, :write)
+        end)
+        Log.info("applied version #{int_version}")
+      else
+        Log.info("version #{int_version} already applied")
+      end
+    end)
+    :mnesia.dump_log()
+    System.stop(0)
+  end
+end

--- a/lib/mix/tasks/migrate_db.ex
+++ b/lib/mix/tasks/migrate_db.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.MigrateDb do
       @migrations_code_path
       |> list_migrations_modules()
       |> Enum.map(&maybe_apply_migration(&1, current_version))
-      |> Enum.count(&(&1))
+      |> Enum.count(& &1)
 
     # assure filesystem sync
     if applied_count > 0, do: :mnesia.dump_log()
@@ -41,7 +41,8 @@ defmodule Mix.Tasks.MigrateDb do
       Ex2ms.fun do
         {_, version, _} -> version
       end
-      Util.select(table, version_spec) |> Enum.max(fn -> -1 end)
+
+    Util.select(table, version_spec) |> Enum.max(fn -> -1 end)
   end
 
   @spec list_migrations_modules(String.t()) :: [{integer(), String.t()}]

--- a/priv/migrations/20210826171900_reindex_remote_logs.ex
+++ b/priv/migrations/20210826171900_reindex_remote_logs.ex
@@ -30,7 +30,7 @@ defmodule AeMdw.Migrations.ReindexRemoteLogs do
   For these new records, the ext_contract field is tagged with {:parent_contract_pk, pubkey} where pubkey
   is the one of the caller contract.
   """
-  @spec run() :: {non_neg_integer(), pos_integer()}
+  @spec run() :: {:ok, {non_neg_integer(), pos_integer()}}
   def run do
     begin = DateTime.utc_now()
 
@@ -63,7 +63,7 @@ defmodule AeMdw.Migrations.ReindexRemoteLogs do
     duration = DateTime.diff(DateTime.utc_now(), begin)
     IO.puts("Indexed #{reindexed_count} records in #{duration}s")
 
-    {reindexed_count, duration}
+    {:ok, {reindexed_count, duration}}
   end
 
   @spec safe_contract_pk({integer(), any(), any(), any()}) :: binary() | nil


### PR DESCRIPTION
## What

Ecto-like database migration automation.

## Why

Issue #193
Avoids running migrations twice and saves the state to follow the changes in db structure and data.

## Validation steps

1. `make shell`
2. `mix migrate_db`
This migration is expected to be applied:
```
10:57:54.933 [info]  applying version 20210826171900 with Elixir.AeMdw.Migrations.ReindexRemoteLogs...
table size: 177072
Indexed 32142 records in 62s

10:58:56.870 [info]  applied version 20210826171900
```
3. `mix migrate_db`
Migration is already is last version:
```
11:00:05.639 [info]  current migration version: 20210826171900

11:00:05.656 [info]  migrations are up to date
```
4. Create a new migration at priv/migrations/20210826171902_new .ex with:
```
defmodule AeMdw.Migrations.New do
  def run(), do: {:ok, nil}
end
```
5. `mix migrate_db`
It applies the new migration:
```
11:10:43.194 [info]  applying version 20210826171902 with Elixir.AeMdw.Migrations.New...

11:10:43.207 [info]  applied version 20210826171902
```
6. `mix migrate_db`
Migration is already is last version:
```
11:12:50.312 [info]  current migration version: 20210826171902

11:12:50.322 [info]  migrations are up to date
```


## Additional Notes

- For safety/consistency it is still important that each migration is idempotent (in case it aborts half way).
- Rollbacks are not available.