### PR TITLE
refactor: add :scope, :query and :offset to Conn.assigns

### DIFF
--- a/lib/ae_mdw/db/util.ex
+++ b/lib/ae_mdw/db/util.ex
@@ -1,5 +1,8 @@
 defmodule AeMdw.Db.Util do
+  # credo:disable-for-this-file
   alias AeMdw.Db.Model
+  alias AeMdw.Db.Model.Block
+  alias AeMdw.Mnesia
 
   require Logger
   require Model
@@ -248,6 +251,22 @@ defmodule AeMdw.Db.Util do
 
       :error ->
         nil
+    end
+  end
+
+  @spec first_gen!() :: non_neg_integer()
+  def first_gen! do
+    case Mnesia.first_key(Block, nil) do
+      nil -> 0
+      {kbi, _txi} -> kbi
+    end
+  end
+
+  @spec last_gen!() :: non_neg_integer()
+  def last_gen! do
+    case Mnesia.last_key(Block, nil) do
+      nil -> 0
+      {kbi, _txi} -> kbi
     end
   end
 end

--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -20,7 +20,9 @@ defmodule AeMdwWeb.NameController do
   import AeMdw.Db.Util
   import AeMdw.Util
 
-  plug(PaginatedPlug, order_by: ~w(expiration name)a)
+  plug PaginatedPlug,
+       [order_by: ~w(expiration name)a]
+       when action in ~w(active_names inactive_names names auctions)a
 
   ##########
 

--- a/lib/ae_mdw_web/plugs/paginated_plug.ex
+++ b/lib/ae_mdw_web/plugs/paginated_plug.ex
@@ -6,8 +6,7 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
 
   alias Phoenix.Controller
   alias Plug.Conn
-  alias AeMdw.Db.Model.Block
-  alias AeMdw.Mnesia
+  alias AeMdw.Db.Util
   alias AeMdw.Node
   alias AeMdw.Validate
 
@@ -171,23 +170,9 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
     end
   end
 
-  defp default_forward_range, do: first_gen()..last_gen()
+  defp default_forward_range, do: Util.first_gen!()..Util.last_gen!()
 
-  defp default_backward_range, do: last_gen()..first_gen()
-
-  defp first_gen do
-    case Mnesia.first_key(Block, nil) do
-      nil -> 0
-      {kbi, _txi} -> kbi
-    end
-  end
-
-  defp last_gen do
-    case Mnesia.last_key(Block, nil) do
-      nil -> 0
-      {kbi, _txi} -> kbi
-    end
-  end
+  defp default_backward_range, do: Util.last_gen!()..Util.first_gen!()
 
   # Page extraction from params is for backwards compat and should be removed
   # after getting rid of non-cursor-based pagination.

--- a/lib/ae_mdw_web/plugs/paginated_plug.ex
+++ b/lib/ae_mdw_web/plugs/paginated_plug.ex
@@ -175,9 +175,19 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
 
   defp default_backward_range, do: last_gen()..first_gen()
 
-  defp first_gen, do: Mnesia.first_key(Block, 0)
+  defp first_gen do
+    case Mnesia.first_key(Block, nil) do
+      nil -> 0
+      {kbi, _txi} -> kbi
+    end
+  end
 
-  defp last_gen, do: Mnesia.last_key(Block, 0)
+  defp last_gen do
+    case Mnesia.last_key(Block, nil) do
+      nil -> 0
+      {kbi, _txi} -> kbi
+    end
+  end
 
   # Page extraction from params is for backwards compat and should be removed
   # after getting rid of non-cursor-based pagination.

--- a/lib/ae_mdw_web/plugs/paginated_plug.ex
+++ b/lib/ae_mdw_web/plugs/paginated_plug.ex
@@ -6,33 +6,44 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
 
   alias Phoenix.Controller
   alias Plug.Conn
+  alias AeMdw.Db.Model.Block
+  alias AeMdw.Mnesia
+  alias AeMdw.Node
+  alias AeMdw.Validate
 
   @type opts() :: [order_by: [atom()] | Plug.opts()]
 
