### PR TITLE
fix: recipient account is the pointee if name have one

### DIFF
--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -1,4 +1,5 @@
 defmodule AeMdw.Db.Name do
+  alias AeMdw.Log
   alias AeMdw.Node, as: AE
   alias AeMdw.Db.{Model, Format}
   alias AeMdw.Validate
@@ -71,6 +72,24 @@ defmodule AeMdw.Db.Name do
     end
   end
 
+  def account_pointer_at(plain_name, time_reference_txi) do
+    case locate(plain_name) do
+      {nil, _module} ->
+        Log.warn("missing name for plain name #{plain_name}")
+        {:error, :name_not_found}
+
+      {m_name, _module} ->
+        case pointee_at(m_name, time_reference_txi) do
+          nil ->
+            Log.warn("missing pointee for plain name #{plain_name} on txi #{time_reference_txi}")
+            {:error, :pointee_not_found}
+
+          pointee_pk ->
+            {:ok, pointee_pk}
+        end
+    end
+  end
+
   def pointee_keys(pk) do
     mspec =
       Ex2ms.fun do
@@ -120,24 +139,6 @@ defmodule AeMdw.Db.Name do
       [{{_, _}, last_transfer_txi} | _] ->
         %{tx: %{recipient_id: curr_owner}} = Format.to_raw_map(read_tx!(last_transfer_txi))
         %{original: orig_owner, current: curr_owner}
-    end
-  end
-
-  def ownership_at(m_name, name_height) do
-    case Model.name(m_name, :transfers) do
-      [] ->
-        claimed_by(m_name)
-
-      transfers ->
-        transfer_txi = find_transfer_txi_before(transfers, name_height)
-
-        if is_nil(transfer_txi) do
-          claimed_by(m_name)
-        else
-          %{tx: %{recipient_id: transfered_to}} = Format.to_raw_map(read_tx!(transfer_txi))
-          {:id, :account, owner_pk} = transfered_to
-          owner_pk
-        end
     end
   end
 
@@ -233,16 +234,31 @@ defmodule AeMdw.Db.Name do
   #
   # Private functions
   #
-  defp claimed_by(m_name) do
-    [{{_, _}, last_claim_txi} | _] = Model.name(m_name, :claims)
-    %{tx: %{account_id: orig_owner}} = Format.to_raw_map(read_tx!(last_claim_txi))
-    {:id, :account, first_owner} = orig_owner
-    first_owner
+  defp pointee_at(m_name, ref_txi) do
+    m_name
+    |> Model.name(:updates)
+    |> find_update_txi_before(ref_txi)
+    |> case do
+      nil ->
+        Log.warn("name #{elem(m_name, 1)} without pointer at txi #{ref_txi}!")
+        nil
+
+      update_txi ->
+        {:id, :account, pointee_pk} =
+          update_txi
+          |> read_tx!()
+          |> Format.to_raw_map()
+          |> get_in([:tx, :pointers])
+          |> Enum.into(%{}, &pointer_kv_raw/1)
+          |> Map.get("account_pubkey")
+
+        pointee_pk
+    end
   end
 
-  defp find_transfer_txi_before(transfers, height) do
-    Enum.find_value(transfers, fn {{transfer_height, _}, transfer_txi} ->
-      if transfer_height <= height, do: transfer_txi
+  defp find_update_txi_before(updates, ref_txi) do
+    Enum.find_value(updates, fn {_block_height, update_txi} ->
+      if update_txi <= ref_txi, do: update_txi
     end)
   end
 end

--- a/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
@@ -1226,9 +1226,9 @@ defmodule Integration.AeMdwWeb.TxControllerTest do
 
     assert Enum.any?(blocks_with_nm, fn %{"tx" => tx, "tx_index" => tx_index} ->
              assert {:ok, plain_name} = Validate.plain_name(tx["recipient_id"])
-             assert m_name = Name.locate(plain_name) |> elem(0)
+             assert Model.name(updates: name_updates) = Name.locate(plain_name) |> elem(0)
 
-             if [] != Model.name(m_name, :updates) do
+             if [] != name_updates do
                assert recipient = tx["recipient"]
                assert recipient["name"] == plain_name
 


### PR DESCRIPTION
## What

Replace name transfer search with update search. 
When the recipient id is an AENS id name (`nm_...`), the recipient account is the pointee of the name (if name have one). 

## Why
Fixes #226 
The recipient of the name used might not be owner of the name, or in other words, the name might point to an account different from the owner.

## Validate steps

```
elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/tx_controller_test.exs:582
elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/tx_controller_test.exs
```