### PR TITLE
fix: add name ttl to last_bid tx

### DIFF
--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -1,5 +1,6 @@
 defmodule AeMdw.Db.Name do
   # credo:disable-for-this-file
+  alias AeMdw.Blocks
   alias AeMdw.Node, as: AE
   alias AeMdw.Db.Model
   alias AeMdw.Db.Format
@@ -31,7 +32,7 @@ defmodule AeMdw.Db.Name do
     }
   end
 
-  @spec expire_after(pos_integer()) :: pos_integer()
+  @spec expire_after(Blocks.height()) :: Blocks.height()
   def expire_after(auction_end) do
     auction_end + :aec_governance.name_claim_max_expiration(proto_vsn(auction_end))
   end

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -30,6 +30,10 @@ defmodule AeMdw.Db.Name do
     }
   end
 
+  def expire_after(auction_end) do
+    auction_end + :aec_governance.name_claim_max_expiration(proto_vsn(auction_end))
+  end
+
   ##########
 
   def pointer_kv_raw(ptr),

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -1,4 +1,5 @@
 defmodule AeMdw.Db.Name do
+  # credo:disable-for-this-file
   alias AeMdw.Node, as: AE
   alias AeMdw.Db.Model
   alias AeMdw.Db.Format
@@ -30,6 +31,7 @@ defmodule AeMdw.Db.Name do
     }
   end
 
+  @spec expire_after(pos_integer()) :: pos_integer()
   def expire_after(auction_end) do
     auction_end + :aec_governance.name_claim_max_expiration(proto_vsn(auction_end))
   end

--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -44,7 +44,7 @@ defmodule AeMdw.Db.Sync.Name do
     case :aec_governance.name_claim_bid_timeout(plain_name, proto_vsn) do
       0 ->
         previous = ok_nil(cache_through_read(Model.InactiveName, plain_name))
-        expire = height + :aec_governance.name_claim_max_expiration(proto_vsn)
+        expire = Name.expire_after(height)
 
         m_name =
           Model.name(
@@ -221,7 +221,7 @@ defmodule AeMdw.Db.Sync.Name do
       bid_key = ok!(cache_through_prev(Model.AuctionBid, Name.bid_top_key(plain_name)))
 
     previous = ok_nil(cache_through_read(Model.InactiveName, plain_name))
-    expire = height + :aec_governance.name_claim_max_expiration(proto_vsn(height))
+    expire = Name.expire_after(height)
 
     m_name =
       Model.name(

--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -174,11 +174,7 @@ defmodule AeMdw.Names do
     {status, auction_bid} =
       case AuctionBids.top_auction_bid(plain_name, expand?) do
         {:ok, auction_bid} ->
-          {_version, auction_bid} =
-            auction_bid
-            |> update_in([:info, :last_bid, :tx], fn val -> val || 0 end)
-            |> pop_in([:info, :last_bid, :tx])
-
+          {_version, auction_bid} = pop_in(auction_bid, [:info, :last_bid, "tx", "version"])
           {:auction, auction_bid}
 
         :not_found ->

--- a/lib/ae_mdw_web/controllers/transfer_controller.ex
+++ b/lib/ae_mdw_web/controllers/transfer_controller.ex
@@ -1,5 +1,4 @@
 defmodule AeMdwWeb.TransferController do
-  # credo:disable-for-this-file
   use AeMdwWeb, :controller
   use PhoenixSwagger
 

--- a/lib/ae_mdw_web/controllers/transfer_controller.ex
+++ b/lib/ae_mdw_web/controllers/transfer_controller.ex
@@ -1,4 +1,5 @@
 defmodule AeMdwWeb.TransferController do
+  # credo:disable-for-this-file
   use AeMdwWeb, :controller
   use PhoenixSwagger
 

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -385,7 +385,8 @@ defmodule AeMdwWeb.NameControllerTest do
         {DbUtil, [],
          [
            last_gen!: fn -> 0 end,
-           first_gen!: fn -> 0 end
+           first_gen!: fn -> 0 end,
+           proto_vsn: fn _height -> 1 end,
          ]}
       ] do
         assert %{"data" => auction_bids, "next" => next} =
@@ -425,7 +426,8 @@ defmodule AeMdwWeb.NameControllerTest do
         {DbUtil, [],
          [
            last_gen!: fn -> 0 end,
-           first_gen!: fn -> 0 end
+           first_gen!: fn -> 0 end,
+           proto_vsn: fn _height -> 1 end,
          ]}
       ] do
         assert %{"data" => auctions} =
