### PR TITLE
refactor: add paginated name endpoints without making use of streams

### DIFF
--- a/lib/ae_mdw/auction_bids.ex
+++ b/lib/ae_mdw/auction_bids.ex
@@ -1,0 +1,49 @@
+defmodule AeMdw.AuctionBids do
+  @moduledoc """
+  Context module for dealing with AuctionBids.
+  """
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Mnesia
+  alias AeMdw.Names
+  alias AeMdw.Txs
+
+  require Model
+
+  @table Model.AuctionBid
+
+  @typep plain_name() :: binary()
+  @typep auction_bid() :: term()
+
+  @spec top_auction_bid(plain_name()) :: {:ok, auction_bid()} | :not_found
+  def top_auction_bid(plain_name) do
+    case Mnesia.prev_key(@table, bid_top_key(plain_name)) do
+      {:ok, auction_bid} ->
+        if(elem(auction_bid, 0) == plain_name, do: {:ok, render(auction_bid)}, else: :not_found)
+
+      :none ->
+        :not_found
+    end
+  end
+
+  defp render(
+         {plain_name, {_block_index, _txi}, expire_height, _owner_pk,
+          [{_last_bid_bi, last_bid_txi} | _rest_bids] = bids}
+       ) do
+    %{
+      name: plain_name,
+      status: :auction,
+      active: false,
+      info: %{
+        auction_end: expire_height,
+        last_bid: Txs.fetch!(last_bid_txi),
+        bids: Enum.map(bids, &bi_txi_txi/1)
+      },
+      previous: Names.fetch_previous_list(plain_name)
+    }
+  end
+
+  defp bid_top_key(name), do: {name, <<>>, <<>>, <<>>, <<>>}
+
+  defp bi_txi_txi({{_height, _mbi}, txi}), do: txi
+end

--- a/lib/ae_mdw/collection.ex
+++ b/lib/ae_mdw/collection.ex
@@ -66,4 +66,57 @@ defmodule AeMdw.Collection do
 
     {{start_table, start_keys}, {end_table, end_keys}, next_key}
   end
+
+  @doc """
+  Merges the results from different tables into a single table in a sorted order.
+
+  ## Examples
+
+    iex> :mnesia.dirty_all_keys(:table1)
+    [:a, :c]
+    iex> :mnesia.dirty_all_keys(:table2)
+    [:b, :d, :e]
+    iex> AeMdw.Collection.merge([:table1, :table2], :forward, nil, 3)
+    {[{:a, :table1}, {:b, :table2}, {:c, :table1}], :d}
+    iex> AeMdw.Collection.merge([:table1, :table2], :forward, :d, 3)
+    {[{:d, :table2}, {:e, :table2}], nil}
+
+  """
+  @spec merge([table()], direction(), cursor(), limit()) :: {[{record(), table()}], cursor()}
+  def merge(tables, direction, cursor, limit) do
+    next_keys =
+      Enum.reduce(tables, %{}, fn table, acc ->
+        case Mnesia.next_key(table, direction, cursor) do
+          {:ok, next_key} -> Map.put(acc, table, next_key)
+          :not_found -> acc
+        end
+      end)
+
+    keys =
+      Stream.unfold({next_keys, limit + 1}, fn
+        {_next_keys, 0} ->
+          nil
+
+        {next_keys, _limit} when next_keys == %{} ->
+          nil
+
+        {next_keys, limit} ->
+          {table, next_key} =
+            if direction == :backwards do
+              Enum.max_by(next_keys, fn {_table, key} -> key end)
+            else
+              Enum.min_by(next_keys, fn {_table, key} -> key end)
+            end
+
+          case Mnesia.next_key(table, direction, next_key) do
+            {:ok, new_key} -> {{next_key, table}, {Map.put(next_keys, table, new_key), limit - 1}}
+            :not_found -> {{next_key, table}, {Map.delete(next_keys, table), limit - 1}}
+          end
+      end)
+
+    case Enum.split(keys, limit) do
+      {keys, [{cursor, _cursor_table}]} -> {keys, cursor}
+      {keys, []} -> {keys, nil}
+    end
+  end
 end

--- a/lib/ae_mdw/mnesia.ex
+++ b/lib/ae_mdw/mnesia.ex
@@ -52,6 +52,14 @@ defmodule AeMdw.Mnesia do
     end
   end
 
