### PR TITLE
fix: remove old oracle expiration

### DIFF
--- a/lib/ae_mdw/db/sync/oracle.ex
+++ b/lib/ae_mdw/db/sync/oracle.ex
@@ -143,6 +143,8 @@ defmodule AeMdw.Db.Sync.Oracle do
   end
 
   defp expire_oracle(height, pubkey) do
+    cache_through_delete(Model.ActiveOracleExpiration, {height, pubkey})
+
     oracle_id = Enc.encode(:oracle_pubkey, pubkey)
 
     case cache_through_read(Model.ActiveOracle, pubkey) do
@@ -153,7 +155,6 @@ defmodule AeMdw.Db.Sync.Oracle do
           cache_through_write(Model.InactiveOracleExpiration, m_exp)
 
           cache_through_delete(Model.ActiveOracle, pubkey)
-          cache_through_delete(Model.ActiveOracleExpiration, {height, pubkey})
           AeMdw.Ets.inc(:stat_sync_cache, :inactive_oracles)
           AeMdw.Ets.dec(:stat_sync_cache, :active_oracles)
 


### PR DESCRIPTION
## What

Removes oracle expiration also when it's not the current one.

## Why

Fixes #351 and #352

## Error screenshots

![image](https://user-images.githubusercontent.com/44991200/143236712-485d6cf6-c5b7-4964-9175-7e241d458c03.png)

After removing with:
```
iex(aeternity@localhost)1> oracles_exp = :mnesia.dirty_select(Model.ActiveOracle, Ex2ms.fun do record -> record end) |> Enum.map(fn Model.oracle(index: pubkey, expire: expire) -> {expire, pubkey} end)
iex(aeternity@localhost)2> Enum.all?(oracles_exp, fn m_exp -> :mnesia.dirty_read(Model.ActiveOracleExpiration, m_exp) != [] end)
true
iex(aeternity@localhost)5> old_exps = Enum.flat_map(oracles_exp, fn {expire, pubkey} -> :mnesia.dirty_select(Model.ActiveOracleExpiration, Ex2ms.fun do {:expiration, {height, ^pubkey}, :_} when height != ^expire -> {height, ^expire, ^pubkey} end) end)
[
  {465432, 520448,
   <<7, 114, 231, 19, 221, 34, 106, 119, 80, 6, 115, 204, 54, 130, 94, 0, 63,
     242, 128, 14, 41, 51, 135, 172, 134, 125, 42, 151, 221, 129, 137, 51>>},
  {455229, 521729,
   <<21, 1, 193, 110, 60, 81, 26, 18, 40, 199, 113, 37, 148, 204, 254, 174, 72,
     82, 64, 205, 42, 181, 108, 10, 199, 204, 49, 93, 143, 58, 87, 187>>},
  {455229, 521729,
   <<49, 22, 99, 56, 223, 252, 119, 83, 60, 248, 63, 39, 157, 240, 154, 21, 138,
     20, 12, 97, 109, 152, 198, 11, 2, 116, 34, 94, 234, 228, 178, 114>>},
  {481791, 528291,
   <<180, 83, 108, 58, 50, 103, 70, 201, 130, 125, 14, 10, 30, 248, 105, 104,
     72, 188, 253, 65, 55, 82, 224, 67, 181, 41, 235, 87, 165, 63, 204, 247>>}
]
iex(aeternity@localhost)6> Enum.each(old_exps, fn exp -> :mnesia.dirty_delete(Model.ActiveOracleExpiration, exp) end)
:ok
```
Result:
![image](https://user-images.githubusercontent.com/44991200/143237051-e32c4c67-83ed-4913-8cd9-08395d9cdc29.png)

## Additional notes

The `extend` already deletes old expirations so consistency is related to transaction/persistence layer.