### PR TITLE
fix: always display the correct contract_id on contract logs

### DIFF
--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -13,6 +13,9 @@ defmodule AeMdw.Contract do
   import AeMdw.Util
 
   @tab __MODULE__
+
+  @type id :: binary()
+
   @typep fname() :: binary()
   @typep tx_hash() :: binary()
   @typep event_name() :: {:internal_call_tx, fname()}

--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -127,7 +127,14 @@ defmodule AeMdw.Db.Format do
   def to_raw_map({create_txi, call_txi, event_hash, log_idx}, Model.ContractLog) do
     m_log = read!(Model.ContractLog, {create_txi, call_txi, event_hash, log_idx})
     ct_id = &:aeser_id.create(:contract, &1)
-    ct_pk = Origin.pubkey({:contract, create_txi})
+
+    ct_pk =
+      if create_txi == -1 do
+        Origin.pubkey({:contract_call, call_txi})
+      else
+        Origin.pubkey({:contract, create_txi})
+      end
+
     ext_ct_pk = Model.contract_log(m_log, :ext_contract)
 
     parent_contract_pk =
@@ -146,7 +153,7 @@ defmodule AeMdw.Db.Format do
 
     %{
       contract_txi: (create_txi != -1 && create_txi) || -1,
-      contract_id: ct_pk && ct_id.(ct_pk),
+      contract_id: ct_id.(ct_pk),
       ext_caller_contract_txi: ext_ct_txi,
       ext_caller_contract_id: (ext_ct_pk != nil && ct_id.(ext_ct_pk)) || nil,
       parent_contract_id: (parent_contract_pk && ct_id.(parent_contract_pk)) || nil,

--- a/lib/ae_mdw/db/origin.ex
+++ b/lib/ae_mdw/db/origin.ex
@@ -1,11 +1,16 @@
 defmodule AeMdw.Db.Origin do
+  alias AeMdw.Contract
   alias AeMdw.Validate
   alias AeMdw.Db.Model
+  alias AeMdw.Node.Db
+  alias AeMdw.Txs
 
   require Model
 
   import AeMdw.Db.Util
   import AeMdw.Util
+
+  @typep contract_locator() :: {:contract, Txs.txi()} | {:contract_call, Txs.txi()}
 
   ##########
 
@@ -30,12 +35,25 @@ defmodule AeMdw.Db.Origin do
     end
   end
 
-  @spec pubkey({:contract, term()}) :: term()
+  @spec pubkey(contract_locator()) :: Contract.id() | nil
   def pubkey({:contract, txi}) do
     case next(Model.RevOrigin, {txi, :contract_create_tx, <<>>}) do
       :"$end_of_table" -> nil
       {^txi, :contract_create_tx, pubkey} -> pubkey
       {_txi, _tx_type, _pubkey} -> nil
     end
+  end
+
+  def pubkey({:contract_call, call_txi}) do
+    Model.tx(id: tx_hash) = read_tx!(call_txi)
+
+    {_block_hash, :contract_call_tx, _siged_tx, tx_rec} = Db.get_tx_data(tx_hash)
+
+    {:contract, contract_id} =
+      tx_rec
+      |> :aect_call_tx.contract_id()
+      |> :aeser_id.specialize()
+
+    contract_id
   end
 end

--- a/test/integration/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/contract_controller_test.exs
@@ -112,7 +112,9 @@ defmodule Integration.AeMdwWeb.ContractControllerTest do
              }
     end
 
-    test "when contract log doesn't have a creation txi, contract_id = nil", %{conn: conn} do
+    test "when contract log doesn't have a creation txi, contract_id shouldn't be nil", %{
+      conn: conn
+    } do
       contract_id = "ct_eJhrbPPS4V97VLKEVbSCJFpdA4uyXiZujQyLqMFoYV88TzDe6"
 
       assert %{"data" => contract_logs} =
@@ -120,15 +122,21 @@ defmodule Integration.AeMdwWeb.ContractControllerTest do
                |> get(path(:forward), contract_id: contract_id)
                |> json_response(200)
 
-      [
-        %{
-          "contract_id" => nil,
-          "contract_txi" => -1,
-          "ext_caller_contract_id" => "ct_eJhrbPPS4V97VLKEVbSCJFpdA4uyXiZujQyLqMFoYV88TzDe6",
-          "ext_caller_contract_txi" => -1
-        }
-        | _rest
-      ] = contract_logs
+      assert [
+               %{
+                 "contract_id" => ^contract_id,
+                 "contract_txi" => -1,
+                 "ext_caller_contract_id" =>
+                   "ct_eJhrbPPS4V97VLKEVbSCJFpdA4uyXiZujQyLqMFoYV88TzDe6",
+                 "ext_caller_contract_txi" => -1
+               }
+               | rest
+             ] = contract_logs
+
+      assert Enum.all?(rest, fn
+               %{"contract_id" => ^contract_id} -> true
+               _contract -> false
+             end)
     end
   end
 


### PR DESCRIPTION
closes: #301