### PR TITLE
fix: validate existing contract when filtering calls by contract_id

### DIFF
--- a/lib/ae_mdw/contracts.ex
+++ b/lib/ae_mdw/contracts.ex
@@ -409,7 +409,11 @@ defmodule AeMdw.Contracts do
 
   defp create_txi!(contract_id) do
     pk = Validate.id!(contract_id)
-    Origin.tx_index({:contract, pk}) || -1
+
+    case Origin.tx_index({:contract, pk}) do
+      nil -> raise ErrInput.Id, value: contract_id
+      txi -> txi
+    end
   end
 
   defp fetch_tx_type(call_txi, local_idx) do


### PR DESCRIPTION
closes #422

This issue needs further work: right now you can't filter calls/logs of contracts that have no create transaction.