### PR TITLE
feat: add gas_used to create contract tx info

### DIFF
--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -309,6 +309,20 @@ defmodule AeMdw.Contract do
     end
   end
 
+  def gas_used_in_create(contract_pk, tx_rec, block_hash) do
+    create_nonce = :aect_create_tx.nonce(tx_rec)
+
+    init_call_id =
+      tx_rec
+      |> :aect_create_tx.owner_pubkey()
+      |> :aect_call.id(create_nonce, contract_pk)
+
+    contract_pk
+    |> :aec_chain.get_contract_call(init_call_id, block_hash)
+    |> ok!
+    |> :aect_call.gas_used()
+  end
+
   ##########
 
   def get_events(<<micro_block_hash::binary>>) do

--- a/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
@@ -34,10 +34,13 @@ defmodule Integration.AeMdwWeb.TxControllerTest do
 
   describe "txi" do
     test "get a transaction by a given index", %{conn: conn} do
-      valid_index = 10_000_000
+      valid_index = 15_499_122
       conn = get(conn, "/txi/#{valid_index}")
 
       assert json_response(conn, 200)["tx_index"] == valid_index
+      assert tx = json_response(conn, 200)["tx"]
+      assert tx["type"] == "ContractCreateTx"
+      assert tx["gas_used"] && tx["gas_used"] > 0
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
## What

Adds `gas_used` (snake case like other fields) on tx_controller response for `:contract_create_tx`.

## Why

Fixes #197 

## Additional Notes

Create tx is referred  as `InitCall` and fetched likewise:
https://github.com/aeternity/aeternity/blob/417774bdddd9ff46a057975f3bbbb8eb8d96d8ff/apps/aecontract/test/aecontract_SUITE.erl#L1018 (used here)

https://github.com/aeternity/aeternity/blob/417774bdddd9ff46a057975f3bbbb8eb8d96d8ff/apps/aecontract/test/aecontract_SUITE.erl#L994 (with InitCallId encoded here)

https://github.com/aeternity/aeternity/blob/417774bdddd9ff46a057975f3bbbb8eb8d96d8ff/apps/aecontract/test/aecontract_SUITE.erl#L985 (from the `create_tx` for a tx that is accessed with `aect_create_tx`)