### PR TITLE
feat: restructure ETS stateful DB streams implementation

### DIFF
--- a/lib/ae_mdw/mnesia.ex
+++ b/lib/ae_mdw/mnesia.ex
@@ -1,0 +1,139 @@
+defmodule AeMdw.Mnesia do
+  @moduledoc """
+  Mnesia wrapper to provide a simpler API.
+
+  In order to iterate throught collections of records we use the
+  concept of "cursor". A cursor is just a key of any given table that
+  is returned in order the access the next page of records.
+
+  This cursor key is whatever the current key of the table might be
+  (e.g. a tuple, a number). If there is no next page, `nil` is
+  returned instead.
+  """
+
+  @type table() :: atom()
+  @type record() :: tuple()
+  @type key() :: term()
+  @type direction() :: :forward | :backward
+  @type cursor() :: key() | nil
+
+  @end_token :"$end_of_table"
+
+  @spec last_key(table()) :: {:ok, key()} | :none
+  def last_key(tab) do
+    case :mnesia.dirty_last(tab) do
+      @end_token -> :none
+      last_key -> {:ok, last_key}
+    end
+  end
+
+  @spec first_key(table()) :: {:ok, key()} | :none
+  def first_key(tab) do
+    case :mnesia.dirty_first(tab) do
+      @end_token -> :none
+      last_key -> {:ok, last_key}
+    end
+  end
+
+  @spec fetch(table(), key()) :: {:ok, record()} | :not_found
+  def fetch(tab, key) do
+    case :mnesia.dirty_read(tab, key) do
+      [record] -> {:ok, record}
+      [] -> :not_found
+    end
+  end
+
+  @spec fetch!(table(), key()) :: record()
+  def fetch!(tab, key) do
+    {:ok, record} = fetch(tab, key)
+
+    record
+  end
+
+  @spec fetch_keys(table(), direction(), cursor(), non_neg_integer()) :: {[record()], cursor()}
+  def fetch_keys(tab, :forward, nil, limit) do
+    {:atomic, {keys, cursor}} =
+      :mnesia.transaction(fn ->
+        case :mnesia.first(tab) do
+          @end_token -> {[], nil}
+          first_key -> fetch_forward_keys(tab, first_key, limit)
+        end
+      end)
+
+    {keys, cursor}
+  end
+
+  def fetch_keys(tab, :forward, first_key, limit) do
+    {:atomic, {keys, cursor}} =
+      :mnesia.transaction(fn ->
+        case :mnesia.read(tab, first_key) do
+          @end_token -> {[], nil}
+          _first_record -> fetch_forward_keys(tab, first_key, limit)
+        end
+      end)
+
+    {keys, cursor}
+  end
+
+  def fetch_keys(tab, :backward, nil, limit) do
+    {:atomic, {keys, cursor}} =
+      :mnesia.transaction(fn ->
+        case :mnesia.last(tab) do
+          @end_token -> {[], nil}
+          last_key -> fetch_backward_keys(tab, last_key, limit)
+        end
+      end)
+
+    {keys, cursor}
+  end
+
+  def fetch_keys(tab, :backward, last_key, limit) do
+    {:atomic, {keys, cursor}} =
+      :mnesia.transaction(fn ->
+        case :mnesia.read(tab, last_key) do
+          @end_token -> {[], nil}
+          _last_record -> fetch_backward_keys(tab, last_key, limit)
+        end
+      end)
+
+    {keys, cursor}
+  end
+
+  defp fetch_forward_keys(tab, first_key, limit) do
+    keys =
+      Stream.unfold({limit, first_key}, fn
+        {0, _current_key} ->
+          nil
+
+        {n, current_key} ->
+          case :mnesia.next(tab, current_key) do
+            @end_token -> nil
+            next_key -> {next_key, {n - 1, next_key}}
+          end
+      end)
+
+    case Enum.split(keys, limit - 1) do
+      {keys, [next_key]} -> {[first_key | keys], next_key}
+      {keys, []} -> {keys, nil}
+    end
+  end
+
+  defp fetch_backward_keys(tab, last_key, limit) do
+    keys =
+      Stream.unfold({limit, last_key}, fn
+        {0, _current_key} ->
+          nil
+
+        {n, current_key} ->
+          case :mnesia.prev(tab, current_key) do
+            @end_token -> nil
+            prev_key -> {prev_key, {n - 1, prev_key}}
+          end
+      end)
+
+    case Enum.split(keys, limit - 1) do
+      {keys, [prev_key]} -> {[last_key | keys], prev_key}
+      {keys, []} -> {keys, nil}
+    end
+  end
+end

