### PR TITLE
perf: avoid loading mbs when processing contract call txs

### DIFF
--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -21,6 +21,7 @@ defmodule AeMdw.Blocks do
   @type block_index_txi_pos() :: {height(), txi_pos()}
   @type key_header() :: term()
   @type key_hash() :: <<_::32>>
+  @type block_hash() :: <<_::256>>
 
   @type block :: map()
   @type cursor :: binary()

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -29,6 +29,13 @@ defmodule AeMdw.Db.Model do
   @block_defaults [index: {-1, -1}, tx_index: nil, hash: <<>>]
   defrecord :block, @block_defaults
 
+  @type block ::
+          record(:block,
+            index: Blocks.block_index(),
+            tx_index: Txs.txi() | nil | -1,
+            hash: Blocks.key_hash()
+          )
+
   # txs table :
   #     index = tx_index (0..), id = tx_id
   @tx_defaults [index: -1, id: <<>>, block_index: {-1, -1}, time: -1]

--- a/lib/ae_mdw/db/mutations/write_links_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_links_mutation.ex
@@ -12,7 +12,7 @@ defmodule AeMdw.Db.WriteLinksMutation do
 
   require Model
 
-  defstruct [:type, :tx, :signed_tx, :txi, :tx_hash, :block_index, :block]
+  defstruct [:type, :tx, :signed_tx, :txi, :tx_hash, :block_index, :block_hash]
 
   @opaque t() :: %__MODULE__{
             type: Node.tx_type(),
@@ -21,7 +21,7 @@ defmodule AeMdw.Db.WriteLinksMutation do
             txi: Txs.txi(),
             tx_hash: Txs.tx_hash(),
             block_index: Blocks.block_index(),
-            block: Model.block()
+            block_hash: Blocks.block_hash()
           }
 
   @spec new(
@@ -31,9 +31,9 @@ defmodule AeMdw.Db.WriteLinksMutation do
           Txs.txi(),
           Txs.tx_hash(),
           Blocks.block_index(),
-          Model.block()
+          Blocks.block_hash()
         ) :: t()
-  def new(type, tx, signed_tx, txi, tx_hash, block_index, block) do
+  def new(type, tx, signed_tx, txi, tx_hash, block_index, block_hash) do
     %__MODULE__{
       type: type,
       tx: tx,
@@ -41,7 +41,7 @@ defmodule AeMdw.Db.WriteLinksMutation do
       txi: txi,
       tx_hash: tx_hash,
       block_index: block_index,
-      block: block
+      block_hash: block_hash
     }
   end
 
@@ -51,18 +51,18 @@ defmodule AeMdw.Db.WriteLinksMutation do
         tx: tx,
         txi: txi,
         tx_hash: tx_hash,
-        block: block
+        block_hash: block_hash
       }) do
     pk = :aect_contracts.pubkey(:aect_contracts.new(tx))
     owner_pk = :aect_create_tx.owner_pubkey(tx)
     :ets.insert(:ct_create_sync_cache, {pk, txi})
     write_origin(:contract_create_tx, pk, txi, tx_hash)
-    Sync.Contract.create(pk, owner_pk, tx, txi, block)
+    Sync.Contract.create(pk, owner_pk, tx, txi, block_hash)
   end
 
-  def mutate(%__MODULE__{type: :contract_call_tx, tx: tx, txi: txi, block: block}) do
+  def mutate(%__MODULE__{type: :contract_call_tx, tx: tx, txi: txi, block_hash: block_hash}) do
     pk = :aect_call_tx.contract_pubkey(tx)
