### PR TITLE
feat: adds account and recipient name to spendtx

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -64,7 +64,7 @@ jobs:
         id: plt-cache
         with:
           path: priv/plts
-          key: plts-${{ hashFiles('mix.lock') }}
+          key: plts-v2-${{ hashFiles('mix.lock') }}
 
       - name: Common tests setup
         uses: ./.github/actions/tests-common

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -123,6 +123,26 @@ defmodule AeMdw.Db.Name do
     end
   end
 
+  def ownership_at(m_name, name_height) do
+    [{{_, _}, last_claim_txi} | _] = Model.name(m_name, :claims)
+
+    case Model.name(m_name, :transfers) do
+      [] ->
+        %{tx: %{account_id: owner_on_height}} = Format.to_raw_map(read_tx!(last_claim_txi))
+        owner_on_height
+
+      transfers ->
+        transfer_txi =
+          transfers
+          |> Enum.reverse()
+          |> Enum.find(fn {{transfer_height, _}, transfer_txi} ->
+              if transfer_height >= name_height, do: transfer_txi
+            end)
+        %{tx: %{recipient_id: owner_on_height}} = Format.to_raw_map(read_tx!(transfer_txi))
+        owner_on_height
+    end
+  end
+
   def revoke_or_expire_height(nil = _revoke, expire),
     do: expire
 

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -136,8 +136,9 @@ defmodule AeMdw.Db.Name do
           transfers
           |> Enum.reverse()
           |> Enum.find(fn {{transfer_height, _}, transfer_txi} ->
-              if transfer_height >= name_height, do: transfer_txi
-            end)
+            if transfer_height >= name_height, do: transfer_txi
+          end)
+
         %{tx: %{recipient_id: owner_on_height}} = Format.to_raw_map(read_tx!(transfer_txi))
         owner_on_height
     end

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -124,23 +124,20 @@ defmodule AeMdw.Db.Name do
   end
 
   def ownership_at(m_name, name_height) do
-    [{{_, _}, last_claim_txi} | _] = Model.name(m_name, :claims)
-
     case Model.name(m_name, :transfers) do
       [] ->
-        %{tx: %{account_id: owner_on_height}} = Format.to_raw_map(read_tx!(last_claim_txi))
-        owner_on_height
+        claimed_by(m_name)
 
       transfers ->
-        transfer_txi =
-          transfers
-          |> Enum.reverse()
-          |> Enum.find(fn {{transfer_height, _}, transfer_txi} ->
-            if transfer_height >= name_height, do: transfer_txi
-          end)
+        transfer_txi = find_transfer_txi_before(transfers, name_height)
 
-        %{tx: %{recipient_id: owner_on_height}} = Format.to_raw_map(read_tx!(transfer_txi))
-        owner_on_height
+        if is_nil(transfer_txi) do
+          claimed_by(m_name)
+        else
+          %{tx: %{recipient_id: transfered_to}} = Format.to_raw_map(read_tx!(transfer_txi))
+          {:id, :account, owner_pk} = transfered_to
+          owner_pk
+        end
     end
   end
 
@@ -232,4 +229,20 @@ defmodule AeMdw.Db.Name do
 
   def cache({_, _} = block_index),
     do: cache(ns_tree!(block_index))
+
+  #
+  # Private functions
+  #
+  defp claimed_by(m_name) do
+    [{{_, _}, last_claim_txi} | _] = Model.name(m_name, :claims)
+    %{tx: %{account_id: orig_owner}} = Format.to_raw_map(read_tx!(last_claim_txi))
+    {:id, :account, first_owner} = orig_owner
+    first_owner
+  end
+
+  defp find_transfer_txi_before(transfers, height) do
+    Enum.find_value(transfers, fn {{transfer_height, _}, transfer_txi} ->
+      if transfer_height <= height, do: transfer_txi
+    end)
+  end
 end

--- a/lib/ae_mdw/log.ex
+++ b/lib/ae_mdw/log.ex
@@ -3,4 +3,7 @@ defmodule AeMdw.Log do
 
   def info(msg),
     do: Logger.info(msg, sync: true)
+
+  def warn(msg),
+    do: Logger.warn(msg, sync: true)
 end

--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -101,6 +101,7 @@ defmodule AeMdwWeb.TxController do
       {nil, _module} ->
         Log.warn("missing name for plain name #{plain_name}")
         {:error, {:owner_not_found, plain_name}}
+
       {name, _module} ->
         owner_pk = Model.name(name, :owner)
         {:ok, Enc.encode(:account_pubkey, owner_pk)}

--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -73,6 +73,7 @@ defmodule AeMdwWeb.TxController do
         case Validate.plain_name(spend_tx_recipient) do
           {:ok, name} ->
             Map.merge(block, %{"name" => name, "account" => account})
+
           _ ->
             Log.warn("missing name for name hash #{spend_tx_recipient}")
             block

