### PR TITLE
test: add blockchain DSL for testing purposes

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,7 @@ defmodule AeMdw.MixProject do
           :aec_hard_forks,
           :aec_hash,
           :aec_headers,
+          :aec_spend_tx,
           :aec_sync,
           :aec_trees,
           :aect_call,
@@ -66,7 +67,8 @@ defmodule AeMdw.MixProject do
           :aetx_env,
           :aetx_sign,
           :aeu_info,
-          :aeu_mtrees
+          :aeu_mtrees,
+          :enacl
         ]
       ],
       dialyzer: dialyzer(),

--- a/test/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/ae_mdw_web/controllers/block_controller_test.exs
@@ -1,163 +1,36 @@
 defmodule AeMdwWeb.BlockControllerTest do
   use AeMdwWeb.ConnCase, async: false
 
-  alias :aeser_api_encoder, as: Enc
-  alias AeMdw.Validate
-  alias AeMdw.Db.{Model, Format}
-  alias AeMdwWeb.TestUtil
-  alias AeMdw.Error.Input, as: ErrInput
-  require Model
+  alias AeMdwWeb.BlockchainSim
 
-  import AeMdw.Db.Util
   import Mock
+  import AeMdwWeb.BlockchainSim
 
   describe "block" do
     test "get key block by hash", %{conn: conn} do
-      kb_hash = "kh_29Gmo8RMdCD5aJ1UUrKd6Kx2c3tvHQu82HKsnVhbprmQnFy5bn"
-      bin_kb_hash = AeMdw.Validate.id!(kb_hash)
+      with_blockchain %{alice: 10_000}, b1: {:kb, :alice} do
+        kb_hash = blocks[:b1]
 
-      with_mocks [
-        {:aec_chain, [], get_block: fn ^bin_kb_hash -> {:ok, sample_key_block()} end},
-        {:aec_db, [], get_header: fn ^bin_kb_hash -> sample_key_header() end}
-      ] do
-        conn = get(conn, "/block/#{kb_hash}")
-
-        assert json_response(conn, 200) == TestUtil.handle_input(fn -> get_block(kb_hash) end)
+        assert %{"hash" => ^kb_hash} = get(conn, "/block/#{kb_hash}") |> json_response(200)
       end
     end
 
     test "get micro block by hash", %{conn: conn} do
-      mb_hash = "mh_RuKG8scokoAdhqNN3uvq29VZBsSaZdpeaoyBsXLeGV69sud85"
-      bin_mb_hash = AeMdw.Validate.id!(mb_hash)
+      with_blockchain %{alice: 10_000, bob: 20_000},
+        b1: [
+          t1: BlockchainSim.spend_tx(:alice, :bob, 5_000)
+        ] do
+        mb_hash = blocks[:b1]
 
-      with_mocks [
-        {:aec_chain, [], get_block: fn ^bin_mb_hash -> {:ok, sample_micro_block()} end},
-        {:aec_db, [], get_header: fn ^bin_mb_hash -> sample_micro_header() end}
-      ] do
-        conn = get(conn, "/block/#{mb_hash}")
-
-        assert json_response(conn, 200) == TestUtil.handle_input(fn -> get_block(mb_hash) end)
+        assert %{"hash" => ^mb_hash} = get(conn, "/block/#{mb_hash}") |> json_response(200)
       end
     end
 
     test "renders error when the hash is invalid", %{conn: conn} do
       hash = "kh_NoSuchHash"
-      conn = get(conn, "/block/#{hash}")
 
-      assert json_response(conn, 400) == %{
-               "error" => TestUtil.handle_input(fn -> get_block(hash) end)
-             }
+      assert %{"error" => <<"invalid id: ", _rest::binary>>} =
+               get(conn, "/block/#{hash}") |> json_response(400)
     end
