### PR TITLE
fix: chain_too_short condition when syncing height 0

### DIFF
--- a/lib/ae_mdw/db/mutations/stats_mutation.ex
+++ b/lib/ae_mdw/db/mutations/stats_mutation.ex
@@ -20,6 +20,21 @@ defmodule AeMdw.Db.StatsMutation do
           }
 
   @spec new(Blocks.height()) :: t()
+  def new(0) do
+    prev_sum_stat =
+      Model.sum_stat(
+        block_reward: 0,
+        dev_reward: 0,
+        total_supply: 0
+      )
+
+    %__MODULE__{
+      height: 1,
+      prev_sum_stat: prev_sum_stat,
+      token_supply_delta: 0
+    }
+  end
+
   def new(height) do
     token_supply_delta = AeMdw.Node.token_supply_delta(height + 1)
 


### PR DESCRIPTION
## What

Fixes `{:error, :chain_too_short}` race condition when syncing the first generation.

## Why

`max_height` is set to `height` (0) + 1 and when `:aec_chain.get_key_header_by_height(1)` is called the generation is not yet synced returning `{:error, :chain_too_short}`.

```
{{badmatch,{error,chain_too_short}},[{'Elixir.AeMdw.Db.Sync.BlockIndex',sync,1,[{file,"lib/ae_mdw/db/sync/block_index.ex"},{line,23}]},{'Elixir.AeMdw.Db.Sync.Transaction',sync,1,[{file,"lib/ae_mdw/db/sync/transaction.ex"},{line,42}]},{'Elixir.AeMdw.Db.Sync.ChainSubscriber',run_action,1,[{file,"lib/ae_mdw/db/sync/chain_subscriber.ex"},{line,94}]}]}
```