### PR TITLE
fix: binary encoding for websocket broadcasting

### DIFF
--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -165,7 +165,6 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
     do: Poison.encode!(%{"payload" => payload, "subscription" => sub, "source" => source})
 
   defp encode_payload(%{"tx" => %{"type" => "NameUpdateTx"}} = block_tx) do
-    # update_in(block_tx, ["tx", "pointers"] -> &(Enum.map(&1, &update_pointer/1)))
     encode_name_pointers(block_tx)
   end
 

--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -153,8 +153,74 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
     )
   end
 
+  defp encode_message(payload, "Transactions", source),
+    do:
+      Poison.encode!(%{
+        "payload" => encode_payload(payload),
+        "subscription" => "Transactions",
+        "source" => source
+      })
+
   defp encode_message(payload, sub, source),
     do: Poison.encode!(%{"payload" => payload, "subscription" => sub, "source" => source})
+
+  defp encode_payload(%{"tx" => %{"type" => "NameUpdateTx"}} = block_tx) do
+    # update_in(block_tx, ["tx", "pointers"] -> &(Enum.map(&1, &update_pointer/1)))
+    encode_name_pointers(block_tx)
+  end
+
+  defp encode_payload(
+         %{"tx" => %{"type" => "GAMetaTx", "tx" => %{"tx" => %{"type" => "NameUpdateTx"}}}} =
+           block_tx
+       ) do
+    encode_gameta_inner(block_tx, &encode_name_pointers/2)
+  end
+
+  defp encode_payload(%{"tx" => %{"type" => "OracleRegisterTx"}} = block_tx) do
+    encode_oracle_register(block_tx)
+  end
+
+  defp encode_payload(
+         %{"tx" => %{"type" => "GAMetaTx", "tx" => %{"tx" => %{"type" => "OracleRegisterTx"}}}} =
+           block_tx
+       ) do
+    encode_gameta_inner(block_tx, &encode_oracle_register/2)
+  end
+
+  defp encode_payload(%{"tx" => %{"type" => "OracleQueryTx"}} = block_tx) do
+    encode_oracle_query(block_tx)
+  end
+
+  defp encode_payload(
+         %{"tx" => %{"type" => "GAMetaTx", "tx" => %{"tx" => %{"type" => "OracleQueryTx"}}}} =
+           block_tx
+       ) do
+    encode_gameta_inner(block_tx, &encode_oracle_query/2)
+  end
+
+  defp encode_payload(block_tx), do: block_tx
+
+  defp encode_name_pointers(block_tx, gameta_keys \\ []) do
+    update_in(block_tx, gameta_keys ++ ["tx", "pointers"], fn pointers ->
+      Enum.map(pointers, &encode_pointer/1)
+    end)
+  end
+
+  defp encode_pointer(ptr), do: Map.update(ptr, "key", "", &Base.encode64/1)
+
+  defp encode_oracle_register(block_tx, gameta_keys \\ []) do
+    block_tx
+    |> update_in(gameta_keys ++ ["tx", "query_format"], &Base.encode64/1)
+    |> update_in(gameta_keys ++ ["tx", "response_format"], &Base.encode64/1)
+  end
+
+  defp encode_oracle_query(block_tx, gameta_keys \\ []) do
+    update_in(block_tx, gameta_keys ++ ["tx", "query"], &Base.encode64/1)
+  end
+
+  defp encode_gameta_inner(block_tx, encode_fn) do
+    encode_fn.(block_tx, ["tx", "tx"])
+  end
 
   defp get_ids_from_tx(signed_tx) do
     wrapped_tx = :aetx_sign.tx(signed_tx)


### PR DESCRIPTION
## What

Fixes encoding of binary tx fields for new and old websocket broadcasting (source = mdw or node).

## Why

Fixes #330

## Validation steps

```
defmodule EncodeTx do
  alias AeMdw.Db.Model
  # import AeMdw.Db.Util, only: [read_block!: 1]
  require Model

  def exec(height) do
    {_key_block, micro_blocks} = AeMdw.Node.Db.get_blocks(height)

    micro_blocks
    |> Enum.with_index()
    |> Enum.map(fn {mblock, mbi} ->
      header = :aec_blocks.to_header(mblock)

      :aec_blocks.txs(mblock)
      |> Enum.each(fn signed_tx ->
        serialized = header |> :aetx_sign.serialize_for_client(signed_tx)
        
        serialized
        |> encode_message("Transactions", "mdw") 
        |> case do 
          {:ok, _} -> :noop
          {:error, error} ->
            IO.inspect serialized 
            IO.inspect error
        end
      end)
    end)
  end

  defp encode_message(payload, "Transactions", source),
    do: Poison.encode(%{"payload" => encode_payload(payload), "subscription" => "Transactions", "source" => source})
    
  defp encode_payload(%{"tx" => %{"type" => "NameUpdateTx"}} = block_tx) do
    encode_name_pointers(block_tx)
  end

  defp encode_payload(%{"tx" => %{"type" => "GAMetaTx", "tx" => %{"tx" => %{"type" => "NameUpdateTx"}}}} = block_tx) do
    encode_gameta_inner(block_tx, &encode_name_pointers/2)
  end

  defp encode_payload(%{"tx" => %{"type" => "OracleRegisterTx"}} = block_tx) do
    encode_oracle_register(block_tx)
  end

  defp encode_payload(%{"tx" => %{"type" => "GAMetaTx", "tx" => %{"tx" => %{"type" => "OracleRegisterTx"}}}} = block_tx) do
    encode_gameta_inner(block_tx, &encode_oracle_register/2)
  end

  defp encode_payload(%{"tx" => %{"type" => "OracleQueryTx"}} = block_tx) do
    encode_oracle_query(block_tx)
  end

  defp encode_payload(%{"tx" => %{"type" => "GAMetaTx", "tx" => %{"tx" => %{"type" => "OracleQueryTx"}}}} = block_tx) do
    encode_gameta_inner(block_tx, &encode_oracle_query/2)
  end

  defp encode_payload(block_tx), do: block_tx

  defp encode_name_pointers(block_tx, gameta_keys \\ []) do
    update_in(block_tx, gameta_keys ++ ["tx", "pointers"], fn pointers -> Enum.map(pointers, &encode_name_pointer/1) end)
  end

  defp encode_name_pointer(ptr), do: Map.update(ptr, "key", "", &Base.encode64/1)

  defp encode_oracle_register(block_tx, gameta_keys \\ []) do
    block_tx
    |> update_in(gameta_keys ++ ["tx", "query_format"], &Base.encode64/1)
    |> update_in(gameta_keys ++ ["tx", "response_format"], &Base.encode64/1)
  end

  defp encode_oracle_query(block_tx, gameta_keys \\ []) do
    update_in(block_tx, gameta_keys ++ ["tx", "query"], &Base.encode64/1)
  end

  defp encode_gameta_inner(block_tx, encode_fn) do
    encode_fn.(block_tx, ["tx", "tx"])
  end
end
```

Run `EncodeTx.exec/1` for:
```
heights = [
173521,
194523,
194730,
195080,
195451,
196901,
196936,
197840,
205180,
70162,
70163,
71122,
73412,
73418,
74885,
74951,
76774,
76865,
77349,
77361,
77768,
77793,
80706,
83557,
83951,
84462,
86297,
86312,
88231,
88232,
]
```
