### PR TITLE
feat: db transactions per microblock

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -69,7 +69,7 @@ jobs:
         id: plt-cache
         with:
           path: priv/plts
-          key: plts-v4-${{ hashFiles('mix.lock') }}
+          key: plts-v5-${{ hashFiles('mix.lock') }}
 
       - name: Common tests setup
         uses: ./.github/actions/tests-common

--- a/lib/ae_mdw/db/mutations/stats_mutation.ex
+++ b/lib/ae_mdw/db/mutations/stats_mutation.ex
@@ -3,28 +3,20 @@ defmodule AeMdw.Db.StatsMutation do
   Inserts statistics about this generation into Model.Stat table.
   """
 
-  alias AeMdw.Blocks
-  alias AeMdw.Db.IntTransfer
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Util
-  alias AeMdw.Ets
   alias AeMdw.Mnesia
 
   require Model
 
   defstruct [:stat, :sum_stat]
 
-  @opaque t() :: %__MODULE__{
-            stat: Model.stat(),
-            sum_stat: Model.sum_stat()
-          }
+  @type t() :: %__MODULE__{
+          stat: Model.stat(),
+          sum_stat: Model.sum_stat()
+        }
 
-  @spec new(Blocks.height(), boolean()) :: t()
-  def new(height, all_cached?) do
-    m_stat = make_stat(height + 1, all_cached?)
-    Model.stat(block_reward: inc_block_reward, dev_reward: inc_dev_reward) = m_stat
-    m_sum_stat = make_sum_stat(height + 1, inc_block_reward, inc_dev_reward)
-
+  @spec new(Model.stat(), Model.sum_stat()) :: t()
+  def new(m_stat, m_sum_stat) do
     %__MODULE__{
       stat: m_stat,
       sum_stat: m_sum_stat
@@ -39,80 +31,6 @@ defmodule AeMdw.Db.StatsMutation do
     Mnesia.write(Model.Stat, stat)
     Mnesia.write(Model.SumStat, sum_stat)
   end
-
-  defp make_stat(height, true = _all_cached?) do
-    Model.stat(
-      index: height,
-      inactive_names: get(:inactive_names, 0),
-      active_names: get(:active_names, 0),
-      active_auctions: get(:active_auctions, 0),
-      inactive_oracles: get(:inactive_oracles, 0),
-      active_oracles: get(:active_oracles, 0),
-      contracts: get(:contracts, 0),
-      block_reward: get(:block_reward, 0),
-      dev_reward: get(:dev_reward, 0)
-    )
-  end
-
-  defp make_stat(height, false = _all_cached?) do
-    Model.stat(
-      inactive_names: prev_inactive_names,
-      active_names: prev_active_names,
-      active_auctions: prev_active_auctions,
-      inactive_oracles: prev_inactive_oracles,
-      active_oracles: prev_active_oracles,
-      contracts: prev_contracts,
-      block_reward: prev_block_reward,
-      dev_reward: prev_dev_reward
-    ) = Util.read!(Model.Stat, height - 1)
-
-    current_active_names = :mnesia.info(Model.ActiveName, :size)
-    current_active_auctions = :mnesia.info(Model.ActiveAuction, :size)
-    current_active_oracles = :mnesia.info(Model.ActiveOracle, :size)
-    current_inactive_names = :mnesia.info(Model.InactiveName, :size)
-    current_inactive_oracles = :mnesia.info(Model.InactiveOracle, :size)
-
-    current_contracts =
-      Model.ContractCall
-      |> :mnesia.dirty_all_keys()
-      |> Enum.map(fn {create_txi, _call_txi} -> create_txi end)
-      |> Enum.uniq()
-      |> length()
-
-    current_block_reward = IntTransfer.count_block_reward(height)
-    current_dev_reward = IntTransfer.count_dev_reward(height)
-
-    Model.stat(
-      index: height,
-      inactive_names: Enum.max([0, current_inactive_names - prev_inactive_names]),
-      active_names: Enum.max([0, current_active_names - prev_active_names]),
-      active_auctions: Enum.max([0, current_active_auctions - prev_active_auctions]),
-      inactive_oracles: Enum.max([0, current_inactive_oracles - prev_inactive_oracles]),
-      active_oracles: Enum.max([0, current_active_oracles - prev_active_oracles]),
-      contracts: Enum.max([0, current_contracts - prev_contracts]),
-      block_reward: Enum.max([0, current_block_reward - prev_block_reward]),
-      dev_reward: Enum.max([0, current_dev_reward - prev_dev_reward])
-    )
-  end
-
-  defp make_sum_stat(height, inc_block_reward, inc_dev_reward) do
-    token_supply_delta = AeMdw.Node.token_supply_delta(height)
-
-    Model.sum_stat(
-      block_reward: prev_block_reward,
-      dev_reward: prev_dev_reward,
-      total_supply: prev_total_supply
-    ) = Util.read!(Model.SumStat, height - 1)
-
-    Model.sum_stat(
-      index: height,
-      block_reward: prev_block_reward + inc_block_reward,
-      dev_reward: prev_dev_reward + inc_dev_reward,
-      total_supply: prev_total_supply + token_supply_delta + inc_block_reward + inc_dev_reward
-    )
-  end
-
-  defp get(stat_sync_key, default), do: Ets.get(:stat_sync_cache, stat_sync_key, default)
 end
 
 defimpl AeMdw.Db.Mutation, for: AeMdw.Db.StatsMutation do

--- a/lib/ae_mdw/db/sync/stats.ex
+++ b/lib/ae_mdw/db/sync/stats.ex
@@ -50,11 +50,11 @@ defmodule AeMdw.Db.Sync.Stats do
       dev_reward: prev_dev_reward
     ) = Util.read!(Model.Stat, height - 1)
 
-    current_active_names = :mnesia.info(Model.ActiveName, :size)
-    current_active_auctions = :mnesia.info(Model.ActiveAuction, :size)
-    current_active_oracles = :mnesia.info(Model.ActiveOracle, :size)
-    current_inactive_names = :mnesia.info(Model.InactiveName, :size)
-    current_inactive_oracles = :mnesia.info(Model.InactiveOracle, :size)
+    current_active_names = :mnesia.table_info(Model.ActiveName, :size)
+    current_active_auctions = :mnesia.table_info(Model.ActiveAuction, :size)
+    current_active_oracles = :mnesia.table_info(Model.ActiveOracle, :size)
+    current_inactive_names = :mnesia.table_info(Model.InactiveName, :size)
+    current_inactive_oracles = :mnesia.table_info(Model.InactiveOracle, :size)
 
     current_contracts =
       Model.ContractCall

--- a/lib/ae_mdw/db/sync/stats.ex
+++ b/lib/ae_mdw/db/sync/stats.ex
@@ -1,0 +1,100 @@
+defmodule AeMdw.Db.Sync.Stats do
+  @moduledoc """
+  Creates stats and sum stats records based on previous height.
+  """
+
+  alias AeMdw.Blocks
+  alias AeMdw.Db.IntTransfer
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.StatsMutation
+  alias AeMdw.Db.Util
+  alias AeMdw.Ets
+
+  require Model
+
+  @spec new_mutation(Blocks.height(), boolean()) :: StatsMutation.t()
+  def new_mutation(height, all_cached?) do
+    m_stat = make_stat(height + 1, all_cached?)
+    Model.stat(block_reward: inc_block_reward, dev_reward: inc_dev_reward) = m_stat
+    m_sum_stat = make_sum_stat(height + 1, inc_block_reward, inc_dev_reward)
+
+    StatsMutation.new(m_stat, m_sum_stat)
+  end
+
+  #
+  # Private functions
+  #
+  defp make_stat(height, true = _all_cached?) do
+    Model.stat(
+      index: height,
+      inactive_names: get(:inactive_names, 0),
+      active_names: get(:active_names, 0),
+      active_auctions: get(:active_auctions, 0),
+      inactive_oracles: get(:inactive_oracles, 0),
+      active_oracles: get(:active_oracles, 0),
+      contracts: get(:contracts, 0),
+      block_reward: get(:block_reward, 0),
+      dev_reward: get(:dev_reward, 0)
+    )
+  end
+
+  defp make_stat(height, false = _all_cached?) do
+    Model.stat(
+      inactive_names: prev_inactive_names,
+      active_names: prev_active_names,
+      active_auctions: prev_active_auctions,
+      inactive_oracles: prev_inactive_oracles,
+      active_oracles: prev_active_oracles,
+      contracts: prev_contracts,
+      block_reward: prev_block_reward,
+      dev_reward: prev_dev_reward
+    ) = Util.read!(Model.Stat, height - 1)
+
+    current_active_names = :mnesia.info(Model.ActiveName, :size)
+    current_active_auctions = :mnesia.info(Model.ActiveAuction, :size)
+    current_active_oracles = :mnesia.info(Model.ActiveOracle, :size)
+    current_inactive_names = :mnesia.info(Model.InactiveName, :size)
+    current_inactive_oracles = :mnesia.info(Model.InactiveOracle, :size)
+
+    current_contracts =
+      Model.ContractCall
+      |> :mnesia.dirty_all_keys()
+      |> Enum.map(fn {create_txi, _call_txi} -> create_txi end)
+      |> Enum.uniq()
+      |> length()
+
+    current_block_reward = IntTransfer.count_block_reward(height)
+    current_dev_reward = IntTransfer.count_dev_reward(height)
+
+    Model.stat(
+      index: height,
+      inactive_names: Enum.max([0, current_inactive_names - prev_inactive_names]),
+      active_names: Enum.max([0, current_active_names - prev_active_names]),
+      active_auctions: Enum.max([0, current_active_auctions - prev_active_auctions]),
+      inactive_oracles: Enum.max([0, current_inactive_oracles - prev_inactive_oracles]),
+      active_oracles: Enum.max([0, current_active_oracles - prev_active_oracles]),
+      contracts: Enum.max([0, current_contracts - prev_contracts]),
+      block_reward: Enum.max([0, current_block_reward - prev_block_reward]),
+      dev_reward: Enum.max([0, current_dev_reward - prev_dev_reward])
+    )
+  end
+
+  defp make_sum_stat(height, inc_block_reward, inc_dev_reward) do
+    token_supply_delta = AeMdw.Node.token_supply_delta(height)
+
+    Model.sum_stat(
+      block_reward: prev_block_reward,
+      dev_reward: prev_dev_reward,
+      total_supply: prev_total_supply
+    ) = Util.read!(Model.SumStat, height - 1)
+
+    Model.sum_stat(
+      index: height,
+      block_reward: prev_block_reward + inc_block_reward,
+      dev_reward: prev_dev_reward + inc_dev_reward,
+      total_supply: prev_total_supply + token_supply_delta + inc_block_reward + inc_dev_reward
+    )
+  end
+
+  defp get(stat_sync_key, default), do: Ets.get(:stat_sync_cache, stat_sync_key, default)
+end

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -162,9 +162,9 @@ defmodule AeMdw.Db.Sync.Transaction do
       end)
 
     [
-      StatsMutation.new(height),
       MnesiaWriteMutation.new(Model.Block, kb_model),
-      block_rewards_mutation
+      block_rewards_mutation,
+      StatsMutation.new(height, last_mbi == -1)
     ]
     |> Enum.reject(&is_nil/1)
     |> Mnesia.transaction()

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -169,8 +169,6 @@ defmodule AeMdw.Db.Sync.Transaction do
     |> Enum.reject(&is_nil/1)
     |> Mnesia.transaction()
 
-    Broadcaster.broadcast_key_block(key_block, :mdw)
-
     if rem(height, @sync_cache_cleanup_freq) == 0 do
       :ets.delete_all_objects(:name_sync_cache)
       :ets.delete_all_objects(:oracle_sync_cache)

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -127,10 +127,13 @@ defmodule AeMdw.Db.Sync.Transaction do
     else
       next_txi = do_sync_generation(height, txi)
 
-      :mnesia.transaction(fn ->
-        [succ_kb] = :mnesia.read(Model.Block, {height + 1, -1})
-        :mnesia.write(Model.Block, Model.block(succ_kb, tx_index: next_txi), :write)
-      end)
+      {:atomic, :ok} =
+        :mnesia.transaction(fn ->
+          [next_kb] = :mnesia.read(Model.Block, {height + 1, -1})
+          :mnesia.write(Model.Block, Model.block(next_kb, tx_index: next_txi), :write)
+        end)
+
+      next_txi
     end
   end
 

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -135,7 +135,32 @@ defmodule AeMdw.Db.Sync.Transaction do
 
     [
       Name.expirations_mutation(height),
-      Oracle.expirations_mutation(height - 1),
+      Oracle.expirations_mutation(height - 1)
+    ]
+    |> Mnesia.transaction()
+
+    last_mbi =
+      case Mnesia.prev_key(Model.Block, {height+1, -1}) do
+        {:ok, {^height, last_mbi}} -> last_mbi
+        {:ok, _other_height} -> -1
+        :none -> -1
+      end
+
+    {next_txi, _mb_index} =
+      Enum.reduce(micro_blocks, {txi, 0}, fn mblock, {txi, mbi} = txi_acc ->
+        if mbi > last_mbi do
+          {mutations, acc} = micro_block_mutations(mblock, txi_acc)
+          Mnesia.transaction(mutations)
+          Broadcaster.broadcast_micro_block(mblock, :mdw)
+          Broadcaster.broadcast_txs(mblock, :mdw)
+          acc
+        else
+          {txi, mbi + 1}
+        end
+      end)
+
+    [
+      StatsMutation.new(height),
       MnesiaWriteMutation.new(Model.Block, kb_model),
       block_rewards_mutation
     ]
@@ -143,20 +168,6 @@ defmodule AeMdw.Db.Sync.Transaction do
     |> Mnesia.transaction()
 
     Broadcaster.broadcast_key_block(key_block, :mdw)
-
-    {next_txi, _mb_index} =
-      Enum.reduce(micro_blocks, {txi, 0}, fn mblock, txi_acc ->
-        {mutations, acc} = micro_block_mutations(mblock, txi_acc)
-        Mnesia.transaction(mutations)
-        Broadcaster.broadcast_micro_block(mblock, :mdw)
-        Broadcaster.broadcast_txs(mblock, :mdw)
-
-        acc
-      end)
-
-    Mnesia.transaction([
-      StatsMutation.new(height)
-    ])
 
     if rem(height, @sync_cache_cleanup_freq) == 0 do
       :ets.delete_all_objects(:name_sync_cache)

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -15,7 +15,7 @@ defmodule AeMdw.Db.Sync.Transaction do
   alias AeMdw.Db.Mutation
   alias AeMdw.Db.Name
   alias AeMdw.Db.Oracle
-  alias AeMdw.Db.StatsMutation
+  alias AeMdw.Db.Sync.Stats
   alias AeMdw.Db.WriteFieldsMutation
   alias AeMdw.Db.WriteLinksMutation
   alias AeMdw.Db.WriteTxMutation
@@ -162,12 +162,14 @@ defmodule AeMdw.Db.Sync.Transaction do
       end)
 
     [
+      Stats.new_mutation(height, last_mbi == -1),
       MnesiaWriteMutation.new(Model.Block, kb_model),
-      block_rewards_mutation,
-      StatsMutation.new(height, last_mbi == -1)
+      block_rewards_mutation
     ]
     |> Enum.reject(&is_nil/1)
     |> Mnesia.transaction()
+
+    Broadcaster.broadcast_key_block(key_block, :mdw)
 
     if rem(height, @sync_cache_cleanup_freq) == 0 do
       :ets.delete_all_objects(:name_sync_cache)


### PR DESCRIPTION
## What

Commits sync changes per micro block.

## Why

Mnesia transaction log is not being fully committed.
Contribute to #387
Contribute to #396 

## Additional notes

This paves the way to make instant syncs of AEX9 txs #211. Not sufficient but one step forward to the next step of having syncs per transaction.