### PR TITLE
chore: expose service ports when starting docker-shell container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ define docker_execute
 	docker-compose run --rm \
 										 --workdir=/app \
 										 --entrypoint="" \
+										 --service-ports \
 										 ae_mdw \
 										 $(1)
 endef


### PR DESCRIPTION
It enables running the phoenix server while inside the container created with docker-shell.