-  end
-
-  ################
-
-  defp get_block(enc_block_hash) when is_binary(enc_block_hash) do
-    block_hash = Validate.id!(enc_block_hash)
-
-    case :aec_chain.get_block(block_hash) do
-      {:ok, _} ->
-        Format.to_map({:block, {nil, nil}, nil, block_hash})
-
-      :error ->
-        raise ErrInput.NotFound, value: enc_block_hash
-    end
-  end
-
-  defp get_block({_, mbi} = block_index) do
-    case read_block(block_index) do
-      [block] ->
-        type = (mbi == -1 && :key_block_hash) || :micro_block_hash
-        hash = Model.block(block, :hash)
-        get_block(Enc.encode(type, hash))
-
-      [] ->
-        raise ErrInput.NotFound, value: block_index
-    end
-  end
-
-  defp sample_key_block do
-    {:key_block, sample_key_header()}
-  end
-
-  defp sample_key_header do
-    {:key_header, 1,
-     <<108, 21, 218, 110, 191, 175, 2, 120, 254, 175, 77, 241, 176, 241, 169, 130, 85, 7, 174,
-       123, 154, 73, 75, 195, 76, 145, 113, 63, 56, 221, 87, 131>>,
-     <<108, 21, 218, 110, 191, 175, 2, 120, 254, 175, 77, 241, 176, 241, 169, 130, 85, 7, 174,
-       123, 154, 73, 75, 195, 76, 145, 113, 63, 56, 221, 87, 131>>,
-     <<52, 183, 229, 249, 54, 69, 51, 88, 116, 15, 122, 6, 182, 198, 8, 237, 95, 88, 152, 76, 53,
-       115, 239, 229, 75, 84, 120, 17, 7, 73, 153, 49>>, 522_133_279, 7_537_663_592_980_547_537,
-     1_543_373_685_748, 1,
-     [
-       26_922_260,
-       37_852_188,
-       59_020_115,
-       60_279_463,
-       79_991_400,
-       85_247_410,
-       107_259_316,
-       109_139_865,
-       110_742_806,
-       135_064_096,
-       135_147_996,
-       168_331_414,
-       172_261_759,
-       199_593_922,
-       202_230_201,
-       203_701_465,
-       210_434_810,
-       231_398_482,
-       262_809_482,
-       271_994_744,
-       272_584_245,
-       287_928_914,
-       292_169_553,
-       362_488_698,
-       364_101_896,
-       364_186_805,
-       373_099_116,
-       398_793_711,
-       400_070_528,
-       409_055_423,
-       410_928_197,
-       423_334_086,
-       423_561_843,
-       428_130_074,
-       496_454_011,
-       501_715_005,
-       505_858_333,
-       514_079_183,
-       522_053_501,
-       526_239_399,
-       527_666_844,
-       532_070_334
-     ],
-     <<109, 80, 187, 72, 39, 0, 181, 159, 179, 75, 226, 70, 33, 153, 149, 169, 59, 82, 131, 166,
-       223, 128, 104, 223, 115, 204, 111, 77, 205, 5, 56, 247>>,
-     <<186, 203, 214, 163, 246, 107, 124, 137, 222, 135, 217, 193, 221, 104, 215, 16, 94, 25, 47,
-       35, 97, 96, 99, 179, 23, 38, 226, 135, 232, 249, 24, 44>>, "",
-     %{consensus: :aec_consensus_bitcoin_ng}}
-  end
-
-  defp sample_micro_block do
-    {:mic_block, sample_micro_header()}
-  end
-
-  defp sample_micro_header do
-    {:mic_header, 305_488, "",
-     <<123, 66, 245, 198, 197, 131, 107, 129, 76, 33, 48, 83, 69, 18, 29, 92, 34, 125, 232, 194,
-       72, 143, 41, 63, 18, 139, 120, 116, 45, 79, 16, 108>>,
-     <<205, 135, 56, 162, 96, 202, 59, 7, 215, 179, 229, 109, 41, 29, 214, 107, 35, 50, 95, 154,
-       219, 228, 142, 169, 53, 232, 166, 4, 232, 147, 188, 64>>,
-     <<159, 240, 58, 171, 83, 153, 27, 217, 82, 171, 254, 252, 207, 84, 95, 53, 51, 74, 232, 74,
-       71, 119, 195, 119, 76, 151, 185, 56, 200, 189, 193, 78>>,
-     <<105, 101, 147, 121, 43, 123, 67, 195, 141, 128, 83, 57, 81, 64, 38, 102, 16, 183, 151, 198,
-       70, 31, 124, 51, 136, 54, 61, 145, 175, 206, 242, 131, 139, 7, 85, 12, 93, 191, 223, 205,
-       50, 239, 189, 136, 12, 18, 31, 47, 127, 94, 194, 131, 254, 70, 243, 168, 236, 149, 63, 101,
-       84, 78, 219, 6>>,
-     <<155, 74, 110, 105, 160, 87, 202, 235, 211, 79, 100, 7, 204, 19, 228, 89, 48, 64, 212, 231,
-       175, 166, 195, 25, 170, 195, 160, 121, 134, 181, 73, 200>>, 1_598_562_036_727, 4,
-     %{consensus: :aec_consensus_bitcoin_ng}}
   end
 end