+  @spec prev_key(table(), key()) :: {:ok, key()} | :none
+  def prev_key(tab, key) do
+    case :mnesia.dirty_prev(tab, key) do
+      @end_token -> :none
+      record -> {:ok, record}
+    end
+  end
+
   @spec fetch(table(), key()) :: {:ok, record()} | :not_found
   def fetch(tab, key) do
     case :mnesia.dirty_read(tab, key) do
@@ -65,6 +73,25 @@ defmodule AeMdw.Mnesia do
     {:ok, record} = fetch(tab, key)
 
     record
+  end
+
+  @spec next_key(table(), direction(), cursor()) :: {:ok, key()} | :not_found
+  def next_key(tab, :forward, nil), do: first_key(tab)
+
+  def next_key(tab, :forward, cursor) do
+    case :mnesia.dirty_next(tab, cursor) do
+      @end_token -> :not_found
+      record -> {:ok, record}
+    end
+  end
+
+  def next_key(tab, :backward, nil), do: last_key(tab)
+
+  def next_key(tab, :backward, cursor) do
+    case :mnesia.dirty_prev(tab, cursor) do
+      @end_token -> :not_found
+      record -> {:ok, record}
+    end
   end
 
   @spec fetch_keys(table(), direction(), cursor(), limit()) :: {[record()], cursor()}

--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -211,8 +211,6 @@ defmodule AeMdw.Names do
     %{auction_info | last_bid: new_last_bid}
   end
 
-  defp serialize_name_cursor(nil), do: nil
-
   defp serialize_name_cursor(name), do: name
 
   defp deserialize_name_cursor(nil), do: nil

