### PR TITLE
fix: add AETERNITY_CONFIG env variable to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,5 @@ services:
       - ${PWD}/docker/aeternity.yaml:/home/aeternity/aeternity.yaml
       - ${PWD}:/app
     expose: [3013, 3014, 3113, 4001, 4000]
+    environment:
+      - AETERNITY_CONFIG=/home/aeternity/aeternity.yaml


### PR DESCRIPTION
Without it, it would cause aeternity node to ignore the local
aeternity.yaml config.