### PR TITLE
feat: add mutations abstraction to deal with mnesia updates

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -69,7 +69,7 @@ jobs:
         id: plt-cache
         with:
           path: priv/plts
-          key: plts-v3-${{ hashFiles('mix.lock') }}
+          key: plts-v4-${{ hashFiles('mix.lock') }}
 
       - name: Common tests setup
         uses: ./.github/actions/tests-common

--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -13,8 +13,11 @@ defmodule AeMdw.Blocks do
 
   require Model
 
-  # This needs to be an actual type like AeMdw.Db.Tx.t()
-  @type block :: term()
+  @type height() :: non_neg_integer()
+  @type mbi() :: non_neg_integer()
+  @type time() :: non_neg_integer()
+  @type block_index() :: {height(), mbi()}
+  @type block :: map()
   @type cursor :: binary()
 
   @typep direction :: Mnesia.direction()

--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -15,6 +15,7 @@ defmodule AeMdw.Contract do
   @tab __MODULE__
 
   @type id :: binary()
+  @type grouped_events() :: %{tx_hash() => [event()]}
 
   @typep fname() :: binary()
   @typep tx_hash() :: binary()
@@ -326,7 +327,7 @@ defmodule AeMdw.Contract do
     end)
   end
 
-  @spec get_grouped_events(micro_block()) :: %{tx_hash() => [event()]}
+  @spec get_grouped_events(micro_block()) :: grouped_events()
   def get_grouped_events(micro_block) do
     Enum.group_by(get_events(micro_block), fn {_event_name, %{tx_hash: tx_hash}} -> tx_hash end)
   end

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -19,7 +19,7 @@ defmodule AeMdw.Db.Contract do
   import AeMdw.Util, only: [compose: 2, max_256bit_int: 0]
   import AeMdw.Db.Util
 
