### PR TITLE
feat: add oracles v2 endpoint without making use of streams

### DIFF
--- a/bench/ae_mdw_web/oracle_controller_bench.exs
+++ b/bench/ae_mdw_web/oracle_controller_bench.exs
@@ -8,19 +8,9 @@ defmodule AeMdw.OracleControllerBench do
     |> get("/oracles/active?direction=forward")
   end
 
-  def active_oracles_v2 do
-    build_conn()
-    |> get("/v2/oracles/active/forward")
-  end
-
   def inactive_oracles do
     build_conn()
     |> get("/oracles/inactive?direction=forward")
-  end
-
-  def inactive_oracles_v2 do
-    build_conn()
-    |> get("/v2/oracles/inactive/forward")
   end
 
   def oracles do
@@ -36,24 +26,21 @@ end
 
 Benchee.run(
   %{
-    active_oracles: &AeMdw.OracleControllerBench.active_oracles/0,
-    active_oracles_v2: &AeMdw.OracleControllerBench.active_oracles_v2/0
+    active_oracles: &AeMdw.OracleControllerBench.active_oracles/0
   },
   memory_time: 1
 )
 
 Benchee.run(
   %{
-    inactive_oracles: &AeMdw.OracleControllerBench.inactive_oracles/0,
-    inactive_oracles_v2: &AeMdw.OracleControllerBench.inactive_oracles_v2/0
+    inactive_oracles: &AeMdw.OracleControllerBench.inactive_oracles/0
   },
   memory_time: 1
 )
 
 Benchee.run(
   %{
-    oracles: &AeMdw.OracleControllerBench.oracles/0,
-    oracles_v2: &AeMdw.OracleControllerBench.oracles_v2/0
+    oracles: &AeMdw.OracleControllerBench.oracles/0
   },
   memory_time: 1
 )

--- a/bench/ae_mdw_web/oracle_controller_bench.exs
+++ b/bench/ae_mdw_web/oracle_controller_bench.exs
@@ -22,6 +22,16 @@ defmodule AeMdw.OracleControllerBench do
     build_conn()
     |> get("/v2/oracles/inactive/forward")
   end
