### PR TITLE
feat: async derive_aex9_presence

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -69,7 +69,7 @@ jobs:
         id: plt-cache
         with:
           path: priv/plts
-          key: plts-v3-${{ hashFiles('mix.lock') }}
+          key: plts-v4-${{ hashFiles('mix.lock') }}
 
       - name: Common tests setup
         uses: ./.github/actions/tests-common

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -109,8 +109,6 @@ defmodule AeMdw.Db.Contract do
   @spec logs_write(integer(), integer(), tuple()) :: :ok
   def logs_write(create_txi, txi, call_rec) do
     contract_pk = :aect_call.contract_pubkey(call_rec)
-    is_aex9_contract? = Contract.is_aex9?(contract_pk)
-    aex9_transfer_evt = AeMdw.Node.aex9_transfer_event_hash()
     raw_logs = :aect_call.log(call_rec)
 
     raw_logs
@@ -149,12 +147,29 @@ defmodule AeMdw.Db.Contract do
         :mnesia.write(Model.ContractLog, m_log_remote, :write)
       end
 
-      aex9_contract_pk = which_aex9_contract_pubkey(is_aex9_contract?, contract_pk, addr)
+      aex9_contract_pk = which_aex9_contract_pubkey(contract_pk, addr)
 
-      if evt_hash == aex9_transfer_evt and aex9_contract_pk != nil do
+      if is_aex9_transfer?(evt_hash, aex9_contract_pk) do
         write_aex9_records(aex9_contract_pk, txi, i, args)
       end
     end)
+  end
+
+  @spec is_aex9_transfer?(binary(), pubkey()) :: boolean()
+  def is_aex9_transfer?(evt_hash, aex9_contract_pk) do
+    aex9_transfer_evt = AeMdw.Node.aex9_transfer_event_hash()
+
+    evt_hash == aex9_transfer_evt and aex9_contract_pk != nil
+  end
+
+  @spec which_aex9_contract_pubkey(pubkey(), pubkey()) :: pubkey()
+  def which_aex9_contract_pubkey(contract_pk, addr) do
+    if Contract.is_aex9?(contract_pk) do
+      contract_pk
+    else
+      # remotely called contract is aex9?
+      if addr != contract_pk and Contract.is_aex9?(addr), do: addr
+    end
   end
 
   @spec call_fun_args_res(pubkey(), integer()) :: call_map()
@@ -320,15 +335,6 @@ defmodule AeMdw.Db.Contract do
   defp prefix_tester(prefix) do
     len = byte_size(prefix)
     &(byte_size(&1) >= len && :binary.part(&1, 0, len) == prefix)
-  end
-
-  defp which_aex9_contract_pubkey(true = _is_aex9, contract_pk, _addr), do: contract_pk
-
-  defp which_aex9_contract_pubkey(false, contract_pk, addr) do
-    # remotely called contract is aex9?
-    if addr != contract_pk and Contract.is_aex9?(addr) do
-      addr
-    end
   end
 
   defp write_aex9_records(contract_pk, txi, i, [from_pk, to_pk, <<amount::256>>]) do

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -19,7 +19,7 @@ defmodule AeMdw.Db.Contract do
   import AeMdw.Util, only: [compose: 2, max_256bit_int: 0]
   import AeMdw.Db.Util
 
-  @typep pubkey() :: <<_::256>>
+  @type pubkey() :: <<_::256>>
   @typep call_map() ::
            %{
              function: any(),

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -162,7 +162,7 @@ defmodule AeMdw.Db.Contract do
     evt_hash == aex9_transfer_evt and aex9_contract_pk != nil
   end
 
-  @spec which_aex9_contract_pubkey(pubkey(), pubkey()) :: pubkey()
+  @spec which_aex9_contract_pubkey(pubkey(), pubkey()) :: pubkey() | nil
   def which_aex9_contract_pubkey(contract_pk, addr) do
     if Contract.is_aex9?(contract_pk) do
       contract_pk

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -1,9 +1,13 @@
 defmodule AeMdw.Db.Sync.Contract do
+  @moduledoc """
+  Saves contract indexed state for creation, calls and events.
+  """
   alias AeMdw.Contract
   alias AeMdw.Db
   alias AeMdw.Db.Contract, as: DBContract
   alias AeMdw.Db.Model
   alias AeMdw.Db.Util, as: DBU
+  alias AeMdw.Sync.AsyncTasks
 
   require Model
 
@@ -43,12 +47,6 @@ defmodule AeMdw.Db.Sync.Contract do
 
   @spec aex9_derive_account_presence!(tuple()) :: true
   def aex9_derive_account_presence!({kbi, mbi}) do
-    next_hash =
-      {kbi, mbi}
-      |> DBU.next_bi!()
-      |> DBU.read_block!()
-      |> Model.block(:hash)
-
     ct_create? = fn
       {{_ct_pk, _txi, -1}, <<_::binary>>, -1} -> true
       {{_ct_pk, _txi, _}, {<<_::binary>>, <<_::binary>>}, _} -> false
@@ -59,20 +57,17 @@ defmodule AeMdw.Db.Sync.Contract do
     |> Enum.group_by(fn {{ct_pk, _, _}, _, _} -> ct_pk end)
     |> Enum.filter(fn {_ct_pk, [first_entry | _]} -> ct_create?.(first_entry) end)
     |> Enum.each(fn {ct_pk, [{{ct_pk, create_txi, -1}, <<_::binary>>, -1} | transfers]} ->
-      {balances, _} = AeMdw.Node.Db.aex9_balances!(ct_pk, {nil, kbi, next_hash})
+      recipients =
+        transfers
+        |> Enum.map(fn
+          {{_ct_pk, _txi, _i}, {_from, to_pk}, _amount} -> to_pk
+          _other -> nil
+        end)
+        |> Enum.reject(&(&1 == nil))
 
-      all_pks =
-        balances
-        |> Map.keys()
-        |> Enum.map(fn {:address, pk} -> pk end)
-        |> Enum.into(MapSet.new())
+      AsyncTasks.DeriveAex9Presence.cache_recipients(ct_pk, recipients)
 
-      pks =
-        for {_, {_, to_pk}, _} <- transfers,
-            reduce: all_pks,
-            do: (pks -> MapSet.delete(pks, to_pk))
-
-      Enum.each(pks, &DBContract.aex9_write_presence(ct_pk, create_txi, &1))
+      AsyncTasks.Producer.enqueue(:derive_aex9_presence, [ct_pk, kbi, mbi, create_txi])
     end)
 
     :ets.delete_all_objects(:aex9_sync_cache)

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -63,7 +63,7 @@ defmodule AeMdw.Db.Sync.Contract do
           {{_ct_pk, _txi, _i}, {_from, to_pk}, _amount} -> to_pk
           _other -> nil
         end)
