### PR TITLE
chore: prepend slash to pagination next

### DIFF
--- a/lib/ae_mdw_web/util.ex
+++ b/lib/ae_mdw_web/util.ex
@@ -53,7 +53,7 @@ defmodule AeMdwWeb.Util do
   def make_link(path_info, scope, query_groups) do
     path_info = path_no_scope(path_info)
     scope_info = (scope == nil && []) || [url_encode_scope(scope)]
-    path = Enum.join(path_info ++ scope_info, "/")
+    path = "/" <> Enum.join(path_info ++ scope_info, "/")
 
     query =
       query_groups


### PR DESCRIPTION
## What

Makes the path of pagination's `next` start with "/".

## Why

Fixes #182
htp url path is like that too.

## Validation steps

`make test-integration`

