### PR TITLE
feat: preload blocks when syncing

### DIFF
--- a/lib/ae_mdw/db/sync/sync.ex
+++ b/lib/ae_mdw/db/sync/sync.ex
@@ -74,9 +74,9 @@ defmodule AeMdw.Db.Sync do
   end
 
   def progress_logger(work_fn, freq, msg_fn) do
-    fn x, acc ->
+    fn {x, _key_block, _micro_blocks} = element, acc ->
       rem(x, freq) == 0 && Log.info(msg_fn.(x, acc))
-      work_fn.(x, acc)
+      work_fn.(element, acc)
     end
   end
 

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -32,7 +32,7 @@ defmodule AeMdw.Db.Sync.Transaction do
 
   @log_freq 1000
   @sync_cache_cleanup_freq 150_000
-  @preload_blocks_buffer_size 300
+  @preload_blocks_buffer_size 100
 
   ################################################################################
 

--- a/lib/ae_mdw/util/buffered_stream.ex
+++ b/lib/ae_mdw/util/buffered_stream.ex
@@ -6,8 +6,11 @@ defmodule AeMdw.Util.BufferedStream do
 
   alias AeMdw.Util.Semaphore
 
-  @spec map(Enumerable.t(), (Enum.element() -> any()), pos_integer()) :: Enumerable.t()
-  def map(enumerable, fun, buffer_size) do
+  @type opt() :: {:buffer_size, pos_integer()}
+
+  @spec map(Enumerable.t(), (Enum.element() -> any()), [opt()]) :: Enumerable.t()
+  def map(enumerable, fun, opts) do
+    buffer_size = Keyword.fetch!(opts, :buffer_size)
     empty_count = Semaphore.new(0)
     full_count = Semaphore.new(buffer_size)
     processing = Semaphore.new(1)
@@ -26,6 +29,7 @@ defmodule AeMdw.Util.BufferedStream do
 
         result
       end,
+      max_concurrency: buffer_size,
       timeout: :infinity
     )
     |> Stream.map(fn {:ok, result} ->

--- a/lib/ae_mdw/util/buffered_stream.ex
+++ b/lib/ae_mdw/util/buffered_stream.ex
@@ -1,0 +1,39 @@
+defmodule AeMdw.Util.BufferedStream do
+  @moduledoc """
+  Producer/consumer implementation of a preloading stream, with a limited buffer
+  size.
+  """
+
+  alias AeMdw.Util.Semaphore
+
+  @spec map(Enumerable.t(), (Enum.element() -> any()), pos_integer()) :: Enumerable.t()
+  def map(enumerable, fun, buffer_size) do
+    empty_count = Semaphore.new(0)
+    full_count = Semaphore.new(buffer_size)
+    processing = Semaphore.new(1)
+
+    enumerable
+    |> Task.async_stream(
+      fn entry ->
+        # PRODUCER
+        Semaphore.wait(full_count)
+        Semaphore.wait(processing)
+
+        result = fun.(entry)
+
+        Semaphore.signal(processing)
+        Semaphore.signal(empty_count)
+
+        result
+      end,
+      timeout: :infinity
+    )
+    |> Stream.map(fn {:ok, result} ->
+      # CONSUMER
+      Semaphore.wait(empty_count)
+      Semaphore.signal(full_count)
+
+      result
+    end)
+  end
+end

--- a/lib/ae_mdw/util/semaphore.ex
+++ b/lib/ae_mdw/util/semaphore.ex
@@ -1,0 +1,51 @@
+defmodule AeMdw.Util.Semaphore do
+  @moduledoc """
+  Simple BEAM processes semaphores implementation.
+  """
+
+  @type limit() :: non_neg_integer()
+
+  @opaque t() :: pid()
+
+  @spec new(limit()) :: t()
+  def new(i), do: spawn_link(fn -> semaphore(i) end)
+
+  @spec signal(t()) :: :ok
+  def signal(sem), do: Process.send(sem, :signal, [])
+
+  @spec wait(t()) :: :ok
+  def wait(sem) do
+    Process.send(sem, {:wait, self()}, [])
+
+    receive do
+      :ok -> :ok
+    end
+  end
+
+  @spec stop(t()) :: :ok
+  def stop(sem) do
+    Process.send(sem, :stop, [])
+  end
+
+  defp semaphore(0) do
+    receive do
+      :signal -> semaphore(1)
+      :stop -> :ok
+    end
+  end
+
+  defp semaphore(n) do
+    receive do
+      :signal ->
+        semaphore(n + 1)
+
+      {:wait, pid} ->
+        Process.send(pid, :ok, [])
+
+        semaphore(n - 1)
+
+      :stop ->
+        :ok
+    end
+  end
+end


### PR DESCRIPTION
Not sure if this is a good alternative to pre-loading chain blocks by using a buffered stream, but we could also use this stream for many other preloading opportunities throughout the code

Thoughts?