--- a/test/support/blockchain_sim.ex
+++ b/test/support/blockchain_sim.ex
@@ -1,0 +1,161 @@
+defmodule AeMdwWeb.BlockchainSim do
+  @moduledoc """
+  """
+
+  require Mock
+
+  @passthrough_functions ~w(module_info)a
+
+  @type account_id() :: :aeser_id.id()
+
+  defmacro with_blockchain(initial_balances, blocks, do: body) do
+    aec_db =
+      :exports
+      |> :aec_db.module_info()
+      |> Enum.map(fn {fun_name, arity} ->
+        args = Macro.generate_arguments(arity, __MODULE__)
+
+        {fun_name,
+         {:fn, [],
+          quote do
+            unquote_splicing(args) ->
+              raise "Unmocked function #{unquote(fun_name)}/#{unquote(arity)}"
+          end}}
+      end)
+      |> Keyword.drop(unquote(@passthrough_functions))
+
+    quote do
+      {
+        aec_db_mock,
+        mock_blocks,
+        mock_transactions,
+        mock_accounts
+      } = unquote(__MODULE__).generate_blockchain(unquote(initial_balances), unquote(blocks))
+
+      aec_db_mock = Keyword.merge(unquote(aec_db), aec_db_mock)
+
+      Mock.with_mocks [{:aec_db, [:passthrough], aec_db_mock}] do
+        var!(blocks) = mock_blocks
+        var!(transactions) = mock_transactions
+        var!(accounts) = mock_accounts
+
+        # HACK: To remove unused warnings
+        {var!(blocks), var!(transactions), var!(accounts)}
+
+        unquote(body)
+      end
+    end
+  end
+
+  @spec spend_tx(account_id(), account_id(), non_neg_integer()) :: :aetx.t()
+  def spend_tx(sender_id, recipient_id, amount) do
+    {:spend_tx, sender_id, recipient_id, amount}
+  end
+
+  def generate_blockchain(initial_balances, blocks) do
+    mock_accounts =
+      initial_balances
+      |> Enum.map(fn {account_id, _balance} ->
+        %{public: account_pkey} = :enacl.sign_keypair()
+
+        {account_id, :aeser_id.create(:account, account_pkey)}
+      end)
+      |> Map.new()
+
+    {mock_blocks, mock_transactions, _max_height} =
+      blocks
+      |> Enum.reduce({%{}, %{}, 1}, fn
+        {block_id, {:kb, account_id}}, {mock_blocks, mock_transactions, height}
+        when is_atom(account_id) ->
+          {
+            Map.put(mock_blocks, block_id, mock_key_block(account_id, mock_accounts, height)),
+            mock_transactions,
+            height + 1
+          }
+
+        {block_id, transactions}, {mock_blocks, mock_transactions, height}
+        when is_list(transactions) ->
+          {micro_block, transactions} = mock_micro_block(transactions, mock_accounts, height)
+
+          {
+            Map.put(mock_blocks, block_id, micro_block),
+            Map.merge(mock_transactions, transactions),
+            height
+          }
+      end)
+
+    aec_db_mock = [
+      find_block: fn hash ->
+        find_block(hash, mock_blocks)
+      end,
+      get_block: fn hash ->
+        {:value, block} = find_block(hash, mock_blocks)
+
+        block
+      end,
+      get_header: fn hash ->
+        {:value, block} = find_block(hash, mock_blocks)
+
+        :aec_blocks.to_header(block)
+      end
+    ]
+
+    blocks_pkeys =
+      mock_blocks
+      |> Enum.map(fn {block_id, block} ->
+        header = :aec_blocks.to_header(block)
+        {:ok, block_hash} = :aec_headers.hash_header(header)
+
+        hash_type =
+          case :aec_blocks.type(block) do
+            :key -> :key_block_hash
+            :micro -> :micro_block_hash
+          end
+
+        {block_id, :aeser_api_encoder.encode(hash_type, block_hash)}
+      end)
+      |> Map.new()
+
+    {aec_db_mock, blocks_pkeys, mock_transactions, mock_accounts}
+  end
+
+  defp mock_key_block(account_id, accounts, height) do
+    miner_pk = Map.fetch!(accounts, account_id) |> :aeser_id.specialize(:account)
+
+    :aec_blocks.new_key(height, <<>>, <<>>, <<>>, 0, 0, 0, :default, 0, miner_pk, miner_pk)
+  end
+
+  defp mock_micro_block(transactions, accounts, height) do
+    txs =
+      transactions
+      |> Enum.map(fn {tx_id, tx} -> {tx_id, serialize_tx(tx, accounts)} end)
+      |> Map.new()
+
+    {:aec_blocks.new_micro(height, <<>>, <<>>, <<>>, <<>>, Map.values(txs), 0, :no_fraud, 0), txs}
+  end
+
+  defp find_block(hash, blocks) do
+    blocks
+    |> Enum.find(fn {_block_id, block} ->
+      header = :aec_blocks.to_header(block)
+      {:ok, block_hash} = :aec_headers.hash_header(header)
+
+      block_hash == hash
+    end)
+    |> case do
+      nil -> :none
+      {_block_id, block} -> {:value, block}
+    end
+  end
+
+  defp serialize_tx({:spend_tx, sender_id, recipient_id, amount}, accounts) do
+    :aec_spend_tx.new(%{
+      sender_id: Map.fetch!(accounts, sender_id),
+      recipient_id: Map.fetch!(accounts, recipient_id),
+      amount: amount,
+      fee: 0,
+      nonce: 0,
+      payload: <<>>
+    })
+  end
+end


### PR DESCRIPTION
This is a temprary experimental approach to remove the synced blockchain requirement for running tests. In the near future, once the devmode is enabled, we can turn this DSL into something more imperative (a Ganache-like approach).

This is an alternative to mocking on every test (e.g. https://github.com/aeternity/ae_mdw/commit/2bd691696db3224c6f0ab0799eff5b340203a442)

Refs #220