### PR TITLE
fix: set :app_ctrl mode to :normal to allow MDW to sync

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -194,7 +194,10 @@ defmodule AeMdw.Application do
     )
   end
 
-  defp init(:app_ctrl_server), do: :app_ctrl_server.start()
+  defp init(:app_ctrl_server) do
+    :app_ctrl_server.start()
+    :app_ctrl.set_mode(:normal)
+  end
 
   defp init(:aesync), do: Application.ensure_all_started(:aesync)
 


### PR DESCRIPTION
Without setting this mode, the :app_ctrl app won't start the aesync app which will do all the node syncing.