--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -71,7 +71,7 @@ defmodule AeMdwWeb.TxController do
   defp add_spendtx_details(response_data, %{"account" => _account}) do
     Enum.map(response_data, fn %{"block_height" => block_height, "tx" => block_tx} = block ->
       spend_tx_recipient = (block_tx["type"] == @type_spend_tx && block_tx["recipient_id"]) || nil
-      add_details? = nil != spend_tx_recipient and String.slice(spend_tx_recipient, 0..2) == "nm_"
+      add_details? = String.starts_with?(spend_tx_recipient || "", "nm_")
 
       if add_details? do
         update_in(block, ["tx"], fn block_tx ->
@@ -107,8 +107,7 @@ defmodule AeMdwWeb.TxController do
         {:error, {:owner_not_found, plain_name}}
 
       {m_name, _module} ->
-        {:id, :account, owner_pk} = Name.ownership_at(m_name, on_height)
-
+        owner_pk = Name.ownership_at(m_name, on_height)
         {:ok, Enc.encode(:account_pubkey, owner_pk)}
     end
   end

--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -2,6 +2,7 @@ defmodule AeMdwWeb.TxController do
   use AeMdwWeb, :controller
   use PhoenixSwagger
 
+  alias AeMdw.Log
   alias AeMdw.Node, as: AE
   alias AeMdw.Validate
   alias AeMdw.Db.Model
@@ -72,6 +73,9 @@ defmodule AeMdwWeb.TxController do
         case Validate.plain_name(spend_tx_recipient) do
           {:ok, name} ->
             Map.merge(block, %{"name" => name, "account" => account})
+          _ ->
+            Log.warn("missing name for name hash #{spend_tx_recipient}")
+            block
         end
       else
         block

--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -64,8 +64,8 @@ defmodule AeMdwWeb.TxController do
   #
   # Private functions
   #
-  defp add_spendtx_details(data_txs, %{"account" => account}) do
-    Enum.map(data_txs, fn block ->
+  defp add_spendtx_details(response_data, %{"account" => account}) do
+    Enum.map(response_data, fn block ->
       spend_tx_recipient =
         if block["tx"]["type"] == @type_spend_tx, do: block["tx"]["recipient_id"]
 
@@ -74,7 +74,7 @@ defmodule AeMdwWeb.TxController do
           {:ok, name} ->
             Map.merge(block, %{"name" => name, "account" => account})
 
-          _ ->
+          {:error, _reason} ->
             Log.warn("missing name for name hash #{spend_tx_recipient}")
             block
         end
@@ -84,7 +84,7 @@ defmodule AeMdwWeb.TxController do
     end)
   end
 
-  defp add_spendtx_details(data_txs, _), do: data_txs
+  defp add_spendtx_details(data_txs, _params), do: data_txs
 
   defp read_tx_hash(tx_hash) do
     with <<_::256>> = mb_hash <- :aec_db.find_tx_location(tx_hash),

--- a/mix.exs
+++ b/mix.exs
@@ -134,7 +134,7 @@ defmodule AeMdw.MixProject do
       ignore_warnings: ".dialyzer_ignore.exs",
       plt_add_apps: [:mix],
       plt_core_path: "priv/plts",
-      # plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
+      plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -134,7 +134,7 @@ defmodule AeMdw.MixProject do
       ignore_warnings: ".dialyzer_ignore.exs",
       plt_add_apps: [:mix],
       plt_core_path: "priv/plts",
-      plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
+      # plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
     ]
   end
 end

--- a/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
@@ -3,7 +3,12 @@ defmodule Integration.AeMdwWeb.TxControllerTest do
 
   alias AeMdw.Validate
   alias AeMdw.Db.Util
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Name
   alias AeMdwWeb.TxController
+  alias :aeser_api_encoder, as: Enc
+
+  require Model
 
   @type_spend_tx "SpendTx"
 
@@ -563,9 +568,11 @@ defmodule Integration.AeMdwWeb.TxControllerTest do
           if block["tx"]["type"] == @type_spend_tx, do: block["tx"]["recipient_id"]
 
         if nil != spend_tx_recipient and String.slice(spend_tx_recipient, 0..2) == "nm_" do
-          assert {:ok, name} = Validate.plain_name(spend_tx_recipient)
-          assert Map.get(block, "name") == name
-          assert Map.get(block, "account") == account_id
+          assert {:ok, plain_name} = Validate.plain_name(spend_tx_recipient)
+          assert recipient = block["tx"]["recipient"]
+          assert recipient["name"] == plain_name
+          name_ownker_pk = Name.locate(plain_name) |> elem(0) |> Model.name(:owner)
+          assert recipient["account"] == Enc.encode(:account_pubkey, name_ownker_pk)
         end
       end)
 
@@ -639,9 +646,11 @@ defmodule Integration.AeMdwWeb.TxControllerTest do
           if block["tx"]["type"] == @type_spend_tx, do: block["tx"]["recipient_id"]
 
         if nil != spend_tx_recipient and String.slice(spend_tx_recipient, 0..2) == "nm_" do
-          assert {:ok, name} = Validate.plain_name(spend_tx_recipient)
-          assert Map.get(block, "name") == name
-          assert Map.get(block, "account") == account_id
+          assert {:ok, plain_name} = Validate.plain_name(spend_tx_recipient)
+          assert recipient = block["tx"]["recipient"]
+          assert recipient["name"] == plain_name
+          name_ownker_pk = Name.locate(plain_name) |> elem(0) |> Model.name(:owner)
+          assert recipient["account"] == Enc.encode(:account_pubkey, name_ownker_pk)
         end
       end)
 


### PR DESCRIPTION
## What

Adds some details to /txs/forward and /txs/backward endpoints when using account as querystring param.
The details are account and recipient chain name.

Note: As the names have expiration and might be tranfered, the recipient account is the owner of the name at the time of the transaction.

## Why

Extra info/fixes #226 

## Validation steps

```
elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/tx_controller_test.exs:583
elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/tx_controller_test.exs:661
elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/tx_controller_test.exs 
```