-        |> Enum.reject(&(&1 == nil))
+        |> Enum.reject(&is_nil/1)
 
       AsyncTasks.DeriveAex9Presence.cache_recipients(ct_pk, recipients)
 

--- a/lib/ae_mdw/sync/async_tasks/consumer.ex
+++ b/lib/ae_mdw/sync/async_tasks/consumer.ex
@@ -9,6 +9,7 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
 
   alias AeMdw.Sync.AsyncTasks.Producer
   alias AeMdw.Sync.AsyncTasks.TaskSupervisor
+  alias AeMdw.Sync.AsyncTasks.DeriveAex9Presence
   alias AeMdw.Sync.AsyncTasks.UpdateAex9Presence
 
   require Model
@@ -21,6 +22,7 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
   @task_timeout_msecs 40_000
 
   @type_mod %{
+    derive_aex9_presence: DeriveAex9Presence,
     update_aex9_presence: UpdateAex9Presence
   }
 

--- a/lib/ae_mdw/sync/async_tasks/derive_aex9_presence.ex
+++ b/lib/ae_mdw/sync/async_tasks/derive_aex9_presence.ex
@@ -1,0 +1,118 @@
+defmodule AeMdw.Sync.AsyncTasks.DeriveAex9Presence do
+  @moduledoc """
+  Async work to derive AEX9 presence from balance dry-running
+  from a create contract.
+  """
+  @behaviour AeMdw.Sync.AsyncTasks.Work
+
+  alias AeMdw.Node.Db, as: DBN
+
+  alias AeMdw.Contract
+  alias AeMdw.Db.Contract, as: DBContract
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Util, as: DBU
+  alias AeMdw.Log
+
+  require Model
+  require Logger
+
+  @microsecs 1_000_000
+
+  @spec process(args :: list()) :: :ok
+  def process([contract_pk, kbi, mbi, create_txi]) do
+    next_hash =
+      {kbi, mbi}
+      |> DBU.next_bi!()
+      |> DBU.read_block!()
+      |> Model.block(:hash)
+
+    Log.info("[:derive_aex9_presence] #{inspect(contract_pk)} ...")
+
+    {time_delta, {balances, _last_block_tuple}} =
+      :timer.tc(fn -> DBN.aex9_balances!(contract_pk, {nil, kbi, next_hash}) end)
+
+    Log.info("[:derive_aex9_presence] #{inspect(contract_pk)} after #{time_delta / @microsecs}s")
+
+    all_pks =
+      balances
+      |> Map.keys()
+      |> Enum.map(fn {:address, pk} -> pk end)
+      |> Enum.into(MapSet.new())
+
+    recipients = get_aex9_recipients(contract_pk, kbi, mbi)
+
+    pks =
+      Enum.reduce(recipients, all_pks, fn to_pk, pks ->
+        MapSet.delete(pks, to_pk)
+      end)
+
+    :mnesia.sync_transaction(fn ->
+      Enum.each(pks, &DBContract.aex9_write_presence(contract_pk, create_txi, &1))
+    end)
+
+    :ets.delete(:derive_aex9_presence_cache, contract_pk)
+
+    :ok
+  end
+
+  def cache_recipients(_contract_pk, []), do: :ok
+
+  def cache_recipients(contract_pk, recipients) do
+    Enum.each(recipients, fn <<to_pk::binary>> ->
+      :ets.insert(:derive_aex9_presence_cache, {contract_pk, to_pk})
+    end)
+  end
+
+  defp get_aex9_recipients(contract_pk, kbi, mbi) do
+    case :ets.lookup(:derive_aex9_presence_cache, contract_pk) do
+      [] ->
+        contract_pk
+        |> read_aex9_transfers_from_mb(kbi, mbi)
+        |> Enum.map(fn [_from_pk, to_pk, <<_amount::256>>] -> to_pk end)
+
+      recipients ->
+        recipients
+    end
+  end
+
+  defp read_aex9_transfers_from_mb(contract_pk, kbi, mbi) do
+    mblock =
+      kbi
+      |> DBN.get_micro_blocks()
+      |> Enum.with_index()
+      |> Enum.find_value(fn {mblock, index} -> if index == mbi, do: mblock end)
+
+    if mblock do
+      mblock
+      |> :aec_blocks.txs()
+      |> Enum.filter(fn signed_tx ->
+        {mod, _tx} = :aetx.specialize_callback(:aetx_sign.tx(signed_tx))
+        mod.type() == :contract_call_tx
+      end)
+      |> Enum.map(fn signed_tx ->
+        {_mod, tx} = :aetx.specialize_callback(:aetx_sign.tx(signed_tx))
+        block_hash = Model.block(DBU.read_block!({kbi, mbi}), :hash)
+
+        {_fun_arg_res, call_rec} =
+          Contract.call_tx_info(tx, contract_pk, block_hash, &Contract.to_map/1)
+
+        get_aex9_transfers_from_call(call_rec)
+      end)
+    end
+  end
+
+  defp get_aex9_transfers_from_call(call_rec) do
+    contract_pk = :aect_call.contract_pubkey(call_rec)
+
+    call_rec
+    |> :aect_call.log()
+    |> Enum.map(fn {addr, [evt_hash | args], _data} ->
+      aex9_contract_pk = DBContract.which_aex9_contract_pubkey(contract_pk, addr)
+
+      if DBContract.is_aex9_transfer?(evt_hash, aex9_contract_pk) do
+        [_from_pk, _to_pk, <<_amount::256>>] = args
+      end
+    end)
+    |> Enum.reject(&(&1 == nil))
+  end
+end

