### PR TITLE
chore: remove name expiration cleanup

### DIFF
--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -104,7 +104,6 @@ defmodule AeMdw.Db.Name do
     m_name_exp = Model.expiration(index: {expire, plain_name})
     m_owner = Model.owner(index: {owner, plain_name})
 
-    ensure_no_exsiting_active_name_expiration(plain_name)
     cache_through_write(Model.ActiveName, m_name)
     cache_through_write(Model.ActiveNameOwner, m_owner)
     cache_through_write(Model.ActiveNameExpiration, m_name_exp)
@@ -341,22 +340,6 @@ defmodule AeMdw.Db.Name do
     Enum.find_value(updates, fn {_block_height, update_txi} ->
       if update_txi <= ref_txi, do: update_txi
     end)
-  end
-
-  defp ensure_no_exsiting_active_name_expiration(plain_name) do
-    name_mspec =
-      Ex2ms.fun do
-        {:expiration, {height, ^plain_name}, :_} -> {height, ^plain_name}
-      end
-
-    expirations = :mnesia.select(Model.ActiveNameExpiration, name_mspec)
-
-    if Enum.count(expirations) > 0 do
-      Log.info("Removing exsiting active name expirations #{inspect(expirations)}")
-
-      expirations
-      |> Enum.map(fn key -> cache_through_delete(Model.ActiveNameExpiration, key) end)
-    end
   end
 
   def read_raw_tx!(txi),


### PR DESCRIPTION
## What

Removes cleanup name expiration code that slows down the sync with a full search. 

## Why

This recent validation already protects from old expirations:
https://github.com/aeternity/ae_mdw/blob/72c500109cfb15afb11a17fdaafe7ef920d5a5a5/lib/ae_mdw/db/name.ex#L68

