### PR TITLE
fix: base64 encode queries when returning oracle query txs

### DIFF
--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -448,6 +448,10 @@ defmodule AeMdw.Db.Format do
     |> put_in(["tx", "gas_used"], Contract.gas_used_in_create(contract_pk, tx_rec, block_hash))
   end
 
+  def custom_encode(:oracle_query_tx, tx, _tx_rec, _signed_tx, _block_hash) do
+    update_in(tx, ["tx", "query"], &Base.encode64/1)
+  end
+
   def custom_encode(:contract_call_tx, tx, tx_rec, _signed_tx, block_hash) do
     contract_pk = :aect_call_tx.contract_pubkey(tx_rec)
     call_rec = Contract.call_rec(tx_rec, contract_pk, block_hash)

--- a/test/integration/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/contract_controller_test.exs
@@ -112,4 +112,19 @@ defmodule Integration.AeMdwWeb.ContractControllerTest do
              }
     end
   end
+
+  describe "calls" do
+    test "it gets calls from a contract", %{conn: conn} do
+      contract_id = "ct_2uJthb5s1D8c8F8ZYMAZ6LYGWno5ubFnrmkkHLE1FBzN3JruQw"
+
+      assert %{"data" => calls} =
+               conn
+               |> get("/contracts/calls/forward?contract_id=#{contract_id}")
+               |> json_response(200)
+
+      assert 10 = length(calls)
+      assert %{"internal_tx" => %{"query" => query_b64}} = Enum.at(calls, 2)
+      assert {:ok, _query} = Base.decode64(query_b64)
+    end
+  end
 end


### PR DESCRIPTION
Oracle queries are binaries with any sort of content, and if these
aren't base64 encoded before encoding them into JSON it fails.

Closes #264