-  @typep pubkey() :: <<_::256>>
+  @type pubkey() :: <<_::256>>
   @typep call_map() ::
            %{
              function: any(),

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -2,6 +2,9 @@ defmodule AeMdw.Db.Model do
   @moduledoc """
   Mnesia database model records.
   """
+  alias AeMdw.Blocks
+  alias AeMdw.Txs
+
   require Record
   require Ex2ms
 
@@ -30,6 +33,14 @@ defmodule AeMdw.Db.Model do
   #     index = tx_index (0..), id = tx_id
   @tx_defaults [index: -1, id: <<>>, block_index: {-1, -1}, time: -1]
   defrecord :tx, @tx_defaults
+
+  @type tx ::
+          record(:tx,
+            index: Txs.txi(),
+            id: Txs.tx_hash(),
+            block_index: Blocks.block_index(),
+            time: Blocks.time()
+          )
 
   # txs time index :
   #     index = {mb_time_msecs (0..), tx_index = (0...)},

--- a/lib/ae_mdw/db/mutation.ex
+++ b/lib/ae_mdw/db/mutation.ex
@@ -1,0 +1,17 @@
+defprotocol AeMdw.Db.Mutation do
+  @moduledoc """
+  Protocol aimed at specifying all database mutations declaratively. This can be
+  a simple write to mnesia, or more complex logic involving multiple mnesia
+  queries or calls to other services.
+
+  The goal of this protocol is to do as much work as possible before starting
+  the mnesia transaction. Once the mnesia transaction is started, the mutate
+  function is called for every mutation generated.
+  """
+
+  @doc """
+  Abstracted function that performs the actual mutation into the mnesia database.
+  """
+  @spec mutate(t()) :: :ok
+  def mutate(mutation)
+end

--- a/lib/ae_mdw/db/mutations/aex9_account_presence_mutation.ex
+++ b/lib/ae_mdw/db/mutations/aex9_account_presence_mutation.ex
@@ -1,0 +1,31 @@
+defmodule AeMdw.Db.Aex9AccountPresenceMutation do
+  @moduledoc """
+  Computes and derives Aex9 tokens, and stores it into the appropriate indexes.
+  """
+
+  alias AeMdw.Db.Sync
+  alias AeMdw.Blocks
+
+  defstruct [:height, :mbi]
+
+  @opaque t() :: %__MODULE__{
+            height: Blocks.height(),
+            mbi: Blocks.mbi()
+          }
+
+  @spec new(Blocks.height(), Blocks.mbi()) :: t()
+  def new(height, mbi) do
+    %__MODULE__{height: height, mbi: mbi}
+  end
+
+  @spec mutate(t()) :: :ok
+  def mutate(%__MODULE__{height: height, mbi: mbi}) do
+    Sync.Contract.aex9_derive_account_presence!({height, mbi})
+  end
+end
+
+defimpl AeMdw.Db.Mutation, for: AeMdw.Db.Aex9AccountPresenceMutation do
+  def mutate(mutation) do
+    @for.mutate(mutation)
+  end
+end

--- a/lib/ae_mdw/db/mutations/contract_events_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_events_mutation.ex
@@ -1,0 +1,36 @@
+defmodule AeMdw.Db.ContractEventsMutation do
+  @moduledoc """
+  Stores the internal contract calls by using the contract events.
+  """
+
+  alias AeMdw.Contract
+  alias AeMdw.Db.Contract, as: DBContract
+  alias AeMdw.Db.Sync
+  alias AeMdw.Txs
+
+  defstruct [:ct_pk, :events, :txi]
+
+  @typep event() :: Contract.event()
+  @opaque t() :: %__MODULE__{
+            ct_pk: DBContract.pubkey(),
+            events: [event()],
+            txi: Txs.txi()
+          }
+
+  @spec new(DBContract.pubkey(), [event()], Txs.txi()) :: t()
+  def new(ct_pk, events, txi) do
+    %__MODULE__{ct_pk: ct_pk, events: events, txi: txi}
+  end
+
+  @spec mutate(t()) :: :ok
+  def mutate(%__MODULE__{ct_pk: ct_pk, events: events, txi: txi}) do
+    ct_txi = Sync.Contract.get_txi(ct_pk)
+    Sync.Contract.events(events, txi, ct_txi)
+  end
+end
+
+defimpl AeMdw.Db.Mutation, for: AeMdw.Db.ContractEventsMutation do
+  def mutate(mutation) do
+    @for.mutate(mutation)
+  end
+end

--- a/lib/ae_mdw/db/mutations/mnesia_write_mutation.ex
+++ b/lib/ae_mdw/db/mutations/mnesia_write_mutation.ex
@@ -1,0 +1,31 @@
+defmodule AeMdw.Db.MnesiaWriteMutation do
+  @moduledoc """
+  This is the most basic kind of transaction, it just inserts a record in a
+  mnesia table.
+  """
+
+  alias AeMdw.Mnesia
+
+  defstruct [:table, :record]
+
+  @opaque t() :: %__MODULE__{
+            table: Mnesia.table(),
+            record: Mnesia.record()
+          }
+
+  @spec new(Mnesia.table(), Mnesia.record()) :: t()
+  def new(table, record) do
+    %__MODULE__{table: table, record: record}
+  end
+
+  @spec mutate(t()) :: :ok
+  def mutate(%__MODULE__{table: table, record: record}) do
+    Mnesia.write(table, record)
+  end
+end
+
+defimpl AeMdw.Db.Mutation, for: AeMdw.Db.MnesiaWriteMutation do
+  def mutate(mutation) do
+    @for.mutate(mutation)
+  end
+end

--- a/lib/ae_mdw/db/mutations/write_fields_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_fields_mutation.ex
@@ -1,0 +1,68 @@
+defmodule AeMdw.Db.WriteFieldsMutation do
+  @moduledoc """
+  Stores the indexes for the Fields table.
+  """
+
+  alias AeMdw.Blocks
+  alias AeMdw.Node
+  alias AeMdw.Db.Model
+  alias AeMdw.Txs
+
+  require Model
+
+  defstruct [:type, :tx, :block_index, :txi]
+
+  @opaque t() :: %__MODULE__{
+            type: Node.tx_type(),
+            tx: Model.tx(),
+            block_index: Blocks.block_index(),
+            txi: Txs.txi()
+          }
+
+  @spec new(Node.tx_type(), Model.tx(), Blocks.block_index(), Txs.txi()) :: t()
+  def new(type, tx, block_index, txi) do
+    %__MODULE__{
+      type: type,
+      tx: tx,
+      block_index: block_index,
+      txi: txi
+    }
+  end
+
+  @spec mutate(t()) :: :ok
+  def mutate(%__MODULE__{type: tx_type, tx: tx, block_index: block_index, txi: txi}) do
+    tx_type
+    |> Node.tx_ids()
+    |> Enum.each(fn {field, pos} ->
+      <<_::256>> = pk = resolve_pubkey(elem(tx, pos), tx_type, field, block_index)
+      write_field(tx_type, pos, pk, txi)
+    end)
+  end
+
+  defp write_field(tx_type, pos, pubkey, txi) do
+    m_field = Model.field(index: {tx_type, pos, pubkey, txi})
+    :mnesia.write(Model.Field, m_field, :write)
+    Model.incr_count({tx_type, pos, pubkey})
+  end
+
+  defp resolve_pubkey(id, :spend_tx, :recipient_id, block_index) do
+    case :aeser_id.specialize(id) do
+      {:name, name_hash} ->
+        AeMdw.Db.Name.ptr_resolve!(block_index, name_hash, "account_pubkey")
+
+      {_tag, pk} ->
+        pk
+    end
+  end
+
+  defp resolve_pubkey(id, _type, _field, _block_index) do
+    {_tag, pk} = :aeser_id.specialize(id)
+    pk
+  end
+end
+
+defimpl AeMdw.Db.Mutation, for: AeMdw.Db.WriteFieldsMutation do
+  def mutate(mutation) do
+    @for.mutate(mutation)
+  end
+end

--- a/lib/ae_mdw/db/mutations/write_links_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_links_mutation.ex
@@ -1,0 +1,143 @@
+defmodule AeMdw.Db.WriteLinksMutation do
+  @moduledoc """
+  Creates all the necessary indexes for both Oracles and Names depending on the
+  transaction type.
+  """
+
+  alias AeMdw.Blocks
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Sync
+  alias AeMdw.Node
+  alias AeMdw.Txs
+
+  require Model
+
+  defstruct [:type, :tx, :signed_tx, :txi, :tx_hash, :block_index]
+
+  @opaque t() :: %__MODULE__{
+            type: Node.tx_type(),
+            tx: Model.tx(),
+            signed_tx: Node.signed_tx(),
+            txi: Txs.txi(),
+            tx_hash: Txs.tx_hash(),
+            block_index: Blocks.block_index()
+          }
+
+  @spec new(
+          Node.tx_type(),
+          Model.tx(),
+          Node.signed_tx(),
+          Txs.txi(),
+          Txs.tx_hash(),
+          Blocks.block_index()
+        ) :: t()
+  def new(type, tx, signed_tx, txi, tx_hash, block_index) do
+    %__MODULE__{
+      type: type,
+      tx: tx,
+      signed_tx: signed_tx,
+      txi: txi,
+      tx_hash: tx_hash,
+      block_index: block_index
+    }
+  end
+
+  @spec mutate(t()) :: :ok
+  def mutate(%__MODULE__{
+        type: :contract_create_tx,
+        tx: tx,
+        txi: txi,
+        tx_hash: tx_hash,
+        block_index: block_index
+      }) do
+    pk = :aect_contracts.pubkey(:aect_contracts.new(tx))
+    owner_pk = :aect_create_tx.owner_pubkey(tx)
+    :ets.insert(:ct_create_sync_cache, {pk, txi})
+    write_origin(:contract_create_tx, pk, txi, tx_hash)
+    Sync.Contract.create(pk, owner_pk, txi, block_index)
+  end
+
+  def mutate(%__MODULE__{type: :contract_call_tx, tx: tx, txi: txi, block_index: block_index}) do
+    pk = :aect_call_tx.contract_pubkey(tx)
+    Sync.Contract.call(pk, tx, txi, block_index)
+  end
+
+  def mutate(%__MODULE__{
+        type: :channel_create_tx,
+        signed_tx: signed_tx,
+        txi: txi,
+        tx_hash: tx_hash
+      }) do
+    {:ok, pk} = :aesc_utils.channel_pubkey(signed_tx)
+    write_origin(:channel_create_tx, pk, txi, tx_hash)
+  end
+
+  def mutate(%__MODULE__{
+        type: :oracle_register_tx,
+        tx: tx,
+        txi: txi,
+        tx_hash: tx_hash,
+        block_index: block_index
+      }) do
+    pk = :aeo_register_tx.account_pubkey(tx)
+    write_origin(:oracle_register_tx, pk, txi, tx_hash)
+    Sync.Oracle.register(pk, tx, txi, block_index)
+  end
+
+  def mutate(%__MODULE__{type: :oracle_extend_tx, tx: tx, txi: txi, block_index: block_index}) do
+    Sync.Oracle.extend(:aeo_extend_tx.oracle_pubkey(tx), tx, txi, block_index)
+  end
+
+  def mutate(%__MODULE__{type: :oracle_response_tx, tx: tx, txi: txi, block_index: block_index}) do
+    Sync.Oracle.respond(:aeo_response_tx.oracle_pubkey(tx), tx, txi, block_index)
+  end
+
+  def mutate(%__MODULE__{
+        type: :name_claim_tx,
+        tx: tx,
+        txi: txi,
+        tx_hash: tx_hash,
+        block_index: block_index
+      }) do
+    plain_name = String.downcase(:aens_claim_tx.name(tx))
+    {:ok, name_hash} = :aens.get_name_hash(plain_name)
+    write_origin(:name_claim_tx, name_hash, txi, tx_hash)
+    Sync.Name.claim(plain_name, name_hash, tx, txi, block_index)
+  end
+
+  def mutate(%__MODULE__{type: :name_update_tx, tx: tx, txi: txi, block_index: block_index}) do
+    Sync.Name.update(:aens_update_tx.name_hash(tx), tx, txi, block_index)
+  end
+
+  def mutate(%__MODULE__{type: :name_transfer_tx, tx: tx, txi: txi, block_index: block_index}) do
+    Sync.Name.transfer(:aens_transfer_tx.name_hash(tx), tx, txi, block_index)
+  end
+
+  def mutate(%__MODULE__{type: :name_revoke_tx, tx: tx, txi: txi, block_index: block_index}) do
+    Sync.Name.revoke(:aens_revoke_tx.name_hash(tx), tx, txi, block_index)
+  end
+
+  def mutate(_write_links_mutation) do
+    :ok
+  end
+
+  defp write_origin(tx_type, pubkey, txi, tx_hash) do
+    m_origin = Model.origin(index: {tx_type, pubkey, txi}, tx_id: tx_hash)
+    m_rev_origin = Model.rev_origin(index: {txi, tx_type, pubkey})
+    :mnesia.write(Model.Origin, m_origin, :write)
+    :mnesia.write(Model.RevOrigin, m_rev_origin, :write)
+    write_field(tx_type, nil, pubkey, txi)
+  end
+
+  defp write_field(tx_type, pos, pubkey, txi) do
+    m_field = Model.field(index: {tx_type, pos, pubkey, txi})
+    :mnesia.write(Model.Field, m_field, :write)
+    Model.incr_count({tx_type, pos, pubkey})
+  end
+end
+
+defimpl AeMdw.Db.Mutation, for: AeMdw.Db.WriteLinksMutation do
+  def mutate(mutation) do
+    @for.mutate(mutation)
+  end
+end

--- a/lib/ae_mdw/db/mutations/write_tx_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_tx_mutation.ex
@@ -1,0 +1,49 @@
+defmodule AeMdw.Db.WriteTxMutation do
+  @moduledoc """
+  Indexes a transaction into the Tx, Type and Time tables.
+  """
+
+  alias AeMdw.Blocks
+  alias AeMdw.Db.Model
+  alias AeMdw.Node
+  alias AeMdw.Txs
+
+  require Model
+
+  defstruct [:tx, :type, :txi, :mb_time, :inner_tx?]
+
+  @opaque t() :: %__MODULE__{
+            tx: Model.tx(),
+            type: Node.tx_type(),
+            txi: Txs.txi(),
+            mb_time: Blocks.time(),
+            inner_tx?: boolean()
+          }
+
+  @spec new(Model.tx(), Node.tx_type(), Txs.txi(), Blocks.time(), boolean()) :: t()
+  def new(tx, type, txi, mb_time, inner_tx?) do
+    %__MODULE__{
+      tx: tx,
+      type: type,
+      txi: txi,
+      mb_time: mb_time,
+      inner_tx?: inner_tx?
+    }
+  end
+
+  @spec mutate(t()) :: :ok
+  def mutate(%__MODULE__{tx: tx, type: type, txi: txi, mb_time: mb_time, inner_tx?: inner_tx?}) do
+    if not inner_tx? do
+      :mnesia.write(Model.Tx, tx, :write)
+    end
+
+    :mnesia.write(Model.Type, Model.type(index: {type, txi}), :write)
+    :mnesia.write(Model.Time, Model.time(index: {mb_time, txi}), :write)
+  end
+end
+
+defimpl AeMdw.Db.Mutation, for: AeMdw.Db.WriteTxMutation do
+  def mutate(mutation) do
+    @for.mutate(mutation)
+  end
+end

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -7,7 +7,7 @@ defmodule AeMdw.Db.Sync.Contract do
 
   require Model
 
-  @typep pubkey() :: <<_::256>>
+  @typep pubkey() :: DBContract.pubkey()
 
   @spec create(pubkey(), pubkey(), integer(), {integer(), integer()}) ::
           term() | :invalid_contract
@@ -41,7 +41,7 @@ defmodule AeMdw.Db.Sync.Contract do
     :ok
   end
 
-  @spec aex9_derive_account_presence!(tuple()) :: true
+  @spec aex9_derive_account_presence!(tuple()) :: :ok
   def aex9_derive_account_presence!({kbi, mbi}) do
     next_hash =
       {kbi, mbi}
@@ -76,6 +76,8 @@ defmodule AeMdw.Db.Sync.Contract do
     end)
 
     :ets.delete_all_objects(:aex9_sync_cache)
