### PR TITLE
test: use specific docker image version of Elixir

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -64,7 +64,7 @@ jobs:
         id: plt-cache
         with:
           path: priv/plts
-          key: plts-${{ hashFiles('mix.lock') }}
+          key: plts-v2-${{ hashFiles('mix.lock') }}
 
       - name: Common tests setup
         uses: ./.github/actions/tests-common

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10
+FROM elixir:1.10.4
 # Add required files to download and compile only the dependencies
 
 # Install other required dependencies
@@ -17,7 +17,7 @@ ENV NODEDIR=/home/aeternity/node/local/rel/aeternity
 RUN mkdir -p ./local/rel/aeternity/data/mnesia
 RUN curl -s https://api.github.com/repos/aeternity/aeternity/releases/latest | \
        jq '.assets[1].browser_download_url' | \
-       xargs curl -L --output aeternity.tar.gz  && tar -C ./local/rel/aeternity -xf aeternity.tar.gz 
+       xargs curl -L --output aeternity.tar.gz  && tar -C ./local/rel/aeternity -xf aeternity.tar.gz
 
 RUN chmod +x ${NODEDIR}/bin/aeternity
 RUN cp -r ./local/rel/aeternity/lib local/

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,8 @@
+config = ExUnit.configuration()
+
+if :integration not in Keyword.fetch!(config, :include) do
+  IO.puts("Stopping :aecore..")
+  Application.stop(:aecore)
+end
+
 ExUnit.start()


### PR DESCRIPTION
This avoids the core to start syncing and causing issues while simultaneously runing tests.