@@ -462,7 +464,8 @@ defmodule AeMdwWeb.NameControllerTest do
         {DbUtil, [],
          [
            last_gen!: fn -> 0 end,
-           first_gen!: fn -> 0 end
+           first_gen!: fn -> 0 end,
+           proto_vsn: fn _height -> 1 end,
          ]}
       ] do
         assert %{"data" => auctions} =

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -386,7 +386,7 @@ defmodule AeMdwWeb.NameControllerTest do
          [
            last_gen!: fn -> 0 end,
            first_gen!: fn -> 0 end,
-           proto_vsn: fn _height -> 1 end,
+           proto_vsn: fn _height -> 1 end
          ]}
       ] do
         assert %{"data" => auction_bids, "next" => next} =
@@ -427,7 +427,7 @@ defmodule AeMdwWeb.NameControllerTest do
          [
            last_gen!: fn -> 0 end,
            first_gen!: fn -> 0 end,
-           proto_vsn: fn _height -> 1 end,
+           proto_vsn: fn _height -> 1 end
          ]}
       ] do
         assert %{"data" => auctions} =
@@ -465,7 +465,7 @@ defmodule AeMdwWeb.NameControllerTest do
          [
            last_gen!: fn -> 0 end,
            first_gen!: fn -> 0 end,
-           proto_vsn: fn _height -> 1 end,
+           proto_vsn: fn _height -> 1 end
          ]}
       ] do
         assert %{"data" => auctions} =

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -144,9 +144,8 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
           @default_limit
         )
 
-      data = add_name_ttl(data, "auction")
       assert Enum.count(response["data"]) <= @default_limit
-      assert Jason.encode!(response["data"]) == Jason.encode!(data)
+      assert Jason.encode!(response["data"]) == Jason.encode!(add_name_ttl(data, "auction"))
 
       conn_next = get(conn, response["next"])
       response_next = json_response(conn_next, 200)
@@ -157,9 +156,10 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
           @default_limit
         )
 
-      next_data = add_name_ttl(next_data, "auction")
       assert Enum.count(response_next["data"]) == @default_limit
-      assert Jason.encode!(response_next["data"]) == Jason.encode!(next_data)
+
+      assert Jason.encode!(response_next["data"]) ==
+               Jason.encode!(add_name_ttl(next_data, "auction"))
     end
 
     test "get inactive names with limit=6", %{conn: conn} do
@@ -173,9 +173,8 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
           limit
         )
 
-      data = add_name_ttl(data, "auction")
       assert Enum.count(response["data"]) <= limit
-      assert Jason.encode!(response["data"]) == Jason.encode!(data)
+      assert Jason.encode!(response["data"]) == Jason.encode!(add_name_ttl(data, "auction"))
     end
 
     test "get inactive names with parameters by=name, direction=forward and limit=4", %{
@@ -273,9 +272,8 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
           @default_limit
         )
 
-      data = add_name_ttl(data, "info")
       assert Enum.count(response["data"]) <= @default_limit
-      assert Jason.encode!(response["data"]) == Jason.encode!(data)
+      assert Jason.encode!(response["data"]) == Jason.encode!(add_name_ttl(data, "info"))
     end
 
     test "get auctions with limit=2", %{conn: conn} do
@@ -289,9 +287,8 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
           limit
         )
 
-      data = add_name_ttl(data, "info")
       assert Enum.count(response["data"]) <= limit
-      assert Jason.encode!(response["data"]) == Jason.encode!(data)
+      assert Jason.encode!(response["data"]) == Jason.encode!(add_name_ttl(data, "info"))
     end
 
     test "get auctions with parameters by=expiration, direction=forward and limit=3", %{
@@ -310,9 +307,8 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
           limit
         )
 
-      data = add_name_ttl(data, "info")
       assert Enum.count(response["data"]) <= limit
-      assert Jason.encode!(response["data"]) == Jason.encode!(data)
+      assert Jason.encode!(response["data"]) == Jason.encode!(add_name_ttl(data, "info"))
     end
 
     test "renders error when parameter by is invalid", %{conn: conn} do


### PR DESCRIPTION
## What

Adds to auction `last_bid` object the expiration height of a name that is set after its auction (future expiration when the name becomes active).

## Why

Fixes #354   

## Validation steps

`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/name_controller_test.exs`