+
+    :ok
   end
 
   @spec events([Contract.event()], integer(), integer()) :: :ok

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -3,10 +3,20 @@ defmodule AeMdw.Db.Sync.Transaction do
   Syncs whole history based on Node events (and assumes block index is in place.
   "
 
+  alias AeMdw.Blocks
   alias AeMdw.Node, as: AE
+  alias AeMdw.Contract
   alias AeMdw.Db.Model
   alias AeMdw.Db.Sync
-
+  alias AeMdw.Db.Aex9AccountPresenceMutation
+  alias AeMdw.Db.ContractEventsMutation
+  alias AeMdw.Db.MnesiaWriteMutation
+  alias AeMdw.Db.Mutation
+  alias AeMdw.Db.WriteFieldsMutation
+  alias AeMdw.Db.WriteLinksMutation
+  alias AeMdw.Db.WriteTxMutation
+  alias AeMdw.Node
+  alias AeMdw.Txs
   alias AeMdwWeb.Websocket.Broadcaster
 
   require Model
@@ -24,8 +34,8 @@ defmodule AeMdw.Db.Sync.Transaction do
     max_height = Sync.height((is_integer(max_height) && max_height + 1) || max_height)
     bi_max_kbi = Sync.BlockIndex.sync(max_height) - 1
 
-    case max_txi() do
-      nil ->
+    case last(Model.Tx) do
+      :"$end_of_table" ->
         sync(0, bi_max_kbi, 0)
 
       max_txi when is_integer(max_txi) ->
@@ -52,35 +62,83 @@ defmodule AeMdw.Db.Sync.Transaction do
   def sync(from_height, to_height, txi) when from_height > to_height,
     do: txi
 
+  @spec transaction_mutations(
+          {Node.signed_tx(), Txs.txi()},
+          {Blocks.block_index(), Blocks.time(), Contract.grouped_events()},
+          boolean()
+        ) :: [Mutation.t()]
+  def transaction_mutations(
+        {signed_tx, txi},
+        {block_index, mb_time, mb_events} = tx_ctx,
+        inner_tx? \\ false
+      ) do
+    {mod, tx} = :aetx.specialize_callback(:aetx_sign.tx(signed_tx))
+    tx_hash = :aetx_sign.hash(signed_tx)
+    type = mod.type()
+    model_tx = Model.tx(index: txi, id: tx_hash, block_index: block_index, time: mb_time)
+
+    contract_events_mutation =
+      if type == :contract_call_tx do
+        ct_pk = :aect_call_tx.contract_pubkey(tx)
+        events = Map.get(mb_events, tx_hash, [])
+
+        ContractEventsMutation.new(ct_pk, events, txi)
+      end
+
+    inner_tx_mutations =
+      if type == :ga_meta_tx or type == :paying_for_tx do
+        inner_signed_tx = Sync.InnerTx.signed_tx(type, tx)
+        # indexes the inner with the txi from the wrapper/outer
+        transaction_mutations({inner_signed_tx, txi}, tx_ctx, true)
+      end
+
+    :ets.insert(:tx_sync_cache, {txi, tx})
+
+    [
+      WriteTxMutation.new(model_tx, type, txi, mb_time, inner_tx?),
+      WriteLinksMutation.new(type, tx, signed_tx, txi, tx_hash, block_index),
+      contract_events_mutation,
+      WriteFieldsMutation.new(type, tx, block_index, txi),
+      inner_tx_mutations
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> List.flatten()
+  end
+
   ################################################################################
 
   defp sync_generation(height, txi) do
     {key_block, micro_blocks} = AE.Db.get_blocks(height)
+    kb_txi = (txi == 0 && -1) || txi
+    kb_header = :aec_blocks.to_key_header(key_block)
+    kb_hash = ok!(:aec_headers.hash_header(kb_header))
+    kb_model = Model.block(index: {height, -1}, tx_index: kb_txi, hash: kb_hash)
 
-    {:atomic, next_txi} =
+    :ets.delete_all_objects(:stat_sync_cache)
+    :ets.delete_all_objects(:ct_create_sync_cache)
+    :ets.delete_all_objects(:tx_sync_cache)
+
+    initial_mutations = [
+      MnesiaWriteMutation.new(Model.Block, kb_model)
+    ]
+
+    {next_txi, _mb_index, mutations} =
+      Enum.reduce(micro_blocks, {txi, 0, initial_mutations}, &micro_block_mutations/2)
+
+    {:atomic, :ok} =
       :mnesia.transaction(fn ->
-        :ets.delete_all_objects(:stat_sync_cache)
-        :ets.delete_all_objects(:ct_create_sync_cache)
-        :ets.delete_all_objects(:tx_sync_cache)
-
         Sync.Name.expire(height)
         Sync.Oracle.expire(height - 1)
-
-        kb_txi = (txi == 0 && -1) || txi
-        kb_header = :aec_blocks.to_key_header(key_block)
-        kb_hash = ok!(:aec_headers.hash_header(kb_header))
-        kb_model = Model.block(index: {height, -1}, tx_index: kb_txi, hash: kb_hash)
-        :mnesia.write(Model.Block, kb_model, :write)
 
         height >= AE.min_block_reward_height() &&
           Sync.IntTransfer.block_rewards(kb_header, kb_hash)
 
-        {next_txi, _mb_index} = Enum.reduce(micro_blocks, {txi, 0}, &sync_micro_block/2)
+        Enum.each(mutations, &Mutation.mutate/1)
 
         Sync.Stat.store(height)
         Sync.Stat.sum_store(height)
 
-        next_txi
+        :ok
       end)
 
     Broadcaster.broadcast_key_block(key_block, :mdw)
@@ -98,164 +156,31 @@ defmodule AeMdw.Db.Sync.Transaction do
     next_txi
   end
 
-  defp sync_micro_block(mblock, {txi, mbi}) do
+  defp micro_block_mutations(mblock, {txi, mbi, mutations}) do
     height = :aec_blocks.height(mblock)
     mb_time = :aec_blocks.time_in_msecs(mblock)
     mb_hash = ok!(:aec_headers.hash_header(:aec_blocks.to_micro_header(mblock)))
     mb_txi = (txi == 0 && -1) || txi
     mb_model = Model.block(index: {height, mbi}, tx_index: mb_txi, hash: mb_hash)
-    :mnesia.write(Model.Block, mb_model, :write)
     mb_txs = :aec_blocks.txs(mblock)
     events = AeMdw.Contract.get_grouped_events(mblock)
     tx_ctx = {{height, mbi}, mb_time, events}
-    next_txi = Enum.reduce(mb_txs, txi, &sync_transaction(&1, &2, tx_ctx))
-    Sync.Contract.aex9_derive_account_presence!({height, mbi})
 
-    {next_txi, mbi + 1}
+    txs_mutations =
+      mb_txs
+      |> Enum.with_index(txi)
+      |> Enum.flat_map(&transaction_mutations(&1, tx_ctx))
+
+    mutations =
+      List.flatten([
+        mutations,
+        MnesiaWriteMutation.new(Model.Block, mb_model),
+        txs_mutations,
+        Aex9AccountPresenceMutation.new(height, mbi)
+      ])
+
+    {txi + length(mb_txs), mbi + 1, mutations}
   end
-
-  @spec sync_transaction(tuple(), non_neg_integer(), tuple(), boolean()) :: pos_integer()
-  def sync_transaction(
-        signed_tx,
-        txi,
-        {block_index, mb_time, mb_events} = tx_ctx,
-        inner_tx? \\ false
-      ) do
-    {mod, tx} = :aetx.specialize_callback(:aetx_sign.tx(signed_tx))
-    hash = :aetx_sign.hash(signed_tx)
-    type = mod.type()
-
-    write_tx(type, txi, hash, block_index, mb_time, inner_tx?)
-    write_links(type, tx, signed_tx, txi, hash, block_index)
-
-    if type == :contract_call_tx do
-      ct_pk = :aect_call_tx.contract_pubkey(tx)
-      ct_txi = Sync.Contract.get_txi(ct_pk)
-      events = Map.get(mb_events, hash, [])
-      Sync.Contract.events(events, txi, ct_txi)
-    end
-
-    write_fields(type, tx, block_index, txi)
-
-    if type == :ga_meta_tx or type == :paying_for_tx do
-      inner_signed_tx = Sync.InnerTx.signed_tx(type, tx)
-      # indexes the inner with the txi from the wrapper/outer
-      sync_transaction(inner_signed_tx, txi, tx_ctx, true)
-    end
-
-    txi + 1
-  end
-
-  #
-  # Private functions
-  #
-  defp write_tx(type, txi, tx_hash, {_kbi, _mbi} = block_index, mb_time, inner_tx?) do
-    model_tx = Model.tx(index: txi, id: tx_hash, block_index: block_index, time: mb_time)
-    :ets.insert(:tx_sync_cache, {txi, model_tx})
-
-    if not inner_tx? do
-      :mnesia.write(Model.Tx, model_tx, :write)
-    end
-
-    :mnesia.write(Model.Type, Model.type(index: {type, txi}), :write)
-    :mnesia.write(Model.Time, Model.time(index: {mb_time, txi}), :write)
-  end
-
-  defp write_links(:contract_create_tx, tx, _signed_tx, txi, tx_hash, bi) do
-    pk = :aect_contracts.pubkey(:aect_contracts.new(tx))
-    owner_pk = :aect_create_tx.owner_pubkey(tx)
-    :ets.insert(:ct_create_sync_cache, {pk, txi})
-    write_origin(:contract_create_tx, pk, txi, tx_hash)
-    Sync.Contract.create(pk, owner_pk, txi, bi)
-  end
-
-  defp write_links(:contract_call_tx, tx, _signed_tx, txi, _tx_hash, bi) do
-    pk = :aect_call_tx.contract_pubkey(tx)
-    Sync.Contract.call(pk, tx, txi, bi)
-  end
-
-  defp write_links(:channel_create_tx, _tx, signed_tx, txi, tx_hash, _bi) do
-    {:ok, pk} = :aesc_utils.channel_pubkey(signed_tx)
-    write_origin(:channel_create_tx, pk, txi, tx_hash)
-  end
-
-  defp write_links(:oracle_register_tx, tx, _signed_tx, txi, tx_hash, bi) do
-    pk = :aeo_register_tx.account_pubkey(tx)
-    write_origin(:oracle_register_tx, pk, txi, tx_hash)
-    Sync.Oracle.register(pk, tx, txi, bi)
-  end
-
-  defp write_links(:oracle_extend_tx, tx, _signed_tx, txi, _tx_hash, bi),
-    do: Sync.Oracle.extend(:aeo_extend_tx.oracle_pubkey(tx), tx, txi, bi)
-
-  defp write_links(:oracle_response_tx, tx, _signed_tx, txi, _tx_hash, bi),
-    do: Sync.Oracle.respond(:aeo_response_tx.oracle_pubkey(tx), tx, txi, bi)
-
-  defp write_links(:name_claim_tx, tx, _signed_tx, txi, tx_hash, bi) do
-    plain_name = String.downcase(:aens_claim_tx.name(tx))
-    {:ok, name_hash} = :aens.get_name_hash(plain_name)
-    write_origin(:name_claim_tx, name_hash, txi, tx_hash)
-    Sync.Name.claim(plain_name, name_hash, tx, txi, bi)
-  end
-
-  defp write_links(:name_update_tx, tx, _signed_tx, txi, _tx_hash, bi),
-    do: Sync.Name.update(:aens_update_tx.name_hash(tx), tx, txi, bi)
-
-  defp write_links(:name_transfer_tx, tx, _signed_tx, txi, _tx_hash, bi),
-    do: Sync.Name.transfer(:aens_transfer_tx.name_hash(tx), tx, txi, bi)
-
-  defp write_links(:name_revoke_tx, tx, _signed_tx, txi, _tx_hash, bi),
-    do: Sync.Name.revoke(:aens_revoke_tx.name_hash(tx), tx, txi, bi)
-
-  defp write_links(_type, _tx, _signed_tx, _txi, _tx_hash, _bi),
-    do: :nop
-
-  defp write_origin(tx_type, pubkey, txi, tx_hash) do
-    m_origin = Model.origin(index: {tx_type, pubkey, txi}, tx_id: tx_hash)
-    m_rev_origin = Model.rev_origin(index: {txi, tx_type, pubkey})
-    :mnesia.write(Model.Origin, m_origin, :write)
-    :mnesia.write(Model.RevOrigin, m_rev_origin, :write)
-    write_field(tx_type, nil, pubkey, txi)
-  end
-
-  defp write_fields(tx_type, tx, block_index, txi) do
-    tx_type
-    |> AE.tx_ids()
-    |> Enum.each(fn {field, pos} ->
-      <<_::256>> = pk = resolve_pubkey(elem(tx, pos), tx_type, field, block_index)
-      write_field(tx_type, pos, pk, txi)
-    end)
-  end
-
-  defp write_field(tx_type, pos, pubkey, txi) do
-    m_field = Model.field(index: {tx_type, pos, pubkey, txi})
-    :mnesia.write(Model.Field, m_field, :write)
-    Model.incr_count({tx_type, pos, pubkey})
-  end
-
-  defp resolve_pubkey(id, :spend_tx, :recipient_id, block_index) do
-    case :aeser_id.specialize(id) do
-      {:name, name_hash} ->
-        AeMdw.Db.Name.ptr_resolve!(block_index, name_hash, "account_pubkey")
-
-      {_tag, pk} ->
-        pk
-    end
-  end
-
-  defp resolve_pubkey(id, _type, _field, _block_index) do
-    {_tag, pk} = :aeser_id.specialize(id)
-    pk
-  end
-
-  defp txi(f) do
-    case f.(Model.Tx) do
-      :"$end_of_table" -> nil
-      txi -> txi
-    end
-  end
-
-  defp max_txi(), do: txi(&last/1)
 
   defp log_msg(height, _ignore),
     do: "syncing transactions at generation #{height}"

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -92,7 +92,7 @@ defmodule AeMdw.Db.Sync.Transaction do
         transaction_mutations({inner_signed_tx, txi}, tx_ctx, true)
       end
 
-    :ets.insert(:tx_sync_cache, {txi, tx})
+    :ets.insert(:tx_sync_cache, {txi, model_tx})
 
     [
       WriteTxMutation.new(model_tx, type, txi, mb_time, inner_tx?),

--- a/lib/ae_mdw/mnesia.ex
+++ b/lib/ae_mdw/mnesia.ex
@@ -148,6 +148,11 @@ defmodule AeMdw.Mnesia do
     {keys, cursor}
   end
 
+  @spec write(table(), record()) :: :ok
+  def write(table, record) do
+    :mnesia.write(table, record, :write)
+  end
+
   defp fetch_forward_keys(tab, first_key, limit) do
     keys =
       Stream.unfold({limit, first_key}, fn

--- a/lib/ae_mdw/node.ex
+++ b/lib/ae_mdw/node.ex
@@ -8,7 +8,41 @@ defmodule AeMdw.Node do
   all of these functions more explicit.
   """
 
+  @type tx_type() ::
+          :spend_tx
+          | :oracle_register_tx
+          | :oracle_extend_tx
+          | :oracle_query_tx
+          | :oracle_response_tx
+          | :name_preclaim_tx
+          | :name_claim_tx
+          | :name_transfer_tx
+          | :name_update_tx
+          | :name_revoke_tx
+          | :contract_create_tx
+          | :contract_call_tx
+          | :ga_attach_tx
+          | :ga_meta_tx
+          | :channel_create_tx
+          | :channel_deposit_tx
+          | :channel_withdraw_tx
+          | :channel_force_progress_tx
+          | :channel_close_mutual_tx
+          | :channel_close_solo_tx
+          | :channel_slash_tx
+          | :channel_settle_tx
+          | :channel_snapshot_solo_tx
+          | :channel_set_delegates_tx
+          | :channel_offchain_tx
+          | :channel_client_reconnect_tx
+          | :paying_for_tx
+
+  @type signed_tx() :: term()
+
   defmodule Oracle do
+    @moduledoc false
+
+    @spec get!(term(), term()) :: non_neg_integer()
     def get!(_a, _b), do: 0
   end
 

--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -18,9 +18,9 @@ defmodule AeMdw.Txs do
 
   require Model
 
+  @type tx :: map()
   @type txi :: non_neg_integer()
-  # This needs to be an actual type like AeMdw.Db.Tx.t()
-  @type tx :: term()
+  @type tx_hash() :: binary()
   @type cursor :: binary()
   @type query :: %{
           types: term(),

--- a/test/ae_mdw/db/sync/transaction_test.exs
+++ b/test/ae_mdw/db/sync/transaction_test.exs
@@ -5,6 +5,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
 
   alias AeMdw.Db.Sync.Transaction
   alias AeMdw.Db.Model
+  alias AeMdw.Db.Mutation
   alias AeMdw.Validate
 
   import AeMdwWeb.BlockchainSim, only: [with_blockchain: 3, spend_tx: 3]
@@ -30,13 +31,15 @@ defmodule AeMdw.Db.Sync.TransactionTest do
         txi = @very_high_txi + 1
         block_index = {height, 0}
 
-        fn ->
-          Transaction.sync_transaction(
-            signed_tx,
-            txi,
+        mutations =
+          Transaction.transaction_mutations(
+            {signed_tx, txi},
             {block_index, mb_time, nil},
             false
           )
+
+        fn ->
+          Enum.each(mutations, &Mutation.mutate/1)
 
           {sender_pk, recipient_pk} = pubkeys_from_tx(signed_tx)
           assert sender_pk != recipient_pk
@@ -64,13 +67,15 @@ defmodule AeMdw.Db.Sync.TransactionTest do
         txi = @very_high_txi + 1
         block_index = {height, 0}
 
-        fn ->
-          Transaction.sync_transaction(
-            signed_tx,
-            txi,
+        mutations =
+          Transaction.transaction_mutations(
+            {signed_tx, txi},
             {block_index, mb_time, nil},
             false
           )
+
+        fn ->
+          Enum.each(mutations, &Mutation.mutate/1)
 
           {sender_pk, recipient_pk} = pubkeys_from_tx(signed_tx)
           assert sender_pk == recipient_pk


### PR DESCRIPTION
The goal of this change is to be able to isolate mnesia updates into
mutations which will all be ran in a single transaction and in the
least amount of time possible.

By making first-class mutations we can also debug easily what changes
any given block or transaction makes.

This also fixes random errors that come up inside mnesia transactions:
mnesia transactions do not work properly when exceptions are thrown
inside them, even if they are captured.

closes #331