+
+  def oracles do
+    build_conn()
+    |> get("/oracles")
+  end
+
+  def oracles_v2 do
+    build_conn()
+    |> get("/v2/oracles")
+  end
 end
 
 Benchee.run(
@@ -36,6 +46,14 @@ Benchee.run(
   %{
     inactive_oracles: &AeMdw.OracleControllerBench.inactive_oracles/0,
     inactive_oracles_v2: &AeMdw.OracleControllerBench.inactive_oracles_v2/0
+  },
+  memory_time: 1
+)
+
+Benchee.run(
+  %{
+    oracles: &AeMdw.OracleControllerBench.oracles/0,
+    oracles_v2: &AeMdw.OracleControllerBench.oracles_v2/0
   },
   memory_time: 1
 )

--- a/bench/ae_mdw_web/oracle_controller_bench.exs
+++ b/bench/ae_mdw_web/oracle_controller_bench.exs
@@ -17,11 +17,6 @@ defmodule AeMdw.OracleControllerBench do
     build_conn()
     |> get("/oracles")
   end
-
-  def oracles_v2 do
-    build_conn()
-    |> get("/v2/oracles")
-  end
 end
 
 Benchee.run(

--- a/lib/ae_mdw/mnesia.ex
+++ b/lib/ae_mdw/mnesia.ex
@@ -83,7 +83,6 @@ defmodule AeMdw.Mnesia do
     {keys, cursor} =
       :mnesia.async_dirty(fn ->
         case :mnesia.read(tab, first_key) do
-          @end_token -> {[], nil}
           [] -> {[], nil}
           _first_record -> fetch_forward_keys(tab, first_key, limit)
         end
@@ -108,7 +107,6 @@ defmodule AeMdw.Mnesia do
     {keys, cursor} =
       :mnesia.async_dirty(fn ->
         case :mnesia.read(tab, last_key) do
-          @end_token -> {[], nil}
           [] -> {[], nil}
           _last_record -> fetch_backward_keys(tab, last_key, limit)
         end

--- a/lib/ae_mdw/mnesia.ex
+++ b/lib/ae_mdw/mnesia.ex
@@ -19,11 +19,27 @@ defmodule AeMdw.Mnesia do
 
   @end_token :"$end_of_table"
 
+  @spec last_key(table(), term()) :: term()
+  def last_key(tab, default) do
+    case last_key(tab) do
+      {:ok, last_key} -> last_key
+      :none -> default
+    end
+  end
+
   @spec last_key(table()) :: {:ok, key()} | :none
   def last_key(tab) do
     case :mnesia.dirty_last(tab) do
       @end_token -> :none
       last_key -> {:ok, last_key}
+    end
+  end
+
+  @spec first_key(table(), term()) :: term()
+  def first_key(tab, default) do
+    case first_key(tab) do
+      {:ok, first_key} -> first_key
+      :none -> default
     end
   end
 
@@ -68,6 +84,7 @@ defmodule AeMdw.Mnesia do
       :mnesia.async_dirty(fn ->
         case :mnesia.read(tab, first_key) do
           @end_token -> {[], nil}
+          [] -> {[], nil}
           _first_record -> fetch_forward_keys(tab, first_key, limit)
         end
       end)
@@ -92,6 +109,7 @@ defmodule AeMdw.Mnesia do
       :mnesia.async_dirty(fn ->
         case :mnesia.read(tab, last_key) do
           @end_token -> {[], nil}
+          [] -> {[], nil}
           _last_record -> fetch_backward_keys(tab, last_key, limit)
         end
       end)

--- a/lib/ae_mdw/oracles.ex
+++ b/lib/ae_mdw/oracles.ex
@@ -7,11 +7,12 @@ defmodule AeMdw.Oracles do
 
   alias AeMdw.Db.Format
   alias AeMdw.Db.Model
+  alias AeMdw.Db.Util
   alias AeMdw.Mnesia
   alias AeMdw.Node
 
   @type cursor :: binary()
-  # TODO: This needs to be an actual type like AeMdw.Db.Oracle.t()
+  # This needs to be an actual type like AeMdw.Db.Oracle.t()
   @type oracle :: term()
   @typep limit :: pos_integer()
 
@@ -20,93 +21,93 @@ defmodule AeMdw.Oracles do
   @table_inactive AeMdw.Db.Model.InactiveOracle
   @table_inactive_expiration Model.InactiveOracleExpiration
 
-  @spec fetch_oracles(Mnesia.direction(), cursor() | nil, limit()) :: {[oracle()], cursor() | nil}
-  def fetch_oracles(direction, cursor, limit) do
+  @spec fetch_oracles(Mnesia.direction(), cursor() | nil, limit(), boolean()) ::
+          {[oracle()], cursor() | nil}
+  def fetch_oracles(direction, cursor, limit, expand?) do
     cursor = deserialize_cursor(cursor)
 
-    {active_exp_keys, inactive_exp_keys, next_cursor} =
-      case fetch_active_keys(direction, cursor, limit) do
+    {first_table, last_table} =
+      case direction do
+        :forward -> {@table_inactive_expiration, @table_active_expiration}
+        :backward -> {@table_active_expiration, @table_inactive_expiration}
+      end
+
+    {first_keys, last_keys, next_cursor} =
+      case Mnesia.fetch_keys(first_table, direction, cursor, limit) do
         {[], nil} ->
-          {inactive_exp_keys, cursor} = fetch_inactive_keys(direction, cursor, limit)
+          {last_exp_keys, cursor} = Mnesia.fetch_keys(last_table, direction, cursor, limit)
 
-          {[], inactive_exp_keys, cursor}
+          {[], last_exp_keys, cursor}
 
-        {active_exp_keys, nil} ->
-          {inactive_exp_keys, inactive_cursor} =
-            fetch_inactive_keys(direction, nil, limit - length(active_exp_keys))
+        {first_exp_keys, nil} when length(first_exp_keys) == limit ->
+          next_cursor =
+            case direction do
+              :forward -> Mnesia.first_key(last_table, nil)
+              :backward -> Mnesia.last_key(last_table, nil)
+            end
 
-          {active_exp_keys, inactive_exp_keys, inactive_cursor}
+          {first_exp_keys, [], next_cursor}
 
-        {active_exp_keys, active_cursor} ->
-          {active_exp_keys, [], active_cursor}
+        {first_exp_keys, nil} ->
+          {last_exp_keys, last_cursor} =
+            Mnesia.fetch_keys(last_table, direction, nil, limit - length(first_exp_keys))
+
+          {first_exp_keys, last_exp_keys, last_cursor}
+
+        {first_exp_keys, last_cursor} ->
+          {first_exp_keys, [], last_cursor}
       end
 
     {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
 
-    active_oracles =
-      active_exp_keys
-      |> Enum.map(fn {_expiration, oracle_pk} -> fetch_active_oracle(oracle_pk) end)
-      |> render_list(last_gen, true)
+    first_oracles =
+      render_list(first_keys, last_gen, first_table == @table_active_expiration, expand?)
 
-    inactive_oracles =
-      inactive_exp_keys
-      |> Enum.map(fn {_expiration, oracle_pk} -> fetch_inactive_oracle(oracle_pk) end)
-      |> render_list(last_gen, true)
+    last_oracles =
+      render_list(last_keys, last_gen, last_table == @table_active_expiration, expand?)
 
-    {active_oracles ++ inactive_oracles, serialize_cursor(next_cursor)}
+    {first_oracles ++ last_oracles, serialize_cursor(next_cursor)}
   end
 
-  @spec fetch_active_oracles(Mnesia.direction(), cursor() | nil, limit()) ::
+  @spec fetch_active_oracles(Mnesia.direction(), cursor() | nil, limit(), boolean()) ::
           {[oracle()], cursor() | nil}
-  def fetch_active_oracles(direction, cursor, limit) do
-    {exp_keys, next_cursor} = fetch_active_keys(direction, deserialize_cursor(cursor), limit)
+  def fetch_active_oracles(direction, cursor, limit, expand?) do
+    {exp_keys, next_cursor} =
+      Mnesia.fetch_keys(@table_active_expiration, direction, deserialize_cursor(cursor), limit)
 
     {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
 
-    oracles =
-      exp_keys
-      |> Enum.map(fn {_expiration, oracle_pk} -> fetch_active_oracle(oracle_pk) end)
-      |> render_list(last_gen, true)
+    oracles = render_list(exp_keys, last_gen, true, expand?)
 
     {oracles, serialize_cursor(next_cursor)}
   end
 
-  @spec fetch_inactive_oracles(Mnesia.direction(), cursor() | nil, limit()) ::
+  @spec fetch_inactive_oracles(Mnesia.direction(), cursor() | nil, limit(), boolean()) ::
           {[oracle()], cursor() | nil}
-  def fetch_inactive_oracles(direction, cursor, limit) do
-    {exp_keys, next_cursor} = fetch_inactive_keys(direction, deserialize_cursor(cursor), limit)
+  def fetch_inactive_oracles(direction, cursor, limit, expand?) do
+    {exp_keys, next_cursor} =
+      Mnesia.fetch_keys(@table_inactive_expiration, direction, deserialize_cursor(cursor), limit)
 
     {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
 
-    oracles =
-      exp_keys
-      |> Enum.map(fn {_expiration, oracle_pk} -> fetch_inactive_oracle(oracle_pk) end)
-      |> render_list(last_gen, false)
+    oracles = render_list(exp_keys, last_gen, false, expand?)
 
     {oracles, serialize_cursor(next_cursor)}
   end
 
-  defp fetch_active_keys(direction, cursor, limit),
-    do: Mnesia.fetch_keys(@table_active_expiration, direction, cursor, limit)
-
-  defp fetch_inactive_keys(direction, cursor, limit),
-    do: Mnesia.fetch_keys(@table_inactive_expiration, direction, cursor, limit)
-
-  defp render_list(oracles, last_gen, is_active?) do
-    Enum.map(oracles, &render(&1, last_gen, is_active?))
+  defp render_list(oracles_keys, last_gen, is_active?, expand?) do
+    Enum.map(oracles_keys, &render(&1, last_gen, is_active?, expand?))
   end
 
-  defp render(
-         Model.oracle(
-           index: pk,
-           expire: expire_height,
-           register: {{register_height, _mbi}, register_txi},
-           extends: extends,
-           previous: _previous
-         ),
-         last_gen,
-         is_active?
-       ) do
+  defp render({_exp, oracle_pk}, last_gen, is_active?, expand?) do
+    Model.oracle(
+      index: pk,
+      expire: expire_height,
+      register: {{register_height, _mbi}, register_txi},
+      extends: extends,
+      previous: _previous
+    ) = Mnesia.fetch!(if(is_active?, do: @table_active, else: @table_inactive), oracle_pk)
+
     kbi = min(expire_height - 1, last_gen)
 
     oracle_tree = AeMdw.Db.Oracle.oracle_tree!({kbi, -1})
@@ -117,8 +118,8 @@ defmodule AeMdw.Oracles do
       active: is_active?,
       active_from: register_height,
       expire_height: expire_height,
-      register: register_txi,
-      extends: Enum.map(extends, &Format.bi_txi_txi/1),
+      register: expand_txi(register_txi, expand?),
+      extends: Enum.map(extends, &expand_txi(Format.bi_txi_txi(&1), expand?)),
       query_fee: Node.Oracle.get!(oracle_rec, :query_fee),
       format: %{
         query: Node.Oracle.get!(oracle_rec, :query_format),
@@ -126,9 +127,6 @@ defmodule AeMdw.Oracles do
       }
     }
   end
-
-  defp fetch_active_oracle(oracle_pk), do: Mnesia.fetch!(@table_active, oracle_pk)
-  defp fetch_inactive_oracle(oracle_pk), do: Mnesia.fetch!(@table_inactive, oracle_pk)
 
   defp serialize_cursor(nil), do: nil
 
@@ -146,4 +144,7 @@ defmodule AeMdw.Oracles do
       _nil_or_error -> nil
     end
   end
+
+  defp expand_txi(bi_txi, false), do: bi_txi
+  defp expand_txi(bi_txi, true), do: Format.to_map(Util.read_tx!(bi_txi))
 end

--- a/lib/ae_mdw_web/controllers/oracle_controller.ex
+++ b/lib/ae_mdw_web/controllers/oracle_controller.ex
@@ -57,6 +57,23 @@ defmodule AeMdwWeb.OracleController do
   def oracles(conn, _req),
     do: handle_input(conn, fn -> Cont.response(conn, &json/2) end)
 
+  def oracles_v2(%Conn{assigns: assigns} = conn, _params) do
+    %{direction: direction, limit: limit, cursor: cursor} = assigns
+
+    {oracles, new_cursor} = Oracles.fetch_oracles(direction, cursor, limit)
+
+    uri =
+      if new_cursor do
+        %URI{
+          path: "/v2/oracles/#{direction}",
+          query: URI.encode_query(%{"cursor" => new_cursor, "limit" => limit})
+        }
+        |> URI.to_string()
+      end
+
+    json(conn, %{"data" => oracles, "next" => uri})
+  end
+
   def active_oracles_v2(%Conn{assigns: assigns} = conn, _params) do
     %{direction: direction, limit: limit, cursor: cursor} = assigns
 

--- a/lib/ae_mdw_web/plugs/paginated_plug.ex
+++ b/lib/ae_mdw_web/plugs/paginated_plug.ex
@@ -4,6 +4,7 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
 
   import Plug.Conn
 
+  alias Phoenix.Controller
   alias Plug.Conn
 
   @direction_map %{
@@ -21,25 +22,45 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
 
   @spec call(Conn.t(), Plug.opts()) :: Conn.t()
   def call(%Conn{params: params} = conn, _opts) do
-    direction =
-      case Map.fetch(params, "direction") do
-        {:ok, direction} when direction in @valid_directions -> Map.get(@direction_map, direction)
-        {:ok, _direction} -> @default_direction
-        :error -> @default_direction
-      end
-
-    limit =
-      case Integer.parse(Map.get(params, "limit", "")) do
-        {limit, ""} when limit <= @max_limit and limit > 0 -> limit
-        {_limit, _rest} -> @default_limit
-        :error -> @default_limit
-      end
-
-    conn
-    |> assign(:direction, direction)
-    |> assign(:cursor, Map.get(params, "cursor"))
-    |> assign(:limit, limit)
+    with {:ok, direction} <- extract_direction(params),
+         {:ok, limit} <- extract_limit(params) do
+      conn
+      |> assign(:direction, direction)
+      |> assign(:cursor, Map.get(params, "cursor"))
+      |> assign(:limit, limit)
+      |> assign(:expand?, Map.get(params, "expand", "false") != "false")
+    else
+      {:error, error_msg} ->
+        conn
+        |> put_status(:bad_request)
+        |> Controller.json(%{"error" => error_msg})
+        |> halt()
+    end
   end
 
   def call(conn, _opts), do: conn
+
+  defp extract_direction(params) do
+    case Map.fetch(params, "direction") do
+      {:ok, direction} when direction in @valid_directions ->
+        {:ok, Map.get(@direction_map, direction)}
+
+      {:ok, direction} ->
+        {:error, "invalid query: direction=#{direction}"}
+
+      :error ->
+        {:ok, @default_direction}
+    end
+  end
+
+  defp extract_limit(params) do
+    limit_bin = Map.get(params, "limit", "#{@default_limit}")
+
+    case Integer.parse(limit_bin) do
+      {limit, ""} when limit <= @max_limit and limit > 0 -> {:ok, limit}
+      {limit, ""} -> {:error, "limit too large: #{limit}"}
+      {_limit, _rest} -> {:error, "invalid limit: #{limit_bin}"}
+      :error -> {:error, "invalid limit: #{limit_bin}"}
+    end
+  end
 end

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -153,6 +153,7 @@ defmodule AeMdwWeb.Router do
     match :*, "/*path", UtilController, :no_route
   end
 
+  @spec swagger_info() :: term()
   def swagger_info do
     %{
       basePath: "/",

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -102,6 +102,8 @@ defmodule AeMdwWeb.Router do
     get "/v2/oracles/active/:direction", OracleController, :active_oracles_v2
     get "/v2/oracles/inactive", OracleController, :inactive_oracles_v2
     get "/v2/oracles/inactive/:direction", OracleController, :inactive_oracles_v2
+    get "/v2/oracles", OracleController, :oracles_v2
+    get "/v2/oracles/:direction", OracleController, :oracles_v2
 
     get "/aex9/by_name", Aex9Controller, :by_names
     get "/aex9/by_symbol", Aex9Controller, :by_symbols

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -89,21 +89,12 @@ defmodule AeMdwWeb.Router do
     get "/oracle/:id", OracleController, :oracle
 
     get "/oracles/inactive", OracleController, :inactive_oracles
-    get "/oracles/inactive/gen/:range", OracleController, :inactive_oracles
-
     get "/oracles/active", OracleController, :active_oracles
-    get "/oracles/active/gen/:range", OracleController, :active_oracles
-
     get "/oracles", OracleController, :oracles
-    get "/oracles/gen/:range", OracleController, :oracles
 
-    # v2
-    get "/v2/oracles/active", OracleController, :active_oracles_v2
-    get "/v2/oracles/active/:direction", OracleController, :active_oracles_v2
-    get "/v2/oracles/inactive", OracleController, :inactive_oracles_v2
-    get "/v2/oracles/inactive/:direction", OracleController, :inactive_oracles_v2
-    get "/v2/oracles", OracleController, :oracles_v2
-    get "/v2/oracles/:direction", OracleController, :oracles_v2
+    get "/oracles/inactive/gen/:range", OracleController, :inactive_oracles
+    get "/oracles/active/gen/:range", OracleController, :active_oracles
+    get "/oracles/gen/:range", OracleController, :oracles
 
     get "/aex9/by_name", Aex9Controller, :by_names
     get "/aex9/by_symbol", Aex9Controller, :by_symbols

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -7,11 +7,83 @@ defmodule AeMdwWeb.OracleControllerTest do
 
   alias AeMdw.Db.Model
   alias AeMdw.Db.Model.ActiveOracleExpiration
-  # alias AeMdw.Db.Model.ActiveOracle
+  alias AeMdw.Db.Model.InactiveOracleExpiration
   alias AeMdw.Db.Model.Block
   alias AeMdw.Db.Oracle
   alias AeMdw.Mnesia
   alias AeMdw.TestSamples, as: TS
+
+  describe "oracles_v2" do
+    test "it retrieves active oracles first", %{conn: conn} do
+      expiration_keys = 1..10 |> Enum.map(fn _index -> TS.oracle_expiration_key(1) end)
+      Model.oracle(index: pk) = oracle = TS.oracle()
+      encoded_pk = :aeser_api_encoder.encode(:oracle_pubkey, pk)
+
+      next_cursor = {next_cursor_exp, next_cursor_pk} = TS.oracle_expiration_key(2)
+      next_cursor_pk_encoded = :aeser_api_encoder.encode(:oracle_pubkey, next_cursor_pk)
+      next_cursor_query_value = "#{next_cursor_exp}-#{next_cursor_pk_encoded}"
+
+      with_mocks [
+        {Mnesia, [],
+         [
+           fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
+           last_key: fn Block -> {:ok, TS.last_gen()} end,
+           fetch!: fn _tab, _oracle_pk -> oracle end
+         ]},
+        {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
+        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
+      ] do
+        assert %{"data" => [oracle1 | _rest] = oracles, "next" => next_uri} =
+                 conn
+                 |> get("/v2/oracles")
+                 |> json_response(200)
+
+        assert 10 = length(oracles)
+        assert %{"oracle" => ^encoded_pk} = oracle1
+
+        assert %URI{
+                 path: "/v2/oracles/backward",
+                 query: query
+               } = URI.parse(next_uri)
+
+        assert %{"cursor" => ^next_cursor_query_value} = URI.decode_query(query)
+
+        assert_called(Mnesia.fetch_keys(ActiveOracleExpiration, :backward, nil, 10))
+        assert_not_called(Mnesia.fetch_keys(InactiveOracleExpiration, :_, :_, :_))
+      end
+    end
+
+    test "it retrieves both active and inactive when length(active) < limit", %{conn: conn} do
+      active_expiration_keys = [TS.oracle_expiration_key(1), TS.oracle_expiration_key(2)]
+      inactive_expiration_keys = [TS.oracle_expiration_key(3), TS.oracle_expiration_key(4)]
+      Model.oracle(index: pk) = oracle = TS.oracle()
+      encoded_pk = :aeser_api_encoder.encode(:oracle_pubkey, pk)
+
+      with_mocks [
+        {Mnesia, [],
+         [
+           fetch_keys: fn
+             ActiveOracleExpiration, _dir, _cursor, _limit -> {active_expiration_keys, nil}
+             InactiveOracleExpiration, _dir, _cursor, _limit -> {inactive_expiration_keys, nil}
+           end,
+           last_key: fn Block -> {:ok, TS.last_gen()} end,
+           fetch!: fn _tab, _oracle_pk -> oracle end
+         ]},
+        {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
+        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
+      ] do
+        assert %{"data" => [oracle1, _oracle2, _oracle3, _oracle4], "next" => nil} =
+                 conn
+                 |> get("/v2/oracles")
+                 |> json_response(200)
+
+        assert %{"oracle" => ^encoded_pk} = oracle1
+
+        assert_called(Mnesia.fetch_keys(ActiveOracleExpiration, :backward, nil, 10))
+        assert_called(Mnesia.fetch_keys(InactiveOracleExpiration, :backward, nil, 8))
+      end
+    end
+  end
 
   describe "active_oracles_v2" do
     test "it retrieves all active oracles backwards by default", %{conn: conn} do

--- a/test/integration/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -115,7 +115,7 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
           limit
         )
 
-      assert Enum.count(response["data"]) == limit
+      assert ^limit = Enum.count(response["data"])
       assert response["data"] |> Jason.encode!() == data |> Jason.encode!()
 
       conn_next = get(conn, response["next"])
@@ -151,163 +151,6 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
 
       assert json_response(conn, 400) == %{"error" => "limit too large: #{limit}"}
     end
-
-    test "renders error when the access is random ", %{conn: conn} do
-      limit = 6
-      page = 2
-      conn = get(conn, "/oracles?limit=#{limit}&page=#{page}")
-
-      assert json_response(conn, 400) == %{"error" => "random access not supported"}
-    end
-  end
-
-  describe "oracles_v2" do
-    test "it fetches inactive oracles going forwards", %{conn: conn} do
-      assert %{
-               "data" => [
-                 %{"oracle" => "ok_2TASQ4QZv584D2ZP7cZxT6sk1L1UyqbWumnWM4g1azGi1qqcR5"},
-                 %{"oracle" => "ok_R7cQfVN15F5ek1wBSYaMRjW2XbMRKx7VDQQmbtwxspjZQvmPM"},
-                 %{"oracle" => "ok_g5vQK6beY3vsTJHH7KBusesyzq9WMdEYorF8VyvZURXTjLnxT"},
-                 %{"oracle" => "ok_pANDBzM259a9UgZFeiCJyWjXSeRhqrBQ6UCBBeXfbCQyP33Tf"},
-                 %{"oracle" => "ok_cnFq6NgPNXzcwtggcAYUuSNKrW6fhRfDgYJa9WoRe6mEXwpah"},
-                 %{"oracle" => "ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR"},
-                 %{"oracle" => "ok_2yjZGhe1fooEnkoax6bJoDjV45DqaHXYLXWKafzaC9coLMJZy"},
-                 %{"oracle" => "ok_2Ez3Y4gQ1USuNxmSJry5YomnqsF6YTVVVFXVasB3jTSgbroB4z"},
-                 %{"oracle" => "ok_KMVEB7Dxjefsn1jJvKQPKYk3a28xkPgSNe5gnum46pcyogUze"},
-                 %{
-                   "active" => false,
-                   "active_from" => 288_192,
-                   "expire_height" => 288_692,
-                   "extends" => [],
-                   "format" => %{"query" => "querySpace", "response" => "responseSpec"},
-                   "oracle" => "ok_LZCSBq98L2kV5svbgE65shnZwgZzg8hMh13v86LMXQ8HJ7Kpp",
-                   "query_fee" => 2_000_000_000_000_000,
-                   "register" => 13_689_244
-                 }
-               ],
-               "next" =>
-                 "/v2/oracles/inactive/forward?cursor=288707-ok_ceRESNanBZ9ddGKZ75JacWQvR6GJnGci3cqXqMSN8yXL2rpkW&limit=10"
-             } =
-               conn
-               |> get("/v2/oracles/inactive/forward")
-               |> json_response(200)
-    end
-
-    test "it fetches active oracles going backward", %{conn: conn} do
-      assert %{"data" => oracles, "next" => _next} =
-               conn
-               |> get("/v2/oracles/active/backward")
-               |> json_response(200)
-
-      assert Enum.all?(oracles, fn %{"active" => is_active?} -> is_active? end)
-    end
-
-    ############################################################################
-    ## BACKWARDS COMPAT TESTING (compare v2 with v2)
-    ############################################################################
-    test "get inactive oracles with default direction=backward and default limit", %{conn: conn} do
-      conn = get(conn, "/v2/oracles/inactive")
-      response = json_response(conn, 200)
-
-      {:ok, data, _has_cont?} =
-        Cont.response_data({OracleController, :inactive_oracles, %{}, :foo, 0}, @default_limit)
-
-      assert Enum.count(response["data"]) == @default_limit
-      assert response["data"] == data
-
-      conn_next = get(conn, response["next"])
-      response_next = json_response(conn_next, 200)
-
-      {:ok, next_data, _has_cont?} =
-        Cont.response_data(
-          {OracleController, :inactive_oracles, %{}, :foo, @default_limit},
-          @default_limit
-        )
-
-      assert Enum.count(response_next["data"]) <= @default_limit
-      assert response_next["data"] == next_data
-    end
-
-    test "get inactive oracles with direction=forward and limit=5", %{conn: conn} do
-      direction = "forward"
-      limit = 5
-      conn = get(conn, "/v2/oracles/inactive?direction=#{direction}&limit=#{limit}")
-      response = json_response(conn, 200)
-
-      {:ok, data, _has_cont?} =
-        Cont.response_data(
-          {OracleController, :inactive_oracles, %{"direction" => [direction]}, :foo, 0},
-          limit
-        )
-
-      assert Enum.count(response["data"]) == limit
-      assert response["data"] == data
-
-      conn_next = get(conn, response["next"])
-      response_next = json_response(conn_next, 200)
-
-      {:ok, next_data, _has_cont?} =
-        Cont.response_data(
-          {OracleController, :inactive_oracles, %{"direction" => [direction]}, :foo, limit},
-          limit
-        )
-
-      assert Enum.count(response_next["data"]) == limit
-      assert response_next["data"] == next_data
-    end
-
-    test "get active oracles with default direction=backward and limit=1", %{conn: conn} do
-      limit = 1
-      conn = get(conn, "/v2/oracles/active?limit=#{limit}")
-      response = json_response(conn, 200)
-
-      {:ok, data, _has_cont?} =
-        Cont.response_data({OracleController, :active_oracles, %{}, :foo, 0}, limit)
-
-      assert Enum.count(response["data"]) == limit
-      assert response["data"] == data
-
-      conn_next = get(conn, response["next"])
-      response_next = json_response(conn_next, 200)
-
-      {:ok, next_data, _has_cont?} =
-        Cont.response_data({OracleController, :active_oracles, %{}, :foo, limit}, limit)
-
-      assert Enum.count(response_next["data"]) == limit
-      assert response_next["data"] == next_data
-    end
-
-    test "get active oracles with direction=forward and limit=1", %{conn: conn} do
-      direction = "forward"
-      limit = 1
-      conn = get(conn, "/v2/oracles/active?direction=#{direction}&limit=#{limit}")
-      response = json_response(conn, 200)
-
-      {:ok, data, _has_cont?} =
-        Cont.response_data(
-          {OracleController, :active_oracles, %{"direction" => [direction]}, :foo, 0},
-          limit
-        )
-
-      assert Enum.count(response["data"]) == limit
-      assert response["data"] == data
-
-      conn_next = get(conn, response["next"])
-      response_next = json_response(conn_next, 200)
-
-      {:ok, next_data, _has_cont?} =
-        Cont.response_data(
-          {OracleController, :active_oracles, %{"direction" => [direction]}, :foo, limit},
-          limit
-        )
-
-      assert Enum.count(response_next["data"]) == limit
-      assert response_next["data"] == next_data
-    end
-
-    ############################################################################
-    ## END BACKWARDS COMPAT
-    ############################################################################
   end
 
   describe "inactive_oracles" do
@@ -414,14 +257,6 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
       conn = get(conn, "/oracles/inactive?limit=#{limit}")
 
       assert json_response(conn, 400) == %{"error" => "limit too large: #{limit}"}
-    end
-
-    test "renders error when the access is random ", %{conn: conn} do
-      limit = 2
-      page = 3
-      conn = get(conn, "/oracles/inactive?limit=#{limit}&page=#{page}")
-
-      assert json_response(conn, 400) == %{"error" => "random access not supported"}
     end
   end
 
@@ -531,22 +366,12 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
 
       assert json_response(conn, 400) == %{"error" => "limit too large: #{limit}"}
     end
-
-    test "renders error when the access is random ", %{conn: conn} do
-      limit = 2
-      page = 3
-      conn = get(conn, "/oracles/active?limit=#{limit}&page=#{page}")
-
-      assert json_response(conn, 400) == %{"error" => "random access not supported"}
-    end
   end
 
   defp get_oracle(pubkey, expand?) do
-    with {m_oracle, source} <- Oracle.locate(pubkey) do
-      Format.to_map(m_oracle, source, expand?)
-    else
-      nil ->
-        raise ErrInput.NotFound, value: Enc.encode(:oracle_pubkey, pubkey)
+    case Oracle.locate(pubkey) do
+      {m_oracle, source} -> Format.to_map(m_oracle, source, expand?)
+      nil -> raise ErrInput.NotFound, value: Enc.encode(:oracle_pubkey, pubkey)
     end
   end
 end


### PR DESCRIPTION
Output from benchmarks (pretty similar to active/inactive output):
```
Name                 ips        average  deviation         median         99th %
oracles_v2         19.89       50.27 ms     ±8.09%       49.80 ms       74.77 ms
oracles            18.40       54.35 ms     ±9.09%       53.14 ms       71.95 ms

Comparison: 
oracles_v2         19.89
oracles            18.40 - 1.08x slower +4.09 ms

Memory usage statistics:

Name               average  deviation         median         99th %
oracles_v2       672.86 KB     ±0.10%      672.62 KB      674.34 KB
oracles          767.22 KB     ±0.09%      767.46 KB      767.57 KB

Comparison: 
oracles_v2       672.62 KB
oracles          767.22 KB - 1.14x memory usage +94.36 KB
```

This is the commit that needs to be checked out to run these benchmarks f369fb662f3e60949c52005b9a51af4b00d7592b