### PR TITLE
fix: inactive names auction rendering

### DIFF
--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -176,8 +176,8 @@ defmodule AeMdw.Names do
         {:ok, auction_bid} ->
           {_version, auction_bid} =
             auction_bid
-            |> update_in([:info, :last_bid, :tx, "ttl"], fn val -> val || 0 end)
-            |> pop_in([:info, :last_bid, :tx, "version"])
+            |> update_in([:info, :last_bid, :tx], fn val -> val || 0 end)
+            |> pop_in([:info, :last_bid, :tx])
 
           {:auction, auction_bid}
 


### PR DESCRIPTION
## What

Removes unexisting auction fields to render inactive names.

## Why

Fixes http://localhost:4000/names/inactive

## Error screenshot

![Screenshot from 2021-11-22 18-33-17](https://user-images.githubusercontent.com/44991200/142917524-f0d0bec2-2ed7-481a-b572-de80f3535af3.png)
