### PR TITLE
fix: contract might not be present

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -69,7 +69,7 @@ jobs:
         id: plt-cache
         with:
           path: priv/plts
-          key: plts-v3-${{ hashFiles('mix.lock') }}
+          key: plts-v4-${{ hashFiles('mix.lock') }}
 
       - name: Common tests setup
         uses: ./.github/actions/tests-common

--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -352,15 +352,12 @@ defmodule AeMdw.Contract do
   end
 
   defp contract_init_args(contract_pk, tx_rec) do
-    {:ok, ct_info} = get_info(contract_pk)
-    call_data = :aect_create_tx.call_data(tx_rec)
-
-    case decode_call_data(ct_info, call_data) do
-      {"init", args} ->
-        args_type_value(args)
-
-      {:error, _reason} ->
-        nil
+    with {:ok, ct_info} <- get_info(contract_pk),
+         call_data <- :aect_create_tx.call_data(tx_rec),
+         {"init", args} <- decode_call_data(ct_info, call_data) do
+      args_type_value(args)
+    else
+      {:error, _reason} -> nil
     end
   end
 

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -1,4 +1,7 @@
 defmodule AeMdw.Db.Sync.Contract do
+  @moduledoc """
+  Saves contract indexed state for creation, calls and events.
+  """
   alias AeMdw.Contract
   alias AeMdw.Db
   alias AeMdw.Db.Contract, as: DBContract


### PR DESCRIPTION
## What

Handles error for contract init info when `contract_create_tx` is on chain but the contract is not in chain db because its `init` has failed.

## Why

Fix for http://localhost:4000/txs/backward?limit=100&type=contract_create

## Error screenshot

![Screenshot from 2021-11-22 17-59-25](https://user-images.githubusercontent.com/44991200/142913900-1c77062f-7c68-43a7-93d2-61e677b6a17b.png)