--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -1,0 +1,255 @@
+defmodule AeMdw.Names do
+  @moduledoc """
+  Context module for dealing with Names.
+  """
+
+  require AeMdw.Db.Model
+
+  alias AeMdw.AuctionBids
+  alias AeMdw.Db.Format
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Util
+  alias AeMdw.Collection
+  alias AeMdw.Mnesia
+  alias AeMdw.Node
+  alias AeMdw.Txs
+
+  @type cursor :: binary()
+  # This needs to be an actual type like AeMdw.Db.Name.t()
+  @type name :: term()
+  @typep order_by :: :expiration | :name
+  @typep limit :: Mnesia.limit()
+  @typep direction :: Mnesia.direction()
+
+  @table_active Model.ActiveName
+  @table_active_expiration Model.ActiveNameExpiration
+  @table_inactive Model.InactiveName
+  @table_inactive_expiration Model.InactiveNameExpiration
+
+  @spec fetch_names(direction(), order_by(), cursor() | nil, limit(), boolean()) ::
+          {[name()], cursor() | nil}
+  def fetch_names(direction, :expiration, cursor, limit, expand?) do
+    cursor = deserialize_expiration_cursor(cursor)
+
+    {{start_table, start_keys}, {end_table, end_keys}, next_key} =
+      Collection.concat(
+        @table_inactive_expiration,
+        @table_active_expiration,
+        direction,
+        cursor,
+        limit
+      )
+
+    start_names = render_exp_list(start_keys, start_table == @table_active_expiration, expand?)
+    end_names = render_exp_list(end_keys, end_table == @table_active_expiration, expand?)
+
+    {start_names ++ end_names, serialize_expiration_cursor(next_key)}
+  end
+
+  def fetch_names(direction, :name, cursor, limit, expand?) do
+    cursor = deserialize_name_cursor(cursor)
+
+    {name_keys, next_key} =
+      Collection.merge([@table_active, @table_inactive], direction, cursor, limit)
+
+    names =
+      Enum.map(name_keys, fn {plain_name, source} ->
+        render(plain_name, source == @table_active, expand?)
+      end)
+
+    {names, serialize_name_cursor(next_key)}
+  end
+
+  @spec fetch_active_names(direction(), order_by(), cursor() | nil, limit(), boolean()) ::
+          {[name()], cursor() | nil}
+  def fetch_active_names(direction, :name, cursor, limit, expand?) do
+    {name_keys, next_cursor} =
+      Mnesia.fetch_keys(@table_active, direction, deserialize_name_cursor(cursor), limit)
+
+    {render_names_list(name_keys, true, expand?), serialize_name_cursor(next_cursor)}
+  end
+
+  def fetch_active_names(direction, :expiration, cursor, limit, expand?) do
+    {exp_keys, next_cursor} =
+      Mnesia.fetch_keys(
+        @table_active_expiration,
+        direction,
+        deserialize_expiration_cursor(cursor),
+        limit
+      )
+
+    {render_exp_list(exp_keys, true, expand?), serialize_expiration_cursor(next_cursor)}
+  end
+
+  @spec fetch_inactive_names(direction(), order_by(), cursor() | nil, limit(), boolean()) ::
+          {[name()], cursor() | nil}
+  def fetch_inactive_names(direction, :name, cursor, limit, expand?) do
+    {name_keys, next_cursor} =
+      Mnesia.fetch_keys(@table_inactive, direction, deserialize_name_cursor(cursor), limit)
+
+    {render_names_list(name_keys, false, expand?), serialize_name_cursor(next_cursor)}
+  end
+
+  def fetch_inactive_names(direction, :expiration, cursor, limit, expand?) do
+    {exp_keys, next_cursor} =
+      Mnesia.fetch_keys(
+        @table_inactive_expiration,
+        direction,
+        deserialize_expiration_cursor(cursor),
+        limit
+      )
+
+    {render_exp_list(exp_keys, false, expand?), serialize_expiration_cursor(next_cursor)}
+  end
+
+  @spec fetch_previous_list(name()) :: [name()]
+  def fetch_previous_list(plain_name) do
+    case Mnesia.fetch(@table_inactive, plain_name) do
+      {:ok, name} ->
+        name
+        |> Stream.unfold(fn
+          nil -> nil
+          Model.name(previous: previous) = name -> {render_name_info(name, false), previous}
+        end)
+        |> Enum.to_list()
+
+      :not_found ->
+        []
+    end
+  end
+
+  defp render_names_list(names_keys, is_active?, expand?) do
+    Enum.map(names_keys, &render(&1, is_active?, expand?))
+  end
+
+  defp render_exp_list(names_keys, is_active?, expand?) do
+    Enum.map(names_keys, fn {_exp, plain_name} -> render(plain_name, is_active?, expand?) end)
+  end
+
+  defp render(plain_name, is_active?, expand?) do
+    name = Mnesia.fetch!(if(is_active?, do: @table_active, else: @table_inactive), plain_name)
+
+    {status, auction_bid} =
+      case AuctionBids.top_auction_bid(plain_name) do
+        {:ok, auction_bid} -> {:auction, auction_bid}
+        :not_found -> {:name, nil}
+      end
+
+    %{
+      name: plain_name,
+      auction: auction_bid && render_auction_bid_info(auction_bid),
+      status: status,
+      active: is_active?,
+      info: render_name_info(name, expand?),
+      previous: render_previous(name, expand?)
+    }
+  end
+
+  defp render_name_info(
+         Model.name(
+           active: active,
+           expire: expire,
+           claims: claims,
+           updates: updates,
+           transfers: transfers,
+           revoke: revoke,
+           auction_timeout: auction_timeout
+         ),
+         expand?
+       ) do
+    %{
+      active_from: active,
+      expire_height: expire,
+      claims: Enum.map(claims, &expand_txi(Format.bi_txi_txi(&1), expand?)),
+      updates: Enum.map(updates, &expand_txi(Format.bi_txi_txi(&1), expand?)),
+      transfers: Enum.map(transfers, &expand_txi(Format.bi_txi_txi(&1), expand?)),
+      revoke: (revoke && expand_txi(Format.bi_txi_txi(revoke), expand?)) || nil,
+      auction_timeout: auction_timeout,
+      pointers: render_pointers(updates),
+      ownership: render_ownership(claims, transfers)
+    }
+  end
+
+  defp render_pointers([]) do
+    %{}
+  end
+
+  defp render_pointers([{_bi, txi} | _rest_updates]) do
+    %{tx: %{pointers: pointers}} = Txs.fetch!(txi)
+
+    pointers
+    |> Enum.map(fn ptr -> {:aens_pointer.key(ptr), render_account_id(:aens_pointer.id(ptr))} end)
+    |> Map.new()
+  end
+
+  defp render_ownership([{{_bi, _txi}, last_claim_txi} | _rest_claims], transfers) do
+    %{tx: %{account_id: orig_owner}} = Txs.fetch!(last_claim_txi)
+
+    case transfers do
+      [] ->
+        %{original: orig_owner, current: orig_owner}
+
+      [{{_bi, _txi}, last_transfer_txi} | _rest_transfers] ->
+        %{tx: %{recipient_id: curr_owner}} = Txs.fetch!(last_transfer_txi)
+
+        %{original: orig_owner, current: curr_owner}
+    end
+  end
+
+  defp render_auction_bid_info(%{info: %{last_bid: last_bid} = auction_info}) do
+    %{block_hash: block_hash, hash: hash, signatures: signatures, tx: %{type: type} = tx} =
+      last_bid
+
+    new_last_bid = %{
+      last_bid
+      | block_hash: :aeser_api_encoder.encode(:micro_block_hash, block_hash),
+        hash: :aeser_api_encoder.encode(:tx_hash, hash),
+        signatures: Enum.map(signatures, &:aeser_api_encoder.encode(:signature, &1)),
+        tx: %{tx | type: Node.tx_name(type)}
+    }
+
+    %{auction_info | last_bid: new_last_bid}
+  end
+
+  defp serialize_name_cursor(nil), do: nil
+
+  defp serialize_name_cursor(name), do: name
+
+  defp deserialize_name_cursor(nil), do: nil
+
+  defp deserialize_name_cursor(cursor_bin) do
+    case Regex.run(~r/\A([\w\.]+\.chain)\z/, cursor_bin) do
+      [_match0, name] -> name
+      nil -> nil
+    end
+  end
+
+  defp serialize_expiration_cursor(nil), do: nil
+
+  defp serialize_expiration_cursor({exp_height, name}), do: "#{exp_height}-#{name}"
+
+  defp deserialize_expiration_cursor(nil), do: nil
+
+  defp deserialize_expiration_cursor(cursor_bin) do
+    case Regex.run(~r/\A(\d+)-([\w\.]+)\z/, cursor_bin) do
+      [_match0, exp_height, name] -> {String.to_integer(exp_height), name}
+      nil -> nil
+    end
+  end
+
+  defp expand_txi(bi_txi, false), do: bi_txi
+  defp expand_txi(bi_txi, true), do: Format.to_map(Util.read_tx!(bi_txi))
+
+  defp render_previous(name, expand?) do
+    name
+    |> Stream.unfold(fn
+      Model.name(previous: nil) -> nil
+      Model.name(previous: previous) -> {previous, previous}
+    end)
+    |> Enum.map(&render_name_info(&1, expand?))
+  end
+
+  defp render_account_id({:id, id_type, payload}) do
+    :aeser_api_encoder.encode(Node.id_type(id_type), payload)
+  end
+end