--- a/lib/ae_mdw/mnesia.ex
+++ b/lib/ae_mdw/mnesia.ex
@@ -114,7 +114,7 @@ defmodule AeMdw.Mnesia do
 
     case Enum.split(keys, limit - 1) do
       {keys, [next_key]} -> {[first_key | keys], next_key}
-      {keys, []} -> {keys, nil}
+      {keys, []} -> {[first_key | keys], nil}
     end
   end
 
@@ -133,7 +133,7 @@ defmodule AeMdw.Mnesia do
 
     case Enum.split(keys, limit - 1) do
       {keys, [prev_key]} -> {[last_key | keys], prev_key}
-      {keys, []} -> {keys, nil}
+      {keys, []} -> {[last_key | keys], nil}
     end
   end
 end

--- a/lib/ae_mdw/mnesia.ex
+++ b/lib/ae_mdw/mnesia.ex
@@ -52,8 +52,8 @@ defmodule AeMdw.Mnesia do
 
   @spec fetch_keys(table(), direction(), cursor(), non_neg_integer()) :: {[record()], cursor()}
   def fetch_keys(tab, :forward, nil, limit) do
-    {:atomic, {keys, cursor}} =
-      :mnesia.transaction(fn ->
+    {keys, cursor} =
+      :mnesia.async_dirty(fn ->
         case :mnesia.first(tab) do
           @end_token -> {[], nil}
           first_key -> fetch_forward_keys(tab, first_key, limit)
@@ -64,8 +64,8 @@ defmodule AeMdw.Mnesia do
   end
 
   def fetch_keys(tab, :forward, first_key, limit) do
-    {:atomic, {keys, cursor}} =
-      :mnesia.transaction(fn ->
+    {keys, cursor} =
+      :mnesia.async_dirty(fn ->
         case :mnesia.read(tab, first_key) do
           @end_token -> {[], nil}
           _first_record -> fetch_forward_keys(tab, first_key, limit)
@@ -76,8 +76,8 @@ defmodule AeMdw.Mnesia do
   end
 
   def fetch_keys(tab, :backward, nil, limit) do
-    {:atomic, {keys, cursor}} =
-      :mnesia.transaction(fn ->
+    {keys, cursor} =
+      :mnesia.async_dirty(fn ->
         case :mnesia.last(tab) do
           @end_token -> {[], nil}
           last_key -> fetch_backward_keys(tab, last_key, limit)
@@ -88,8 +88,8 @@ defmodule AeMdw.Mnesia do
   end
 
   def fetch_keys(tab, :backward, last_key, limit) do
-    {:atomic, {keys, cursor}} =
-      :mnesia.transaction(fn ->
+    {keys, cursor} =
+      :mnesia.async_dirty(fn ->
         case :mnesia.read(tab, last_key) do
           @end_token -> {[], nil}
           _last_record -> fetch_backward_keys(tab, last_key, limit)

--- a/lib/ae_mdw/oracles.ex
+++ b/lib/ae_mdw/oracles.ex
@@ -1,0 +1,119 @@
+defmodule AeMdw.Oracles do
+  @moduledoc """
+  Context module for dealing with Oracles.
+  """
+
+  require AeMdw.Db.Model
+
+  alias AeMdw.Db.Format
+  alias AeMdw.Db.Model
+  alias AeMdw.Mnesia
+  alias AeMdw.Node
+
+  @type cursor :: binary()
+  # TODO: This needs to be an actual type like AeMdw.Db.Oracle.t()
+  @type oracle :: term()
+  @typep limit :: pos_integer()
+
+  @table_active AeMdw.Db.Model.ActiveOracle
+  @table_active_expiration Model.ActiveOracleExpiration
+  @table_inactive AeMdw.Db.Model.InactiveOracle
+  @table_inactive_expiration Model.InactiveOracleExpiration
+
+  @spec fetch_active_oracles(Mnesia.direction(), cursor() | nil, limit()) ::
+          {[oracle()], cursor() | nil}
+  def fetch_active_oracles(direction, cursor, limit) do
+    {exp_keys, next_cursor} =
+      Mnesia.fetch_keys(
+        @table_active_expiration,
+        direction,
+        deserialize_cursor(cursor),
+        limit
+      )
+
+    {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
+
+    oracles =
+      exp_keys
+      |> Enum.map(fn {_expiration, oracle_pk} -> fetch_active_oracle(oracle_pk) end)
+      |> render_list(last_gen, true)
+
+    {oracles, serialize_cursor(next_cursor)}
+  end
+
+  @spec fetch_inactive_oracles(Mnesia.direction(), cursor() | nil, limit()) ::
+          {[oracle()], cursor() | nil}
+  def fetch_inactive_oracles(direction, cursor, limit) do
+    {exp_keys, next_cursor} =
+      Mnesia.fetch_keys(
+        @table_inactive_expiration,
+        direction,
+        deserialize_cursor(cursor),
+        limit
+      )
+
+    {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
+
+    oracles =
+      exp_keys
+      |> Enum.map(fn {_expiration, oracle_pk} -> fetch_inactive_oracle(oracle_pk) end)
+      |> render_list(last_gen, false)
+
+    {oracles, serialize_cursor(next_cursor)}
+  end
+
+  defp render_list(oracles, last_gen, is_active?) do
+    Enum.map(oracles, &render(&1, last_gen, is_active?))
+  end
+
+  defp render(
+         Model.oracle(
+           index: pk,
+           expire: expire_height,
+           register: {{register_height, _mbi}, register_txi},
+           extends: extends,
+           previous: _previous
+         ),
+         last_gen,
+         is_active?
+       ) do
+    kbi = min(expire_height - 1, last_gen)
+
+    oracle_tree = AeMdw.Db.Oracle.oracle_tree!({kbi, -1})
+    oracle_rec = :aeo_state_tree.get_oracle(pk, oracle_tree)
+
+    %{
+      oracle: :aeser_api_encoder.encode(:oracle_pubkey, pk),
+      active: is_active?,
+      active_from: register_height,
+      expire_height: expire_height,
+      register: register_txi,
+      extends: Enum.map(extends, &Format.bi_txi_txi/1),
+      query_fee: Node.Oracle.get!(oracle_rec, :query_fee),
+      format: %{
+        query: Node.Oracle.get!(oracle_rec, :query_format),
+        response: Node.Oracle.get!(oracle_rec, :response_format)
+      }
+    }
+  end
+
+  defp fetch_active_oracle(oracle_pk), do: Mnesia.fetch!(@table_active, oracle_pk)
+  defp fetch_inactive_oracle(oracle_pk), do: Mnesia.fetch!(@table_inactive, oracle_pk)
+
+  defp serialize_cursor(nil), do: nil
+
+  defp serialize_cursor({exp_height, oracle_pk}) do
+    "#{exp_height}-#{:aeser_api_encoder.encode(:oracle_pubkey, oracle_pk)}"
+  end
+
+  defp deserialize_cursor(nil), do: nil
+
+  defp deserialize_cursor(cursor_bin) do
+    with [_match0, exp_height, encoded_pk] <- Regex.run(~r/(\d+)-(ok_\w+)/, cursor_bin),
+         {:ok, pk} <- :aeser_api_encoder.safe_decode(:oracle_pubkey, encoded_pk) do
+      {String.to_integer(exp_height), pk}
+    else
+      _nil_or_error -> nil
+    end
+  end
+end

--- a/lib/ae_mdw_web/controllers/oracle_controller.ex
+++ b/lib/ae_mdw_web/controllers/oracle_controller.ex
@@ -9,12 +9,18 @@ defmodule AeMdwWeb.OracleController do
   alias AeMdw.Db.Oracle
   alias AeMdw.Db.Stream, as: DBS
   alias AeMdw.Error.Input, as: ErrInput
+  alias AeMdw.Oracles
   alias AeMdwWeb.Continuation, as: Cont
   alias AeMdwWeb.SwaggerParameters
+  alias AeMdwWeb.Plugs.PaginatedPlug
+  alias Plug.Conn
+
   require Model
 
   import AeMdwWeb.Util
   import AeMdw.Db.Util
+
+  plug(PaginatedPlug)
 
   ##########
 
@@ -50,6 +56,40 @@ defmodule AeMdwWeb.OracleController do
 
   def oracles(conn, _req),
     do: handle_input(conn, fn -> Cont.response(conn, &json/2) end)
+
+  def active_oracles_v2(%Conn{assigns: assigns} = conn, _params) do
+    %{direction: direction, limit: limit, cursor: cursor} = assigns
+
+    {oracles, new_cursor} = Oracles.fetch_active_oracles(direction, cursor, limit)
+
+    uri =
+      if new_cursor do
+        %URI{
+          path: "/v2/oracles/active/#{direction}",
+          query: URI.encode_query(%{"cursor" => new_cursor, "limit" => limit})
+        }
+        |> URI.to_string()
+      end
+
+    json(conn, %{"data" => oracles, "next" => uri})
+  end
+
+  def inactive_oracles_v2(%Conn{assigns: assigns} = conn, _params) do
+    %{direction: direction, limit: limit, cursor: cursor} = assigns
+
+    {oracles, new_cursor} = Oracles.fetch_inactive_oracles(direction, cursor, limit)
+
+    uri =
+      if new_cursor do
+        %URI{
+          path: "/v2/oracles/inactive/#{direction}",
+          query: URI.encode_query(%{"cursor" => new_cursor, "limit" => limit})
+        }
+        |> URI.to_string()
+      end
+
+    json(conn, %{"data" => oracles, "next" => uri})
+  end
 
   ##########
 

--- a/lib/ae_mdw_web/plugs/paginated_plug.ex
+++ b/lib/ae_mdw_web/plugs/paginated_plug.ex
@@ -1,0 +1,45 @@
+defmodule AeMdwWeb.Plugs.PaginatedPlug do
+  @moduledoc """
+  """
+
+  import Plug.Conn
+
+  alias Plug.Conn
+
+  @direction_map %{
+    "forward" => :forward,
+    "backward" => :backward
+  }
+  @valid_directions Map.keys(@direction_map)
+  @default_direction :backward
+
+  @default_limit 10
+  @max_limit 20
+
+  @spec init(Plug.opts()) :: Conn.t()
+  def init(opts), do: opts
+
+  @spec call(Conn.t(), Plug.opts()) :: Conn.t()
+  def call(%Conn{params: params} = conn, _opts) do
+    direction =
+      case Map.fetch(params, "direction") do
+        {:ok, direction} when direction in @valid_directions -> Map.get(@direction_map, direction)
+        {:ok, _direction} -> @default_direction
+        :error -> @default_direction
+      end
+
+    limit =
+      case Integer.parse(Map.get(params, "limit", "")) do
+        {limit, ""} when limit <= @max_limit and limit > 0 -> limit
+        {_limit, _rest} -> @default_limit
+        :error -> @default_limit
+      end
+
+    conn
+    |> assign(:direction, direction)
+    |> assign(:cursor, Map.get(params, "cursor"))
+    |> assign(:limit, limit)
+  end
+
+  def call(conn, _opts), do: conn
+end

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -93,6 +93,12 @@ defmodule AeMdwWeb.Router do
     get "/oracles", OracleController, :oracles
     get "/oracles/gen/:range", OracleController, :oracles
 
+    # v2
+    get "/v2/oracles/active", OracleController, :active_oracles_v2
+    get "/v2/oracles/active/:direction", OracleController, :active_oracles_v2
+    get "/v2/oracles/inactive", OracleController, :inactive_oracles_v2
+    get "/v2/oracles/inactive/:direction", OracleController, :inactive_oracles_v2
+
     get "/aex9/by_name", Aex9Controller, :by_names
     get "/aex9/by_symbol", Aex9Controller, :by_symbols
 

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -1,0 +1,74 @@
+defmodule AeMdwWeb.OracleControllerTest do
+  use AeMdwWeb.ConnCase, async: false
+
+  import Mock
+
+  require AeMdw.Db.Model
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Model.ActiveOracleExpiration
+  # alias AeMdw.Db.Model.ActiveOracle
+  alias AeMdw.Db.Model.Block
+  alias AeMdw.Db.Oracle
+  alias AeMdw.Mnesia
+  alias AeMdw.TestSamples, as: TS
+
+  describe "active_oracles_v2" do
+    test "it retrieves all active oracles backwards by default", %{conn: conn} do
+      next_cursor = nil
+      expiration_keys = [TS.oracle_expiration_key(1), TS.oracle_expiration_key(2)]
+      Model.oracle(index: pk) = oracle = TS.oracle()
+      encoded_pk = :aeser_api_encoder.encode(:oracle_pubkey, pk)
+
+      with_mocks [
+        {Mnesia, [],
+         [
+           fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
+           last_key: fn Block -> {:ok, TS.last_gen()} end,
+           fetch!: fn _tab, _oracle_pk -> oracle end
+         ]},
+        {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
+        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
+      ] do
+        assert %{"data" => [oracle1, _oracle2], "next" => nil} =
+                 conn
+                 |> get("/v2/oracles/active")
+                 |> json_response(200)
+
+        assert %{"oracle" => ^encoded_pk} = oracle1
+
+        assert_called(Mnesia.fetch_keys(ActiveOracleExpiration, :backward, nil, 10))
+        assert_called(Mnesia.last_key(Block))
+      end
+    end
+
+    test "it provides a 'next' cursor when more than limit of 10", %{conn: conn} do
+      next_cursor = {next_cursor_exp, next_cursor_pk} = TS.oracle_expiration_key(0)
+      next_cursor_pk_encoded = :aeser_api_encoder.encode(:oracle_pubkey, next_cursor_pk)
+      next_cursor_query_value = "#{next_cursor_exp}-#{next_cursor_pk_encoded}"
+      expiration_keys = 0..4 |> Enum.map(fn n -> TS.oracle_expiration_key(n) end)
+
+      with_mocks [
+        {Mnesia, [],
+         [
+           fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
+           last_key: fn Block -> {:ok, TS.last_gen()} end,
+           fetch!: fn _tab, _oracle_pk -> TS.oracle() end
+         ]},
+        {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
+        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
+      ] do
+        assert %{"next" => next_uri} = conn |> get("/v2/oracles/active") |> json_response(200)
+
+        assert %URI{
+                 path: "/v2/oracles/active/backward",
+                 query: query
+               } = URI.parse(next_uri)
+
+        assert %{"cursor" => ^next_cursor_query_value} = URI.decode_query(query)
+
+        assert_called(Mnesia.fetch_keys(ActiveOracleExpiration, :backward, nil, 10))
+      end
+    end
+  end
+end

--- a/test/integration/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -161,6 +161,48 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
     end
   end
 
+  describe "oracles_v2" do
+    test "it fetches inactive oracles going forwards", %{conn: conn} do
+      assert %{
+               "data" => [
+                 %{"oracle" => "ok_2TASQ4QZv584D2ZP7cZxT6sk1L1UyqbWumnWM4g1azGi1qqcR5"},
+                 %{"oracle" => "ok_R7cQfVN15F5ek1wBSYaMRjW2XbMRKx7VDQQmbtwxspjZQvmPM"},
+                 %{"oracle" => "ok_g5vQK6beY3vsTJHH7KBusesyzq9WMdEYorF8VyvZURXTjLnxT"},
+                 %{"oracle" => "ok_pANDBzM259a9UgZFeiCJyWjXSeRhqrBQ6UCBBeXfbCQyP33Tf"},
+                 %{"oracle" => "ok_cnFq6NgPNXzcwtggcAYUuSNKrW6fhRfDgYJa9WoRe6mEXwpah"},
+                 %{"oracle" => "ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR"},
+                 %{"oracle" => "ok_2yjZGhe1fooEnkoax6bJoDjV45DqaHXYLXWKafzaC9coLMJZy"},
+                 %{"oracle" => "ok_2Ez3Y4gQ1USuNxmSJry5YomnqsF6YTVVVFXVasB3jTSgbroB4z"},
+                 %{"oracle" => "ok_KMVEB7Dxjefsn1jJvKQPKYk3a28xkPgSNe5gnum46pcyogUze"},
+                 %{
+                   "active" => false,
+                   "active_from" => 288_192,
+                   "expire_height" => 288_692,
+                   "extends" => [],
+                   "format" => %{"query" => "querySpace", "response" => "responseSpec"},
+                   "oracle" => "ok_LZCSBq98L2kV5svbgE65shnZwgZzg8hMh13v86LMXQ8HJ7Kpp",
+                   "query_fee" => 2_000_000_000_000_000,
+                   "register" => 13_689_244
+                 }
+               ],
+               "next" =>
+                 "/v2/oracles/inactive/forward?cursor=288707-ok_ceRESNanBZ9ddGKZ75JacWQvR6GJnGci3cqXqMSN8yXL2rpkW"
+             } =
+               conn
+               |> get("/v2/oracles/inactive/forward")
+               |> json_response(200)
+    end
+
+    test "it fetches active oracles going backward", %{conn: conn} do
+      assert %{"data" => oracles, "next" => _next} =
+               conn
+               |> get("/v2/oracles/active/backward")
+               |> json_response(200)
+
+      assert Enum.all?(oracles, fn %{"active" => is_active?} -> is_active? end)
+    end
+  end
+
   describe "inactive_oracles" do
     test "get inactive oracles with default direction=backward and default limit", %{conn: conn} do
       conn = get(conn, "/oracles/inactive")

--- a/test/support/test_sample.ex
+++ b/test/support/test_sample.ex
@@ -1,0 +1,50 @@
+defmodule AeMdw.TestSamples do
+  require AeMdw.Db.Model
+
+  alias AeMdw.Db.Model
+
+  @spec oracle_expiration_key(non_neg_integer()) :: binary()
+  def oracle_expiration_key(n) do
+    ~w(
+      ok_2TASQ4QZv584D2ZP7cZxT6sk1L1UyqbWumnWM4g1azGi1qqcR5
+      ok_R7cQfVN15F5ek1wBSYaMRjW2XbMRKx7VDQQmbtwxspjZQvmPM
+      ok_g5vQK6beY3vsTJHH7KBusesyzq9WMdEYorF8VyvZURXTjLnxT
+      ok_pANDBzM259a9UgZFeiCJyWjXSeRhqrBQ6UCBBeXfbCQyP33Tf
+      ok_cnFq6NgPNXzcwtggcAYUuSNKrW6fhRfDgYJa9WoRe6mEXwpah
+    )
+    |> Enum.with_index()
+    |> Enum.map(fn {key, index} ->
+      {:ok, pk} = :aeser_api_encoder.safe_decode(:oracle_pubkey, key)
+
+      {expire_height(index), pk}
+    end)
+    |> Enum.at(n)
+  end
+
+  @spec expire_height(non_neg_integer()) :: non_neg_integer()
+  def expire_height(n) do
+    ~w(5851 6894 7499 34919 35040) |> Enum.at(n) |> String.to_integer()
+  end
+
+  @spec last_gen() :: {non_neg_integer(), -1}
+  def last_gen do
+    {484_402, -1}
+  end
+
+  @spec oracle() :: Model.oracle()
+  def oracle do
+    {:oracle,
+     <<191, 26, 12, 186, 4, 218, 249, 80, 53, 193, 143, 183, 72, 192, 245, 70, 194, 128, 17, 36,
+       177, 223, 218, 73, 7, 139, 204, 31, 194, 87, 254, 212>>, 4608, 5851, {{4608, 0}, 8916},
+     [{{4609, 0}, 8989}], nil}
+  end
+
+  @spec core_oracle() :: :aeo_oracles.oracle()
+  def core_oracle do
+    {:oracle,
+     {:id, :oracle,
+      <<44, 102, 253, 22, 212, 89, 216, 54, 106, 220, 2, 78, 65, 149, 128, 184, 42, 187, 24, 251,
+        165, 15, 161, 139, 112, 108, 233, 167, 103, 44, 158, 24>>}, "querySpace", "responseSpec",
+     2_000_000_000_000_000, 288_692, 0}
+  end
+end


### PR DESCRIPTION
Because we're having problems before with dealing with instance state by using ETS to store the remaining streams, a substantial change was necessary to both get rid of streams and to simplify the way the MDW works by using a more encapsulated and layered coding style.

Changes introduced:

1. **Refactor MDW domain logic to use a layered coding style.**

   Before this change, there weren't really any layers, the `AeMdw`, `AeMdwWeb` and `AeMdwWeb.Db` modules went back and forth calling each other out.

   Now, the layer model consists of the following:

   1. `AeMdwWeb.<Resource>Controller` (e.g. `OracleController`) only deals with getting the request params and displaying the returned data properly.
   2. `AeMdw.<Resource>` (e.g. Oracles) deals with all of the logic related to oracles, which right now includes fetching and
      serializing.
   3. `AeMdw.Mnesia` is just a wrapper around the `:mnesia` operations on the middleware tables.

   Each of these layers can only talk to the layer below, but never the other way round.

2. **Stop using ETS for storing the remaining slices of streams when dealing with pagination. Because of this, a greater refactor such as the one mentioned in 1. was needed.**

   Before this change, in order to get pagination working the entire  list of records from the database was represented as a
   stream. Whenever the user requested for any of these streams, the first few elements of the stream were returned, while the rest of the stream was stored in the instance ETS table, where the key was made out of the pagination options of that particular user for that list of records.

   Because of this, in order to traverse a full list of records doing several requests, the user had to the same server instance throughout all of the pages visited. It is because of this that a load balancer would break pagination by performing requests from the same user to different instances which had different ETS instance state.

By getting rid of streams and no longer storing state in ETS tables, the whole application now becomes stateless, and can be scaled horizontally indefinitely.

This is a PoC