-  @direction_map %{
-    "forward" => :forward,
-    "backward" => :backward
+  @scope_types %{
+    "gen" => :gen,
+    "txi" => :txi
   }
-  @valid_directions Map.keys(@direction_map)
-  @default_direction :backward
+  @scope_types_keys Map.keys(@scope_types)
 
   @default_limit 10
   @max_limit 100
+
+  @type_query_params ~w(type type_group)
+  @pagination_param_keys ~w(limit page cursor expand direction scope_type range by)
 
   @spec init(opts()) :: opts()
   def init(opts), do: opts
 
   @spec call(Conn.t(), opts()) :: Conn.t()
-  def call(%Conn{params: params} = conn, opts) do
-    with {:ok, direction} <- extract_direction(params),
+  def call(%Conn{params: params, query_params: query_params} = conn, opts) do
+    with {:ok, direction, scope} <- extract_direction_and_scope(params),
          {:ok, limit} <- extract_limit(params),
-         {:ok, order_by} <- extract_order_by(params, opts) do
+         {:ok, order_by} <- extract_order_by(params, opts),
+         {:ok, query} <- extract_query(query_params),
+         {:ok, page} <- extract_page(params) do
       conn
       |> assign(:direction, direction)
       |> assign(:cursor, Map.get(params, "cursor"))
       |> assign(:limit, limit)
       |> assign(:expand?, Map.get(params, "expand", "false") != "false")
       |> assign(:order_by, order_by)
+      |> assign(:scope, scope)
+      |> assign(:query, query)
+      |> assign(:offset, {limit, page})
     else
       {:error, error_msg} ->
         conn
@@ -44,18 +55,52 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
 
   def call(conn, _opts), do: conn
 
-  defp extract_direction(params) do
-    case Map.fetch(params, "direction") do
-      {:ok, direction} when direction in @valid_directions ->
-        {:ok, Map.get(@direction_map, direction)}
+  defp extract_direction_and_scope(%{"scope_type" => scope_type, "range" => range})
+       when scope_type in @scope_types_keys do
+    scope_type = Map.fetch!(@scope_types, scope_type)
 
-      {:ok, direction} ->
-        {:error, "invalid query: direction=#{direction}"}
-
-      :error ->
-        {:ok, @default_direction}
+    case extract_range(range) do
+      {:ok, first, last} when first <= last -> {:ok, :forward, {scope_type, first..last}}
+      {:ok, first, last} -> {:ok, :backward, {scope_type, first..last}}
+      {:error, reason} -> {:error, reason}
     end
   end
+
+  defp extract_direction_and_scope(%{"scope_type" => scope_type}),
+    do: {:error, "invalid scope: #{scope_type}"}
+
+  defp extract_direction_and_scope(%{"direction" => "forward"}),
+    do: {:ok, :forward, {:gen, default_forward_range()}}
+
+  defp extract_direction_and_scope(%{"direction" => "backward"}),
+    do: {:ok, :backward, {:gen, default_backward_range()}}
+
+  defp extract_direction_and_scope(%{"direction" => direction}),
+    do: {:error, "invalid direction: #{direction}"}
+
+  defp extract_direction_and_scope(_params),
+    do: {:ok, :backward, {:gen, default_backward_range()}}
+
+  defp extract_range(range) when is_binary(range) do
+    case String.split(range, "-") do
+      [from, to] ->
+        case {Integer.parse(from), Integer.parse(to)} do
+          {{from, ""}, {to, ""}} when from >= 0 and to >= 0 -> {:ok, from, to}
+          {_from_err, _to_err} -> {:error, "invalid range: #{range}"}
+        end
+
+      [single] ->
+        case Integer.parse(single) do
+          {single, ""} when single >= 0 -> {:ok, single, single}
+          _single_err -> {:error, "invalid range: #{range}"}
+        end
+
+      _splitted_range ->
+        {:error, "invalid range: #{range}"}
+    end
+  end
+
+  defp extract_range(range), do: {:error, "invalid range: #{range}"}
 
   defp extract_limit(params) do
     limit_bin = Map.get(params, "limit", "#{@default_limit}")
@@ -83,4 +128,65 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
         end
     end
   end
+
+  defp extract_query(query_params) do
+    query_params
+    |> Enum.reject(fn {key, _val} -> key in @pagination_param_keys end)
+    |> Enum.reduce_while({:ok, %{}}, fn {key, val}, {:ok, top_level} ->
+      kw = (key in @type_query_params && :types) || :ids
+      group = Map.get(top_level, kw, MapSet.new())
+
+      case extract_group(key, val, group) do
+        {:ok, new_group} -> {:cont, {:ok, Map.put(top_level, kw, new_group)}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp extract_group("type", val, group) do
+    case Validate.tx_type(val) do
+      {:ok, type} -> {:ok, MapSet.put(group, type)}
+      {:error, {err_kind, offender}} -> {:error, AeMdw.Error.to_string(err_kind, offender)}
+    end
+  end
+
+  defp extract_group("type_group", val, group) do
+    case Validate.tx_group(val) do
+      {:ok, new_group} ->
+        {:ok, new_group |> Node.tx_group() |> MapSet.new() |> MapSet.union(group)}
+
+      {:error, {err_kind, offender}} ->
+        {:error, AeMdw.Error.to_string(err_kind, offender)}
+    end
+  end
+
+  defp extract_group(key, val, group) do
+    {_is_base_id?, validator} = AeMdw.Db.Stream.Query.Parser.classify_ident(key)
+
+    try do
+      {:ok, MapSet.put(group, {key, validator.(val)})}
+    rescue
+      err in [AeMdw.Error.Input] ->
+        {:error, err.message}
+    end
+  end
+
+  defp default_forward_range, do: first_gen()..last_gen()
+
+  defp default_backward_range, do: last_gen()..first_gen()
+
+  defp first_gen, do: Mnesia.first_key(Block, 0)
+
+  defp last_gen, do: Mnesia.last_key(Block, 0)
+
+  # Page extraction from params is for backwards compat and should be removed
+  # after getting rid of non-cursor-based pagination.
+  defp extract_page(%{"page" => page}) do
+    case Integer.parse(page) do
+      {page, ""} -> {:ok, page}
+      _err_or_invalid -> {:error, "invalid_page: #{page}"}
+    end
+  end
+
+  defp extract_page(_params), do: {:ok, 1}
 end

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -52,8 +52,8 @@ defmodule AeMdwWeb.NameControllerTest do
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
            prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -101,8 +101,8 @@ defmodule AeMdwWeb.NameControllerTest do
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
            prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -167,8 +167,8 @@ defmodule AeMdwWeb.NameControllerTest do
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
            prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -214,8 +214,8 @@ defmodule AeMdwWeb.NameControllerTest do
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
            prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -258,8 +258,8 @@ defmodule AeMdwWeb.NameControllerTest do
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
            prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -311,8 +311,8 @@ defmodule AeMdwWeb.NameControllerTest do
            prev_key: fn AuctionBid, _key ->
              {:ok, {plain_name, {0, 1}, 0, :owner_pk, [{{2, 3}, 4}]}}
            end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -348,8 +348,8 @@ defmodule AeMdwWeb.NameControllerTest do
            prev_key: fn AuctionBid, _key ->
              {:ok, {plain_name, {0, 1}, 0, :owner_pk, [{{2, 3}, 4}]}}
            end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -382,8 +382,8 @@ defmodule AeMdwWeb.NameControllerTest do
            prev_key: fn AuctionBid, _key ->
              {:ok, {plain_name, {0, 1}, 0, :owner_pk, [{{2, 3}, 4}]}}
            end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -444,8 +444,8 @@ defmodule AeMdwWeb.NameControllerTest do
              )
            end,
            prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -483,9 +483,9 @@ defmodule AeMdwWeb.NameControllerTest do
            prev_key: fn AuctionBid, _key -> :none end,
            last_key: fn
              InactiveNameExpiration, nil -> nil
-             Block, _default -> 0
+             Block, _default -> {0, 0}
            end,
-           first_key: fn Block, _default -> 0 end
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [
@@ -524,8 +524,8 @@ defmodule AeMdwWeb.NameControllerTest do
              )
            end,
            prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Txs, [],
          [

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -6,11 +6,11 @@ defmodule AeMdwWeb.NameControllerTest do
   alias AeMdw.Db.Model.ActiveNameExpiration
   alias AeMdw.Db.Model.AuctionBid
   alias AeMdw.Db.Model.AuctionExpiration
-  alias AeMdw.Db.Model.Block
   alias AeMdw.Db.Model.InactiveName
   alias AeMdw.Db.Model.InactiveNameExpiration
   alias AeMdw.Db.Model.Tx
   alias AeMdw.Db.Name
+  alias AeMdw.Db.Util, as: DbUtil
   alias AeMdw.Mnesia
   alias AeMdw.Validate
   alias AeMdw.TestSamples, as: TS
@@ -51,13 +51,16 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           prev_key: fn AuctionBid, _key -> :none end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => names, "next" => next} =
@@ -100,13 +103,16 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           prev_key: fn AuctionBid, _key -> :none end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => names} =
@@ -166,13 +172,16 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           prev_key: fn AuctionBid, _key -> :none end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => names, "next" => next} =
@@ -213,13 +222,16 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           prev_key: fn AuctionBid, _key -> :none end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => names} =
@@ -257,13 +269,16 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           prev_key: fn AuctionBid, _key -> :none end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => names} =
@@ -310,13 +325,16 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn InactiveName, ^plain_name -> :not_found end,
            prev_key: fn AuctionBid, _key ->
              {:ok, {plain_name, {0, 1}, 0, :owner_pk, [{{2, 3}, 4}]}}
