### PR TITLE
fix: expiration inconsistencies

### DIFF
--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -230,7 +230,6 @@ defmodule AeMdw.Db.Sync.Name do
     m_name_exp = Model.expiration(index: {expire, plain_name})
     m_owner = Model.owner(index: {owner, plain_name})
 
-    ensure_no_exsiting_active_name_expiration(plain_name)
     cache_through_write(Model.ActiveName, m_name)
     cache_through_write(Model.ActiveNameOwner, m_owner)
     cache_through_write(Model.ActiveNameExpiration, m_name_exp)
@@ -244,22 +243,6 @@ defmodule AeMdw.Db.Sync.Name do
     inc(:stat_sync_cache, :active_names)
     dec(:stat_sync_cache, :active_auctions)
     log_expired_auction(height, plain_name)
-  end
-
-  def ensure_no_exsiting_active_name_expiration(plain_name) do
-    name_mspec =
-      Ex2ms.fun do
-        {:expiration, {height, ^plain_name}, :_} -> {height, ^plain_name}
-      end
-
-    expirations = :mnesia.select(Model.ActiveNameExpiration, name_mspec)
-
-    if Enum.count(expirations) > 0 do
-      Log.info("Removing exsiting active name expirations #{inspect(expirations)}")
-
-      expirations
-      |> Enum.map(fn key -> cache_through_delete(Model.ActiveNameExpiration, key) end)
-    end
   end
 
   ##########

--- a/priv/migrations/20211104081901_update_homedepot_expiration.ex
+++ b/priv/migrations/20211104081901_update_homedepot_expiration.ex
@@ -1,0 +1,51 @@
+defmodule AeMdw.Migrations.UpdateHomeDepotExpiration do
+  @moduledoc """
+  Update homedepot.chain expiration.
+  """
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Util
+  alias AeMdw.Log
+
+  require Model
+  require Ex2ms
+  require Logger
+
+  @homedepot "homedepot.chain"
+  @last_claim 408123
+
+  @spec run(boolean()) :: {:ok, {pos_integer(), pos_integer()}}
+  def run(_from_start?) do
+    begin = DateTime.utc_now()
+
+    expired_at =
+      if [] != :mnesia.dirty_read(Model.InactiveNameExpiration, {458121, @homedepot}) do
+        :mnesia.dirty_delete(Model.InactiveNameExpiration, {458121, @homedepot})
+        :mnesia.dirty_delete(Model.ActiveNameExpiration, {633884, @homedepot})
+
+        expired_at = expire_from_claim(@homedepot, @last_claim)
+        m_exp = Model.expiration(index: {expired_at, @homedepot})
+        :mnesia.dirty_write(Model.InactiveNameExpiration, m_exp)
+
+        expired_at
+      end
+
+    duration = DateTime.diff(DateTime.utc_now(), begin)
+
+    indexed_count =
+      if nil != expired_at do
+        Log.info("Name homedepot expiration updated to #{expired_at} in #{duration}s")
+        1
+      else
+        Log.info("No homedepot expiration update (in #{duration}s)")
+        0
+      end
+
+    {:ok, {indexed_count, duration}}
+  end
+
+  defp expire_from_claim(plain_name, height) do
+    proto_vsn = Util.proto_vsn(height)
+    :aec_governance.name_claim_bid_timeout(plain_name, proto_vsn)
+    height + :aec_governance.name_claim_max_expiration(proto_vsn)
+  end
+end


### PR DESCRIPTION
## What

Migration to fix database state for the specific and unique case in mainnet of `homedepot.chain` name that has ActiveNameExpiration record while it's an inactive name.

## Why

It's a single case so this is a first specific migration and a more generic one is in WIP and will be provided to recompute and validate the expiration state of all names (in any network).

## Validation steps

1. Run `iex --sname aeternity@localhost -S mix phx.server`
2. Check it logged in `log/info.log`: `[info] Name homedepot expiration updated to 458123 in 0s`
3. Running:
```
alias AeMdw.Db.Model; require Model; require Ex2ms; 
homedepot_spec = Ex2ms.fun do {:expiration, {height, plain_name}, :_} = record when plain_name == "homedepot.chain" -> record end;
:mnesia.dirty_select(Model.ActiveNameExpiration, homedepot_spec)
```
returns 
```
[]
```
4. Running:
```
:mnesia.dirty_select(Model.InactiveNameExpiration, homedepot_spec)
```
returns 
```
[{:expiration, {458123, "homedepot.chain"}, nil}]
```