--- a/lib/ae_mdw/oracles.ex
+++ b/lib/ae_mdw/oracles.ex
@@ -15,7 +15,7 @@ defmodule AeMdw.Oracles do
   @type cursor :: binary()
   # This needs to be an actual type like AeMdw.Db.Oracle.t()
   @type oracle :: term()
-  @typep limit :: pos_integer()
+  @typep limit :: Mnesia.limit()
 
   @table_active AeMdw.Db.Model.ActiveOracle
   @table_active_expiration Model.ActiveOracleExpiration

--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -1,0 +1,68 @@
+defmodule AeMdw.Txs do
+  @moduledoc """
+  Context module for dealing with Transactions.
+  """
+
+  alias AeMdw.Db.Format
+  alias AeMdw.Db.Model
+  alias AeMdw.Mnesia
+  alias AeMdw.Node
+  alias AeMdw.Node.Db
+
+  require Model
+
+  @type txi :: non_neg_integer()
+  # This needs to be an actual type like AeMdw.Db.Tx.t()
+  @type tx :: term()
+
+  @table Model.Tx
+
+  @spec fetch!(txi()) :: tx()
+  def fetch!(txi) do
+    {:ok, tx} = fetch(txi)
+
+    tx
+  end
+
+  @spec fetch(txi()) :: {:ok, tx()} | :not_found
+  def fetch(txi) do
+    case Mnesia.fetch(@table, txi) do
+      {:ok, tx} -> {:ok, render(tx)}
+      :not_found -> :not_found
+    end
+  end
+
+  defp render(
+         Model.tx(index: tx_index, id: tx_hash, block_index: {kb_index, mb_index}, time: mb_time)
+       ) do
+    {block_hash, type, signed_tx, tx_rec} = Db.get_tx_data(tx_hash)
+
+    tx_map =
+      tx_rec
+      |> Format.to_raw_map(type)
+      |> put_in([:type], type)
+
+    raw = %{
+      block_hash: block_hash,
+      signatures: :aetx_sign.signatures(signed_tx),
+      hash: tx_hash,
+      block_height: kb_index,
+      micro_index: mb_index,
+      micro_time: mb_time,
+      tx_index: tx_index,
+      tx: tx_map
+    }
+
+    type
+    |> Format.custom_raw_data(raw, tx_rec, signed_tx, block_hash)
+    |> update_in([:tx, :account_id], &render_id/1)
+    |> update_in([:tx, :name_id], &render_id/1)
+    |> update_in([:tx, :recipient_id], &render_id/1)
+  end
+
+  defp render_id({:id, id_type, payload}) do
+    :aeser_api_encoder.encode(Node.id_type(id_type), payload)
+  end
+
+  defp render_id(id), do: id
+end