-    Sync.Contract.call(pk, tx, txi, block)
+    Sync.Contract.call(pk, tx, txi, block_hash)
   end
 
   def mutate(%__MODULE__{

--- a/lib/ae_mdw/db/mutations/write_links_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_links_mutation.ex
@@ -12,7 +12,7 @@ defmodule AeMdw.Db.WriteLinksMutation do
 
   require Model
 
-  defstruct [:type, :tx, :signed_tx, :txi, :tx_hash, :block_index]
+  defstruct [:type, :tx, :signed_tx, :txi, :tx_hash, :block_index, :block]
 
   @opaque t() :: %__MODULE__{
             type: Node.tx_type(),
@@ -20,7 +20,8 @@ defmodule AeMdw.Db.WriteLinksMutation do
             signed_tx: Node.signed_tx(),
             txi: Txs.txi(),
             tx_hash: Txs.tx_hash(),
-            block_index: Blocks.block_index()
+            block_index: Blocks.block_index(),
+            block: Model.block()
           }
 
   @spec new(
@@ -29,16 +30,18 @@ defmodule AeMdw.Db.WriteLinksMutation do
           Node.signed_tx(),
           Txs.txi(),
           Txs.tx_hash(),
-          Blocks.block_index()
+          Blocks.block_index(),
+          Model.block()
         ) :: t()
-  def new(type, tx, signed_tx, txi, tx_hash, block_index) do
+  def new(type, tx, signed_tx, txi, tx_hash, block_index, block) do
     %__MODULE__{
       type: type,
       tx: tx,
       signed_tx: signed_tx,
       txi: txi,
       tx_hash: tx_hash,
-      block_index: block_index
+      block_index: block_index,
+      block: block
     }
   end
 
@@ -57,9 +60,9 @@ defmodule AeMdw.Db.WriteLinksMutation do
     Sync.Contract.create(pk, owner_pk, tx, txi, block_index)
   end
 
-  def mutate(%__MODULE__{type: :contract_call_tx, tx: tx, txi: txi, block_index: block_index}) do
+  def mutate(%__MODULE__{type: :contract_call_tx, tx: tx, txi: txi, block: block}) do
     pk = :aect_call_tx.contract_pubkey(tx)
-    Sync.Contract.call(pk, tx, txi, block_index)
+    Sync.Contract.call(pk, tx, txi, block)
   end
 
   def mutate(%__MODULE__{

--- a/lib/ae_mdw/db/mutations/write_links_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_links_mutation.ex
@@ -51,13 +51,13 @@ defmodule AeMdw.Db.WriteLinksMutation do
         tx: tx,
         txi: txi,
         tx_hash: tx_hash,
-        block_index: block_index
+        block: block
       }) do
     pk = :aect_contracts.pubkey(:aect_contracts.new(tx))
     owner_pk = :aect_create_tx.owner_pubkey(tx)
     :ets.insert(:ct_create_sync_cache, {pk, txi})
     write_origin(:contract_create_tx, pk, txi, tx_hash)
-    Sync.Contract.create(pk, owner_pk, tx, txi, block_index)
+    Sync.Contract.create(pk, owner_pk, tx, txi, block)
   end
 
   def mutate(%__MODULE__{type: :contract_call_tx, tx: tx, txi: txi, block: block}) do

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -6,7 +6,6 @@ defmodule AeMdw.Db.Sync.Contract do
   alias AeMdw.Db
   alias AeMdw.Db.Contract, as: DBContract
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Util, as: DBU
   alias AeMdw.Sync.AsyncTasks
 
   require Model
@@ -36,10 +35,9 @@ defmodule AeMdw.Db.Sync.Contract do
     end
   end
 
-  @spec call(pubkey(), tuple(), integer(), {integer(), integer()}) :: :ok
-  def call(contract_pk, tx, txi, bi) do
-    block_hash = Model.block(DBU.read_block!(bi), :hash)
-
+  @spec call(pubkey(), tuple(), integer(), Model.block()) :: :ok
+  def call(contract_pk, tx, txi, block) do
+    block_hash = Model.block(block, :hash)
     create_txi = get_txi(contract_pk)
 
     {fun_arg_res, call_rec} =
@@ -47,6 +45,7 @@ defmodule AeMdw.Db.Sync.Contract do
 
     DBContract.call_write(create_txi, txi, fun_arg_res)
     DBContract.logs_write(create_txi, txi, call_rec)
+
     :ok
   end
 

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -14,7 +14,7 @@ defmodule AeMdw.Db.Sync.Contract do
 
   @spec create(pubkey(), pubkey(), tuple(), integer(), {integer(), integer()}) ::
           term() | :invalid_contract
-  def create(contract_pk, owner_pk, tx, txi, bi) do
+  def create(contract_pk, owner_pk, tx, txi, block) do
     case Contract.get_info(contract_pk) do
       {:ok, contract_info} ->
         with true <- Contract.is_aex9?(contract_info) do
@@ -24,7 +24,7 @@ defmodule AeMdw.Db.Sync.Contract do
         end
 
         AeMdw.Ets.inc(:stat_sync_cache, :contracts)
-        block_hash = Model.block(DBU.read_block!(bi), :hash)
+        block_hash = Model.block(block, :hash)
 
         call_rec = Contract.get_init_call_rec(contract_pk, tx, block_hash)
 

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -69,12 +69,12 @@ defmodule AeMdw.Db.Sync.Transaction do
 
   @spec transaction_mutations(
           {Node.signed_tx(), Txs.txi()},
-          {Blocks.block_index(), Model.block(), Blocks.time(), Contract.grouped_events()},
+          {Blocks.block_index(), Blocks.block_hash(), Blocks.time(), Contract.grouped_events()},
           boolean()
         ) :: [Mutation.t()]
   def transaction_mutations(
         {signed_tx, txi},
-        {block_index, block, mb_time, mb_events} = tx_ctx,
+        {block_index, block_hash, mb_time, mb_events} = tx_ctx,
         inner_tx? \\ false
       ) do
     {mod, tx} = :aetx.specialize_callback(:aetx_sign.tx(signed_tx))
@@ -106,7 +106,7 @@ defmodule AeMdw.Db.Sync.Transaction do
 
     [
       WriteTxMutation.new(model_tx, type, txi, mb_time, inner_tx?),
-      WriteLinksMutation.new(type, tx, signed_tx, txi, tx_hash, block_index, block),
+      WriteLinksMutation.new(type, tx, signed_tx, txi, tx_hash, block_index, block_hash),
       contract_events_mutation,
       WriteFieldsMutation.new(type, tx, block_index, txi),
       inner_tx_mutations
@@ -177,7 +177,7 @@ defmodule AeMdw.Db.Sync.Transaction do
     mb_model = Model.block(index: {height, mbi}, tx_index: mb_txi, hash: mb_hash)
     mb_txs = :aec_blocks.txs(mblock)
     events = AeMdw.Contract.get_grouped_events(mblock)
-    tx_ctx = {{height, mbi}, mb_model, mb_time, events}
+    tx_ctx = {{height, mbi}, mb_hash, mb_time, events}
 
     txs_mutations =
       mb_txs

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -69,12 +69,12 @@ defmodule AeMdw.Db.Sync.Transaction do
 
   @spec transaction_mutations(
           {Node.signed_tx(), Txs.txi()},
-          {Blocks.block_index(), Blocks.time(), Contract.grouped_events()},
+          {Blocks.block_index(), Model.block(), Blocks.time(), Contract.grouped_events()},
           boolean()
         ) :: [Mutation.t()]
   def transaction_mutations(
         {signed_tx, txi},
-        {block_index, mb_time, mb_events} = tx_ctx,
+        {block_index, block, mb_time, mb_events} = tx_ctx,
         inner_tx? \\ false
       ) do
     {mod, tx} = :aetx.specialize_callback(:aetx_sign.tx(signed_tx))
@@ -106,7 +106,7 @@ defmodule AeMdw.Db.Sync.Transaction do
 
     [
       WriteTxMutation.new(model_tx, type, txi, mb_time, inner_tx?),
-      WriteLinksMutation.new(type, tx, signed_tx, txi, tx_hash, block_index),
+      WriteLinksMutation.new(type, tx, signed_tx, txi, tx_hash, block_index, block),
       contract_events_mutation,
       WriteFieldsMutation.new(type, tx, block_index, txi),
       inner_tx_mutations
@@ -177,7 +177,7 @@ defmodule AeMdw.Db.Sync.Transaction do
     mb_model = Model.block(index: {height, mbi}, tx_index: mb_txi, hash: mb_hash)
     mb_txs = :aec_blocks.txs(mblock)
     events = AeMdw.Contract.get_grouped_events(mblock)
-    tx_ctx = {{height, mbi}, mb_time, events}
+    tx_ctx = {{height, mbi}, mb_model, mb_time, events}
 
     txs_mutations =
       mb_txs

--- a/priv/migrations/20210914100800_index_inner_txs.ex
+++ b/priv/migrations/20210914100800_index_inner_txs.ex
@@ -113,7 +113,8 @@ defmodule AeMdw.Migrations.IndexInnerTxs do
     block_index = {:aec_blocks.height(mblock), mbi}
     mb_time = :aec_blocks.time_in_msecs(mblock)
     mb_events = Contract.get_grouped_events(mblock)
+    {:ok, mb_hash} = :aec_headers.hash_header(:aec_blocks.to_micro_header(mblock))
 
-    {block_index, mblock, mb_time, mb_events}
+    {block_index, mb_hash, mb_time, mb_events}
   end
 end

--- a/priv/migrations/20210914100800_index_inner_txs.ex
+++ b/priv/migrations/20210914100800_index_inner_txs.ex
@@ -114,6 +114,6 @@ defmodule AeMdw.Migrations.IndexInnerTxs do
     mb_time = :aec_blocks.time_in_msecs(mblock)
     mb_events = Contract.get_grouped_events(mblock)
 
-    {block_index, mb_time, mb_events}
+    {block_index, mblock, mb_time, mb_events}
   end
 end

--- a/test/ae_mdw/db/sync/transaction_test.exs
+++ b/test/ae_mdw/db/sync/transaction_test.exs
@@ -25,7 +25,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
         mb1: [
           t1: spend_tx(:alice, :bob, 5_000)
         ] do
-        %{height: height, time: mb_time, txs: [tx_rec]} = blocks[:mb1]
+        %{height: height, block: mb, time: mb_time, txs: [tx_rec]} = blocks[:mb1]
 
         signed_tx = :aetx_sign.new(tx_rec, [])
         txi = @very_high_txi + 1
@@ -34,7 +34,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
         mutations =
           Transaction.transaction_mutations(
             {signed_tx, txi},
-            {block_index, mb_time, nil},
+            {block_index, mb, mb_time, nil},
             false
           )
 
@@ -61,7 +61,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
         mb1: [
           t1: spend_tx(:alice, :alice, 5_000)
         ] do
-        %{height: height, time: mb_time, txs: [tx_rec]} = blocks[:mb1]
+        %{height: height, block: mb, time: mb_time, txs: [tx_rec]} = blocks[:mb1]
 
         signed_tx = :aetx_sign.new(tx_rec, [])
         txi = @very_high_txi + 1
@@ -70,7 +70,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
         mutations =
           Transaction.transaction_mutations(
             {signed_tx, txi},
-            {block_index, mb_time, nil},
+            {block_index, mb, mb_time, nil},
             false
           )
 

--- a/test/support/blockchain_sim.ex
+++ b/test/support/blockchain_sim.ex
@@ -114,7 +114,8 @@ defmodule AeMdwWeb.BlockchainSim do
             %{
               hash: :aeser_api_encoder.encode(hash_type, block_hash),
               height: :aec_blocks.height(block),
-              time: :aec_blocks.time_in_msecs(block)
+              time: :aec_blocks.time_in_msecs(block),
+              block: block
             },
             hash_type,
             block


### PR DESCRIPTION
For some of the generations whose microblocks have lots of contract call transactions in them, this reduces processing time by 50%

refs #346