### PR TITLE
fix: add missing aliases on the Db.Oracle module

### DIFF
--- a/lib/ae_mdw/db/oracle.ex
+++ b/lib/ae_mdw/db/oracle.ex
@@ -2,12 +2,15 @@ defmodule AeMdw.Db.Oracle do
   @moduledoc """
   Cache through operations for active and inactive oracles.
   """
+  alias :aeser_api_encoder, as: Enc
   alias AeMdw.Blocks
   alias AeMdw.Db.Model
   alias AeMdw.Db.OraclesExpirationMutation
+  alias AeMdw.Log
 
   require Ex2ms
   require Model
+  require Logger
 
   import AeMdw.Db.Util
   import AeMdw.Util


### PR DESCRIPTION
Fixing an error due to a rebase with master