-           end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => auction_bids, "next" => next} =
@@ -347,13 +365,16 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn InactiveName, ^plain_name -> :not_found end,
            prev_key: fn AuctionBid, _key ->
              {:ok, {plain_name, {0, 1}, 0, :owner_pk, [{{2, 3}, 4}]}}
-           end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => auctions} =
@@ -381,13 +402,16 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn InactiveName, ^plain_name -> :not_found end,
            prev_key: fn AuctionBid, _key ->
              {:ok, {plain_name, {0, 1}, 0, :owner_pk, [{{2, 3}, 4}]}}
-           end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => auctions} =
@@ -443,13 +467,16 @@ defmodule AeMdwWeb.NameControllerTest do
                auction_timeout: 1
              )
            end,
-           prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           prev_key: fn AuctionBid, _key -> :none end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => names, "next" => nil} =
@@ -481,15 +508,16 @@ defmodule AeMdwWeb.NameControllerTest do
              )
            end,
            prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn
-             InactiveNameExpiration, nil -> nil
-             Block, _default -> {0, 0}
-           end,
-           first_key: fn Block, _default -> {0, 0} end
+           last_key: fn InactiveNameExpiration, nil -> nil end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => names} =
@@ -523,13 +551,16 @@ defmodule AeMdwWeb.NameControllerTest do
                auction_timeout: 1
              )
            end,
