### PR TITLE
fix: start :aesync and :app_ctrl_server when initializing app

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -25,6 +25,8 @@ defmodule AeMdw.Application do
     init(:aehttp)
     init_public(:db_state)
     # init(:aesophia)
+    init(:app_ctrl_server)
+    init(:aesync)
 
     children = [
       AeMdw.Sync.Watcher,
@@ -191,6 +193,10 @@ defmodule AeMdw.Application do
       }
     )
   end
+
+  defp init(:app_ctrl_server), do: :app_ctrl_server.start()
+
+  defp init(:aesync), do: Application.ensure_all_started(:aesync)
 
   @spec init_public(atom()) :: :ok
   def init_public(:contract_cache) do

--- a/mix.exs
+++ b/mix.exs
@@ -125,7 +125,8 @@ defmodule AeMdw.MixProject do
       {:mock, "~> 0.3.0", only: :test},
       {:phoenix_html, "~> 2.11"},
       {:credo, "~> 1.5", only: [:dev, :test], runtime: false},
-      {:benchee, "~> 1.0.0", only: [:dev]}
+      {:benchee, "~> 1.0.0", only: [:dev]},
+      {:ex_json_schema, "~> 0.7.1"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -17,6 +17,7 @@
   "elixir_uuid": {:hex, :elixir_uuid, "1.2.1", "dce506597acb7e6b0daeaff52ff6a9043f5919a4c3315abb4143f0b00378c097", [:mix], [], "hexpm", "f7eba2ea6c3555cea09706492716b0d87397b88946e6380898c2889d68585752"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "ex2ms": {:hex, :ex2ms, "1.6.0", "f39bbd9ff1b0f27b3f707bab2d167066dd8965e7df1149b962d94c74615d0e09", [:mix], [], "hexpm", "0d1ab5e08421af5cd69146efb408dbb1ff77f38a2f4df5f086f2512dc8cf65bf"},
+  "ex_json_schema": {:hex, :ex_json_schema, "0.7.4", "09eb5b0c8184e5702bc89625a9d0c05c7a0a845d382e9f6f406a0fc1c9a8cc3f", [:mix], [], "hexpm", "45c67fa840f0d719a2b5578126dc29bcdc1f92499c0f61bcb8a3bcb5935f9684"},
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "gettext": {:hex, :gettext, "0.18.2", "7df3ea191bb56c0309c00a783334b288d08a879f53a7014341284635850a6e55", [:mix], [], "hexpm", "f9f537b13d4fdd30f3039d33cb80144c3aa1f8d9698e47d7bcbcc8df93b1f5c5"},
   "git_hooks": {:hex, :git_hooks, "0.5.2", "61160eb52112d37b018c94ef5383a31d2187b00b046ecb10e802e71556549e85", [:mix], [{:blankable, "~> 1.0.0", [hex: :blankable, repo: "hexpm", optional: false]}, {:recase, "~> 0.7.0", [hex: :recase, repo: "hexpm", optional: false]}], "hexpm", "38e452c3cbd407d0ec30f8327f54d59d2ada1ecea62ecc13a3fa2ddd799881de"},


### PR DESCRIPTION
In this new version of aecore (6.3.0) both the :app_ctrl_server process are required for aecore to start syncing and to respond to
functions such as `:asc_sync.sync_progress()`.

This is rather hack-ish, but I don't know why none of these things are started when aecore starts.

closes #275