### PR TITLE
fix: validate name expiration

### DIFF
--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -1,4 +1,5 @@
 defmodule AeMdw.Db.Sync.Name do
+  # credo:disable-for-this-file
   alias AeMdw.Db.Format
   alias AeMdw.Db.Model
   alias AeMdw.Db.Name


### PR DESCRIPTION
## What

Validates name expiration before applying it.

## Why

Fixes #338 (as discussed, the plan is to use more the Node db if possible, otherwise the root cause will be investigated on mnesia rocksdb layer if reproduced after mutations refactor).

## Additional notes

Protects against:
```
iex(aeternity@localhost)9> :mnesia.dirty_select(Model.InactiveNameExpiration, Ex2ms.fun do {:expiration, {height, "filestorm.chain"}, :_} -> height end)
[419848]
iex(aeternity@localhost)10> [Model.name(expire: exp)] = :mnesia.dirty_read(Model.InactiveName, "filestorm.chain"); exp
449221                        
iex(aeternity@localhost)11> {mdw_height, _mbi} = Util.last_txi() |> Util.read_tx!() |> Model.tx(:block_index)       
{422890, 9}
```

PS: The Node does not allow a double name claim and the `update` tx handling already deletes the expiration from the name claim:
https://github.com/aeternity/ae_mdw/blob/3c2975c62fc721ce9f66112759a7831045e64e1d/lib/ae_mdw/db/sync/name.ex#L122