-           prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           prev_key: fn AuctionBid, _key -> :none end
          ]},
         {Txs, [],
          [
            fetch!: fn _hash -> %{"tx" => %{"account_id" => <<>>}} end
+         ]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
          ]}
       ] do
         assert %{"data" => names, "next" => _next} =

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -6,6 +6,7 @@ defmodule AeMdwWeb.NameControllerTest do
   alias AeMdw.Db.Model.ActiveNameExpiration
   alias AeMdw.Db.Model.AuctionBid
   alias AeMdw.Db.Model.AuctionExpiration
+  alias AeMdw.Db.Model.Block
   alias AeMdw.Db.Model.InactiveName
   alias AeMdw.Db.Model.InactiveNameExpiration
   alias AeMdw.Db.Model.Tx
@@ -50,7 +51,9 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end
+           prev_key: fn AuctionBid, _key -> :none end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -97,7 +100,9 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end
+           prev_key: fn AuctionBid, _key -> :none end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -123,7 +128,7 @@ defmodule AeMdwWeb.NameControllerTest do
     test "renders error when parameter direction is invalid", %{conn: conn} do
       by = "name"
       direction = "invalid_direction"
-      error = "invalid query: direction=#{direction}"
+      error = "invalid direction: #{direction}"
 
       assert %{"error" => ^error} =
                conn