--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -55,9 +55,9 @@ defmodule AeMdw.Txs do
 
     type
     |> Format.custom_raw_data(raw, tx_rec, signed_tx, block_hash)
-    |> update_in([:tx, :account_id], &render_id/1)
-    |> update_in([:tx, :name_id], &render_id/1)
-    |> update_in([:tx, :recipient_id], &render_id/1)
+    |> update_in_if_present([:tx, :account_id], &render_id/1)
+    |> update_in_if_present([:tx, :name_id], &render_id/1)
+    |> update_in_if_present([:tx, :recipient_id], &render_id/1)
   end
 
   defp render_id({:id, id_type, payload}) do
@@ -65,4 +65,11 @@ defmodule AeMdw.Txs do
   end
 
   defp render_id(id), do: id
+
+  defp update_in_if_present(map, path, fun) do
+    case get_in(map, path) do
+      nil -> map
+      val -> put_in(map, path, fun.(val))
+    end
+  end
 end

--- a/lib/ae_mdw_web/plugs/paginated_plug.ex
+++ b/lib/ae_mdw_web/plugs/paginated_plug.ex
@@ -7,6 +7,8 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
   alias Phoenix.Controller
   alias Plug.Conn
 
+  @type opts() :: [order_by: [atom()] | Plug.opts()]
+
   @direction_map %{
     "forward" => :forward,
     "backward" => :backward
@@ -17,18 +19,20 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
   @default_limit 10
   @max_limit 20
 
-  @spec init(Plug.opts()) :: Conn.t()
+  @spec init(opts()) :: opts()
   def init(opts), do: opts
 
-  @spec call(Conn.t(), Plug.opts()) :: Conn.t()
-  def call(%Conn{params: params} = conn, _opts) do
+  @spec call(Conn.t(), opts()) :: Conn.t()
+  def call(%Conn{params: params} = conn, opts) do
     with {:ok, direction} <- extract_direction(params),
-         {:ok, limit} <- extract_limit(params) do
+         {:ok, limit} <- extract_limit(params),
+         {:ok, order_by} <- extract_order_by(params, opts) do
       conn
       |> assign(:direction, direction)
       |> assign(:cursor, Map.get(params, "cursor"))
       |> assign(:limit, limit)
       |> assign(:expand?, Map.get(params, "expand", "false") != "false")
+      |> assign(:order_by, order_by)
     else
       {:error, error_msg} ->
         conn
@@ -61,6 +65,22 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
       {limit, ""} -> {:error, "limit too large: #{limit}"}
       {_limit, _rest} -> {:error, "invalid limit: #{limit_bin}"}
       :error -> {:error, "invalid limit: #{limit_bin}"}
+    end
+  end
+
+  defp extract_order_by(params, opts) do
+    case {Keyword.get(opts, :order_by), Map.get(params, "by")} do
+      {nil, _order_by} ->
+        {:ok, nil}
+
+      {[first_order | _rest], nil} ->
+        {:ok, first_order}
+
+      {valid_orders, order_by} ->
+        case Enum.find(valid_orders, &(Atom.to_string(&1) == order_by)) do
+          nil -> {:error, "invalid query: by=#{order_by}"}
+          valid_order_by -> {:ok, valid_order_by}
+        end
     end
   end
 end

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -21,7 +21,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, data, _has_cont?} =
         Cont.response_data(
-          {NameController, :active_names, %{}, conn.assigns.scope, 0},
+          {NameController, :active_names, %{}, :unused_scope, 0},
           @default_limit
         )
 
@@ -33,7 +33,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, next_data, _has_cont?} =
         Cont.response_data(
-          {NameController, :active_names, %{}, conn.assigns.scope, @default_limit},
+          {NameController, :active_names, %{}, :unused_scope, @default_limit},
           @default_limit
         )
 
