### PR TITLE
feat: add paginated /names/search/:prefix endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4265,6 +4265,7 @@ This is a list of the exceptions together with the changes that need to be done:
   `/names/inactive/:scope_type/:range` - Can now be accessed via `/v2/names?scope=txi:100-200` or `/v2/names?scope=gen:30-40`.
 * `/names/auctions` - Can now be accessed via `/v2/names/auctions`
 * `/names/auctions/:scope_type/:range` - Can now be accessed via `/v2/auctions?scope=gen:10-100` (or `?scope=txi:1000-2000`).
+* `/names/search/:prefix` - The prefix is no longer part of the path, but a query parameter instead (`?prefix=...`).
 
 ## Websocket interface
 

--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -29,6 +29,7 @@ defmodule AeMdwWeb.NameController do
     "inactive" => :inactive,
     "auction" => :auction
   }
+  @lifecycles Map.keys(@lifecycles_map)
 
   @spec auction(Conn.t(), map()) :: Conn.t()
   def auction(conn, %{"id" => ident} = params),
@@ -140,10 +141,8 @@ defmodule AeMdwWeb.NameController do
     lifecycles =
       query_string
       |> URI.query_decoder()
-      |> Enum.filter(&match?({"only", _lifecycle}, &1))
-      |> Enum.map(fn {"only", lifecycle} -> lifecycle end)
-      |> Enum.filter(&Map.get(@lifecycles_map, &1))
-      |> Enum.reject(&is_nil/1)
+      |> Enum.filter(&match?({"only", lifecycle} when lifecycle in @lifecycles, &1))
+      |> Enum.map(fn {"only", lifecycle} -> Map.fetch!(@lifecycles_map, lifecycle) end)
       |> Enum.uniq()
 
     %{pagination: pagination, cursor: cursor, expand?: expand?} = assigns

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -88,6 +88,7 @@ defmodule AeMdwWeb.Router do
       get "/names/:id/pointers", NameController, :pointers
       get "/names/:id/pointees", NameController, :pointees
       get "/names/auctions", NameController, :auctions
+      get "/names/search", NameController, :search
       get "/names", NameController, :names
       get "/names/:id", NameController, :name
     end
@@ -105,7 +106,7 @@ defmodule AeMdwWeb.Router do
     get "/name/pointees/:id", NameController, :pointees
     get "/name/owned_by/:id", NameController, :owned_by
     get "/name/:id", NameController, :name
-    get "/names/search/:prefix", NameController, :search
+    get "/names/search/:prefix", NameController, :search_v1
     get "/names/auctions", NameController, :auctions
     get "/names/auctions/:scope_type/:range", NameController, :auctions
     get "/names/inactive", NameController, :inactive_names


### PR DESCRIPTION
Previously, this endpoint returned all results that matched on a
single page, potentially causing security concerns.