### PR TITLE
perf: preload all microblock events concurrently when syncing

### DIFF
--- a/lib/ae_mdw/util/buffered_stream.ex
+++ b/lib/ae_mdw/util/buffered_stream.ex
@@ -47,6 +47,41 @@ defmodule AeMdw.Util.BufferedStream do
     )
   end
 
+  @spec async_map(Enumerable.t(), (Enum.element() -> any()), [opt()]) :: Enumerable.t()
+  def async_map(enumerable, fun, opts) do
+    buffer_size = Keyword.fetch!(opts, :buffer_size)
+
+    Stream.resource(
+      fn ->
+        empty_count = Semaphore.new(0)
+        full_count = Semaphore.new(buffer_size)
+
+        tasks = produce_results_async(enumerable, fun, empty_count, full_count)
+
+        {tasks, empty_count, full_count}
+      end,
+      fn
+        {[task | rest_tasks], empty_count, full_count} ->
+          # CONSUMER
+          Semaphore.wait(empty_count)
+
+          result = Task.await(task, :infinity)
+
+          Semaphore.signal(full_count)
+
+          {[result], {rest_tasks, empty_count, full_count}}
+
+        {[], _empty_count, _full_count} = state ->
+          {:halt, state}
+      end,
+      fn {tasks, empty_count, full_count} ->
+        Enum.each(tasks, &Task.shutdown(&1))
+        Semaphore.stop(empty_count)
+        Semaphore.stop(full_count)
+      end
+    )
+  end
+
   defp push_agent_item(agent, item) do
     Agent.update(agent, fn queue -> :queue.in(item, queue) end)
   end
@@ -74,5 +109,20 @@ defmodule AeMdw.Util.BufferedStream do
     end)
 
     Agent.update(agent, fn _queue -> :ended end)
+  end
+
+  defp produce_results_async(enumerable, fun, empty_count, full_count) do
+    Enum.map(enumerable, fn entry ->
+      Task.async(fn ->
+        # PRODUCER
+        Semaphore.wait(full_count)
+
+        result = fun.(entry)
+
+        Semaphore.signal(empty_count)
+
+        result
+      end)
+    end)
   end
 end


### PR DESCRIPTION
refs #346 