@@ -161,7 +166,9 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end
+           prev_key: fn AuctionBid, _key -> :none end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -206,7 +213,9 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end
+           prev_key: fn AuctionBid, _key -> :none end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -248,7 +257,9 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn Tx, _key ->
              {:ok, Model.tx(index: 0, id: 0, block_index: {0, 0}, time: 0)}
            end,
-           prev_key: fn AuctionBid, _key -> :none end
+           prev_key: fn AuctionBid, _key -> :none end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -274,7 +285,7 @@ defmodule AeMdwWeb.NameControllerTest do
     test "renders error when parameter direction is invalid", %{conn: conn} do
       by = "name"
       direction = "invalid_direction"
-      error = "invalid query: direction=#{direction}"
+      error = "invalid direction: #{direction}"
 
       assert %{"error" => ^error} =
                conn
@@ -299,7 +310,9 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn InactiveName, ^plain_name -> :not_found end,
            prev_key: fn AuctionBid, _key ->
              {:ok, {plain_name, {0, 1}, 0, :owner_pk, [{{2, 3}, 4}]}}
-           end
+           end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -334,7 +347,9 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn InactiveName, ^plain_name -> :not_found end,
            prev_key: fn AuctionBid, _key ->
              {:ok, {plain_name, {0, 1}, 0, :owner_pk, [{{2, 3}, 4}]}}
-           end
+           end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -366,7 +381,9 @@ defmodule AeMdwWeb.NameControllerTest do
            fetch: fn InactiveName, ^plain_name -> :not_found end,
            prev_key: fn AuctionBid, _key ->
              {:ok, {plain_name, {0, 1}, 0, :owner_pk, [{{2, 3}, 4}]}}
-           end
+           end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -392,7 +409,7 @@ defmodule AeMdwWeb.NameControllerTest do
     test "renders error when parameter direction is invalid", %{conn: conn} do
       by = "name"
       direction = "invalid_direction"
-      error = "invalid query: direction=#{direction}"
+      error = "invalid direction: #{direction}"
 
       assert %{"error" => ^error} =
                conn
@@ -426,7 +443,9 @@ defmodule AeMdwWeb.NameControllerTest do
                auction_timeout: 1
              )
            end,
-           prev_key: fn AuctionBid, _key -> :none end
+           prev_key: fn AuctionBid, _key -> :none end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -462,7 +481,11 @@ defmodule AeMdwWeb.NameControllerTest do
              )
            end,
            prev_key: fn AuctionBid, _key -> :none end,
-           last_key: fn InactiveNameExpiration, nil -> nil end
+           last_key: fn
+             InactiveNameExpiration, nil -> nil
+             Block, _default -> 0
+           end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -500,8 +523,9 @@ defmodule AeMdwWeb.NameControllerTest do
                auction_timeout: 1
              )
            end,