--- a/lib/ae_mdw/sync/async_tasks/derive_aex9_presence.ex
+++ b/lib/ae_mdw/sync/async_tasks/derive_aex9_presence.ex
@@ -18,6 +18,8 @@ defmodule AeMdw.Sync.AsyncTasks.DeriveAex9Presence do
 
   @microsecs 1_000_000
 
+  @typep pubkey() :: DBContract.pubkey()
+
   @spec process(args :: list()) :: :ok
   def process([contract_pk, kbi, mbi, create_txi]) do
     next_hash =
@@ -55,6 +57,7 @@ defmodule AeMdw.Sync.AsyncTasks.DeriveAex9Presence do
     :ok
   end
 
+  @spec cache_recipients(pubkey(), list()) :: :ok
   def cache_recipients(_contract_pk, []), do: :ok
 
   def cache_recipients(contract_pk, recipients) do
@@ -63,6 +66,9 @@ defmodule AeMdw.Sync.AsyncTasks.DeriveAex9Presence do
     end)
   end
 
+  #
+  # Private functions
+  #
   defp get_aex9_recipients(contract_pk, kbi, mbi) do
     case :ets.lookup(:derive_aex9_presence_cache, contract_pk) do
       [] ->

--- a/lib/ae_mdw/sync/async_tasks/store.ex
+++ b/lib/ae_mdw/sync/async_tasks/store.ex
@@ -85,7 +85,7 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
   defp dedup_records(tasks) do
     tasks
     |> Enum.group_by(fn Model.async_tasks(args: args) -> args end)
-    |> Enum.map(fn {[_contract_pk], [first | to_delete]} ->
+    |> Enum.map(fn {_args, [first | to_delete]} ->
       Enum.each(to_delete, fn Model.async_tasks(index: index) ->
         :mnesia.dirty_delete(Model.AsyncTasks, index)
       end)

--- a/lib/ae_mdw/sync/supervisor.ex
+++ b/lib/ae_mdw/sync/supervisor.ex
@@ -19,6 +19,7 @@ defmodule AeMdw.Sync.Supervisor do
     :ets.new(:name_sync_cache, [:named_table, :ordered_set, :public])
     :ets.new(:oracle_sync_cache, [:named_table, :ordered_set, :public])
     :ets.new(:aex9_sync_cache, [:named_table, :ordered_set, :public])
+    :ets.new(:derive_aex9_presence_cache, [:named_table, :duplicate_bag, :public])
     :ets.new(:ct_create_sync_cache, [:named_table, :ordered_set, :public])
     :ets.new(:stat_sync_cache, [:named_table, :ordered_set, :public])
     :ok


### PR DESCRIPTION
## What

Async processing for the `Sync.Contract.aex9_derive_account_presence!/1`.

## Why

Synchronous aex9 balances makes mdw database sync slower. 
It helps with #346 