### PR TITLE
fix: use last synced gen for stats and totalstats

### DIFF
--- a/lib/ae_mdw/stats.ex
+++ b/lib/ae_mdw/stats.ex
@@ -25,7 +25,7 @@ defmodule AeMdw.Stats do
 
   @spec fetch_stats(direction(), range(), cursor(), limit()) :: {[stat()], cursor()}
   def fetch_stats(direction, range, cursor, limit) do
-    {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
+    {:ok, last_gen} = Mnesia.last_key(AeMdw.Db.Model.Stat)
 
     range_scope = deserialize_scope(range)
 
@@ -51,7 +51,7 @@ defmodule AeMdw.Stats do
 
   @spec fetch_sum_stats(direction(), range(), cursor(), limit()) :: {[sum_stat()], cursor()}
   def fetch_sum_stats(direction, range, cursor, limit) do
-    {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
+    {:ok, last_gen} = Mnesia.last_key(AeMdw.Db.Model.SumStat)
 
     range_scope = deserialize_scope(range)
 


### PR DESCRIPTION
## What

Use last synced height as last gen for `/stats` and `/totalstats`

## Why

Doing multiple requests some fail because the blocks might not be synced yet.