-           prev_key: fn AuctionBid, _key -> :none end
-           # last_key: fn InactiveNameExpiration, nil -> nil end
+           prev_key: fn AuctionBid, _key -> :none end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Txs, [],
          [
@@ -527,7 +551,7 @@ defmodule AeMdwWeb.NameControllerTest do
     test "renders error when parameter direction is invalid", %{conn: conn} do
       by = "name"
       direction = "invalid_direction"
-      error = "invalid query: direction=#{direction}"
+      error = "invalid direction: #{direction}"
 
       assert %{"error" => ^error} =
                conn |> get("/names?by=#{by}&direction=#{direction}") |> json_response(400)

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -29,8 +29,8 @@ defmodule AeMdwWeb.OracleControllerTest do
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> oracle end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
@@ -70,8 +70,8 @@ defmodule AeMdwWeb.OracleControllerTest do
              InactiveOracleExpiration, _dir, _cursor, _limit -> {inactive_expiration_keys, nil}
            end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end,
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end,
            fetch!: fn _tab, _oracle_pk -> oracle end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
@@ -103,8 +103,8 @@ defmodule AeMdwWeb.OracleControllerTest do
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> oracle end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
@@ -133,8 +133,8 @@ defmodule AeMdwWeb.OracleControllerTest do
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> TS.oracle() end,
-           last_key: fn Block, _default -> 0 end,
-           first_key: fn Block, _default -> 0 end
+           last_key: fn Block, _default -> {0, 0} end,
+           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -29,15 +29,15 @@ defmodule AeMdwWeb.OracleControllerTest do
          [
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
-           fetch!: fn _tab, _oracle_pk -> oracle end,
+           fetch!: fn _tab, _oracle_pk -> oracle end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
-        {DbUtil, [], [
+        {DbUtil, [],
+         [
            last_gen!: fn -> 0 end,
            first_gen!: fn -> 0 end
-           ]}
-
+         ]}
       ] do
         assert %{"data" => [oracle1 | _rest] = oracles, "next" => next_uri} =
                  conn
@@ -74,12 +74,15 @@ defmodule AeMdwWeb.OracleControllerTest do
              InactiveOracleExpiration, _dir, _cursor, _limit -> {inactive_expiration_keys, nil}
            end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end,
            fetch!: fn _tab, _oracle_pk -> oracle end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
-        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
+        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
+         ]}
       ] do
         assert %{"data" => [oracle1, _oracle2, _oracle3, _oracle4], "next" => nil} =
                  conn
@@ -106,12 +109,15 @@ defmodule AeMdwWeb.OracleControllerTest do
          [
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
-           fetch!: fn _tab, _oracle_pk -> oracle end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           fetch!: fn _tab, _oracle_pk -> oracle end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
-        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
+        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
+         ]}
       ] do
         assert %{"data" => [oracle1, _oracle2], "next" => nil} =
                  conn
@@ -136,12 +142,15 @@ defmodule AeMdwWeb.OracleControllerTest do
          [
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
-           fetch!: fn _tab, _oracle_pk -> TS.oracle() end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
+           fetch!: fn _tab, _oracle_pk -> TS.oracle() end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
-        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
+        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
+        {DbUtil, [],
+         [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
+         ]}
       ] do
         assert %{"next" => next_uri} = conn |> get("/oracles/active") |> json_response(200)
 

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -28,7 +28,9 @@ defmodule AeMdwWeb.OracleControllerTest do
          [
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
-           fetch!: fn _tab, _oracle_pk -> oracle end
+           fetch!: fn _tab, _oracle_pk -> oracle end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
@@ -68,6 +70,8 @@ defmodule AeMdwWeb.OracleControllerTest do
              InactiveOracleExpiration, _dir, _cursor, _limit -> {inactive_expiration_keys, nil}
            end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end,
            fetch!: fn _tab, _oracle_pk -> oracle end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
@@ -98,7 +102,9 @@ defmodule AeMdwWeb.OracleControllerTest do
          [
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
-           fetch!: fn _tab, _oracle_pk -> oracle end
+           fetch!: fn _tab, _oracle_pk -> oracle end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
@@ -126,7 +132,9 @@ defmodule AeMdwWeb.OracleControllerTest do
          [
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
-           fetch!: fn _tab, _oracle_pk -> TS.oracle() end
+           fetch!: fn _tab, _oracle_pk -> TS.oracle() end,
+           last_key: fn Block, _default -> 0 end,
+           first_key: fn Block, _default -> 0 end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -10,6 +10,7 @@ defmodule AeMdwWeb.OracleControllerTest do
   alias AeMdw.Db.Model.InactiveOracleExpiration
   alias AeMdw.Db.Model.Block
   alias AeMdw.Db.Oracle
+  alias AeMdw.Db.Util, as: DbUtil
   alias AeMdw.Mnesia
   alias AeMdw.TestSamples, as: TS
 
@@ -29,11 +30,14 @@ defmodule AeMdwWeb.OracleControllerTest do
            fetch_keys: fn _tab, _dir, _cursor, _limit -> {expiration_keys, next_cursor} end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> oracle end,
-           last_key: fn Block, _default -> {0, 0} end,
-           first_key: fn Block, _default -> {0, 0} end
          ]},
         {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
-        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]}
+        {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
+        {DbUtil, [], [
+           last_gen!: fn -> 0 end,
+           first_gen!: fn -> 0 end
+           ]}
+
       ] do
         assert %{"data" => [oracle1 | _rest] = oracles, "next" => next_uri} =
                  conn

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -95,7 +95,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       direction = "invalid_direction"
       conn = get(conn, "/names/active?by=#{by}&direction=#{direction}")
 
