### PR TITLE
test: refactor name controller integration tests

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -69,7 +69,7 @@ jobs:
         id: plt-cache
         with:
           path: priv/plts
-          key: plts-v4-${{ hashFiles('mix.lock') }}
+          key: plts-v5-${{ hashFiles('mix.lock') }}
 
       - name: Common tests setup
         uses: ./.github/actions/tests-common

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -343,7 +343,9 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       assert %{"data" => names, "next" => next} = conn |> get("/names") |> json_response(200)
 
       expirations =
-        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        names
+        |> Enum.map(fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        |> Enum.reverse()
 
       assert @default_limit = length(names)
       assert ^expirations = Enum.sort(expirations)
@@ -351,9 +353,9 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       assert %{"data" => next_names} = conn |> get(next) |> json_response(200)
 
       next_expirations =
-        Enum.map(next_names, fn %{"info" => %{"expire_height" => expire_height}} ->
-          expire_height
-        end)
+        next_names
+        |> Enum.map(fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        |> Enum.reverse()
 
       assert @default_limit = length(next_expirations)
       assert ^next_expirations = Enum.sort(next_expirations)
@@ -365,7 +367,9 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       assert %{"data" => names} = conn |> get("/names", limit: limit) |> json_response(200)
 
       expirations =
-        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        names
+        |> Enum.map(fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        |> Enum.reverse()
 
       assert ^limit = length(names)
       assert ^expirations = Enum.sort(expirations)


### PR DESCRIPTION
The purpose of this is to test pagination properly, with the added
benefi that many of the tests would fail when there's name
inconsistencies in the DB.