### PR TITLE
feat: aex9 migration balance timeout

### DIFF
--- a/priv/migrations/20210826171900_reindex_remote_logs.ex
+++ b/priv/migrations/20210826171900_reindex_remote_logs.ex
@@ -6,9 +6,11 @@ defmodule AeMdw.Migrations.ReindexRemoteLogs do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Origin
   alias AeMdw.Db.Util
+  alias AeMdw.Log
 
   require Model
   require Ex2ms
+  require Logger
 
   # single case of pubkey that causes a pk mismatch error:
   # ** (CaseClauseError) no case clause matching: {:contract_create_tx, <<84, 161, 71, 116, 248, 82, 0, 46, 52, 142, 60, 121, 255, 115, 239, 189, 180, 252, 224, 142, 255, 39, 10, 83, 243, 93, 69, 189, 148, 123, 164, 60>>, 22913712}
@@ -35,7 +37,7 @@ defmodule AeMdw.Migrations.ReindexRemoteLogs do
     begin = DateTime.utc_now()
 
     table_size = :mnesia.async_dirty(fn -> Util.count(Model.ContractLog) end)
-    IO.puts("table size: #{table_size}")
+    Log.info("table size: #{table_size}")
     num_chunks = div(table_size, @max_chunk_size) + 1
 
     log_spec =
@@ -61,7 +63,7 @@ defmodule AeMdw.Migrations.ReindexRemoteLogs do
       end)
 
     duration = DateTime.diff(DateTime.utc_now(), begin)
-    IO.puts("Indexed #{reindexed_count} records in #{duration}s")
+    Log.info("Indexed #{reindexed_count} records in #{duration}s")
 
     {:ok, {reindexed_count, duration}}
   end

--- a/priv/migrations/20210914100800_index_inner_txs.ex
+++ b/priv/migrations/20210914100800_index_inner_txs.ex
@@ -11,10 +11,12 @@ defmodule AeMdw.Migrations.IndexInnerTxs do
   alias AeMdw.Db.Util
   alias AeMdw.Db.Sync.InnerTx, as: SyncInnerTx
   alias AeMdw.Db.Sync.Transaction, as: SyncTx
+  alias AeMdw.Log
   alias AeMdw.Sync.Supervisor, as: SyncSup
 
   require Model
   require Ex2ms
+  require Logger
 
   @fortuna_txi_begin 2129380
 
@@ -26,7 +28,7 @@ defmodule AeMdw.Migrations.IndexInnerTxs do
     begin = DateTime.utc_now()
 
     if not from_startup? and :ok != Application.ensure_started(:ae_mdw) do
-      IO.puts("Ensure sync tables...")
+      Log.info("Ensure sync tables...")
       SyncSup.init_tables()
       MdwApp.init_public(:contract_cache)
       MdwApp.init_public(:db_state)
@@ -39,7 +41,7 @@ defmodule AeMdw.Migrations.IndexInnerTxs do
     indexed_count = reindex_txs(txi_list)
 
     duration = DateTime.diff(DateTime.utc_now(), begin)
-    IO.puts("Indexed #{indexed_count} records in #{duration}s")
+    Log.info("Indexed #{indexed_count} records in #{duration}s")
 
     {:ok, {indexed_count, duration}}
   end


### PR DESCRIPTION
## What

Adds 1 minute timeout to aex9 balance and saves the contract to be handled separately (in a dets/temporary table).

## Why

Migration was taking more than 10 minutes (sometimes 20 min) because of two very big contracts. 
This change avoids the Mdw (testnet and mainnet) to be out of sync for so long time.

## Result
Total time reduced:
![Screenshot from 2021-11-03 11-09-50](https://user-images.githubusercontent.com/44991200/140052327-000c66fb-52c0-4cdd-9ac1-eeafda80b5ab.png)

Contracts saved:
![Screenshot from 2021-11-03 11-09-14](https://user-images.githubusercontent.com/44991200/140052397-74a6f43e-6a0c-4d34-be6e-0931803b54b9.png)