-      assert json_response(conn, 400) == %{"error" => "invalid query: direction=#{direction}"}
+      assert json_response(conn, 400) == %{"error" => "invalid direction: #{direction}"}
     end
   end
 
@@ -174,7 +174,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       direction = "invalid_direction"
       conn = get(conn, "/names/inactive?by=#{by}&direction=#{direction}")
 
-      assert json_response(conn, 400) == %{"error" => "invalid query: direction=#{direction}"}
+      assert json_response(conn, 400) == %{"error" => "invalid direction: #{direction}"}
     end
   end
 
@@ -240,7 +240,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       direction = "invalid_direction"
       conn = get(conn, "/names/auctions?by=#{by}&direction=#{direction}")
 
-      assert json_response(conn, 400) == %{"error" => "invalid query: direction=#{direction}"}
+      assert json_response(conn, 400) == %{"error" => "invalid direction: #{direction}"}
     end
   end
 
@@ -319,7 +319,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       direction = "invalid_direction"
       conn = get(conn, "/names?by=#{by}&direction=#{direction}")
 
-      assert json_response(conn, 400) == %{"error" => "invalid query: direction=#{direction}"}
+      assert json_response(conn, 400) == %{"error" => "invalid direction: #{direction}"}
     end
   end
 

--- a/test/integration/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -134,7 +134,7 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
       direction = "invalid"
       conn = get(conn, "/oracles?direction=#{direction}")
 
-      assert json_response(conn, 400) == %{"error" => "invalid query: direction=#{direction}"}
+      assert json_response(conn, 400) == %{"error" => "invalid direction: #{direction}"}
     end
 
     test "renders error when limit is invalid", %{conn: conn} do
@@ -239,7 +239,7 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
       direction = "invalid"
       conn = get(conn, "/oracles/inactive?direction=#{direction}")
 
-      assert json_response(conn, 400) == %{"error" => "invalid query: direction=#{direction}"}
+      assert json_response(conn, 400) == %{"error" => "invalid direction: #{direction}"}
     end
 
     test "renders error when limit is invalid", %{conn: conn} do
@@ -345,7 +345,7 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
       direction = "invalid"
       conn = get(conn, "/oracles/active?direction=#{direction}")
 
-      assert json_response(conn, 400) == %{"error" => "invalid query: direction=#{direction}"}
+      assert json_response(conn, 400) == %{"error" => "invalid direction: #{direction}"}
     end
 
     test "renders error when limit is invalid", %{conn: conn} do


### PR DESCRIPTION
This is a preamble to the scope handling of all newly paginated
resources. Ultimately, to get rid of the DataStreamPlug and all the
stream_plug_hook functions from the controllers.