@@ -49,7 +49,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, data, _has_cont?} =
         Cont.response_data(
-          {NameController, :active_names, %{}, conn.assigns.scope, 0},
+          {NameController, :active_names, %{}, :unused_scope, 0},
           limit
         )
 
@@ -67,12 +67,12 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       {:ok, data, _has_cont?} =
         Cont.response_data(
           {NameController, :active_names, %{"by" => [by], "direction" => [direction]},
-           conn.assigns.scope, 0},
+           :unused_scope, 0},
           limit
         )
 
       assert Enum.count(response["data"]) <= limit
-      assert Jason.encode!(response["data"]) == Jason.encode!(data)
+      assert response["data"] == data
     end
 
     test "renders error when parameter by is invalid", %{conn: conn} do
@@ -98,7 +98,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, data, _has_cont?} =
         Cont.response_data(
-          {NameController, :inactive_names, %{}, conn.assigns.scope, 0},
+          {NameController, :inactive_names, %{}, :unused_scope, 0},
           @default_limit
         )
 
@@ -110,7 +110,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, next_data, _has_cont?} =
         Cont.response_data(
-          {NameController, :inactive_names, %{}, conn.assigns.scope, @default_limit},
+          {NameController, :inactive_names, %{}, :unused_scope, @default_limit},
           @default_limit
         )
 
@@ -126,7 +126,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, data, _has_cont?} =
         Cont.response_data(
-          {NameController, :inactive_names, %{}, conn.assigns.scope, 0},
+          {NameController, :inactive_names, %{}, :unused_scope, 0},
           limit
         )
 
@@ -146,7 +146,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       {:ok, data, _has_cont?} =
         Cont.response_data(
           {NameController, :inactive_names, %{"by" => [by], "direction" => [direction]},
-           conn.assigns.scope, 0},
+           :unused_scope, 0},
           limit
         )
 
@@ -245,7 +245,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, data, _has_cont?} =
         Cont.response_data(
-          {NameController, :names, %{}, conn.assigns.scope, 0},
+          {NameController, :names, %{}, :unused_scope, 0},
           @default_limit
         )
 
@@ -257,7 +257,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, next_data, _has_cont?} =
         Cont.response_data(
-          {NameController, :names, %{}, conn.assigns.scope, @default_limit},
+          {NameController, :names, %{}, :unused_scope, @default_limit},
           @default_limit
         )
 
@@ -273,7 +273,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, data, _has_cont?} =
         Cont.response_data(
-          {NameController, :names, %{}, conn.assigns.scope, 0},
+          {NameController, :names, %{}, :unused_scope, 0},
           limit
         )
 
@@ -291,12 +291,12 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       {:ok, data, _has_cont?} =
         Cont.response_data(
-          {NameController, :names, %{"by" => [by]}, conn.assigns.scope, 0},
+          {NameController, :names, %{"by" => [by]}, :unused_scope, 0},
           limit
         )
 
       assert Enum.count(response["data"]) == limit
-      assert Jason.encode!(response["data"]) == Jason.encode!(data)
+      assert response["data"] == data
     end
 
     test "renders error when parameter by is invalid", %{conn: conn} do

--- a/test/support/test_sample.ex
+++ b/test/support/test_sample.ex
@@ -21,6 +21,20 @@ defmodule AeMdw.TestSamples do
     |> Enum.at(n)
   end
 
+  @spec plain_name(non_neg_integer()) :: binary()
+  def plain_name(n) do
+    ~w(aaaaa.chain bbbbb.chain ccccc.chain dddddd.chain eeeeee.chain)
+    |> Enum.at(n)
+  end
+
+  @spec name_expiration_key(non_neg_integer()) :: {non_neg_integer(), binary()}
+  def name_expiration_key(n) do
+    ~w(aaaaa.chain bbbbb.chain ccccc.chain dddddd.chain eeeeee.chain)
+    |> Enum.with_index()
+    |> Enum.map(fn {plain_name, index} -> {expire_height(index), plain_name} end)
+    |> Enum.at(n)
+  end
+
   @spec expire_height(non_neg_integer()) :: non_neg_integer()
   def expire_height(n) do
     ~w(5851 6894 7499 34919 35040) |> Enum.at(n) |> String.to_integer()


### PR DESCRIPTION
This includes `/names`, `/names/active`, `/names/inactive` endpoints.