### PR TITLE
fix: stats count for existing objects

### DIFF
--- a/lib/ae_mdw/db/int_transfer.ex
+++ b/lib/ae_mdw/db/int_transfer.ex
@@ -90,7 +90,7 @@ defmodule AeMdw.Db.IntTransfer do
 
     kind_spec =
       Ex2ms.fun do
-        {:kind_int_transfer_tx, {^kind, ^height_pos, :_, :_}, :_} -> 1
+        Model.kind_int_transfer_tx(index: {^kind, ^height_pos, :_, :_}) -> 1
       end
 
     Model.KindIntTransferTx

--- a/lib/ae_mdw/db/int_transfer.ex
+++ b/lib/ae_mdw/db/int_transfer.ex
@@ -90,7 +90,7 @@ defmodule AeMdw.Db.IntTransfer do
 
     kind_spec =
       Ex2ms.fun do
-        {:kind_int_transfer_tx, {^kind, ^height_pos, :_, :_}} -> 1
+        {:kind_int_transfer_tx, {^kind, ^height_pos, :_, :_}, :_} -> 1
       end
 
     Model.KindIntTransferTx

--- a/lib/ae_mdw/db/sync/stats.ex
+++ b/lib/ae_mdw/db/sync/stats.ex
@@ -50,11 +50,18 @@ defmodule AeMdw.Db.Sync.Stats do
       dev_reward: prev_dev_reward
     ) = Util.read!(Model.Stat, height - 1)
 
-    current_active_names = :mnesia.table_info(Model.ActiveName, :size)
-    current_active_auctions = :mnesia.table_info(Model.ActiveAuction, :size)
-    current_active_oracles = :mnesia.table_info(Model.ActiveOracle, :size)
-    current_inactive_names = :mnesia.table_info(Model.InactiveName, :size)
-    current_inactive_oracles = :mnesia.table_info(Model.InactiveOracle, :size)
+    {current_active_names, current_active_auctions, current_active_oracles,
+     current_inactive_names,
+     current_inactive_oracles} =
+      :mnesia.async_dirty(fn ->
+        {
+          Util.count(Model.ActiveName),
+          Util.count(Model.AuctionExpiration),
+          Util.count(Model.ActiveOracle),
+          Util.count(Model.InactiveName),
+          Util.count(Model.InactiveOracle)
+        }
+      end)
 
     current_contracts =
       Model.ContractCall

--- a/test/integration/ae_mdw/sync/stats_test.exs
+++ b/test/integration/ae_mdw/sync/stats_test.exs
@@ -1,0 +1,32 @@
+defmodule Integration.AeMdw.Db.Sync.StatsTest do
+  use ExUnit.Case
+
+  @moduletag :integration
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Sync.Stats
+  alias AeMdw.Db.StatsMutation
+
+  require Model
+
+  @initial_token_offer AeMdw.Node.token_supply_delta(0)
+  @first_block_reward_height 181
+
+  describe "new_mutation/2" do
+    test "with all_cached? = false and 1 block reward" do
+      %StatsMutation{stat: m_stat, sum_stat: m_sum_stat} =
+        Stats.new_mutation(@first_block_reward_height - 1, false)
+
+      assert Model.sum_stat(m_sum_stat, :block_reward) == 1
+      assert Model.sum_stat(m_sum_stat, :dev_reward) == 0
+      assert Model.sum_stat(m_sum_stat, :total_supply) == @initial_token_offer + 1
+
+      assert Model.stat(m_stat, :inactive_names) > 0
+      assert Model.stat(m_stat, :active_names) > 0
+      assert Model.stat(m_stat, :active_auctions) > 0
+      assert Model.stat(m_stat, :inactive_oracles) > 0
+      assert Model.stat(m_stat, :active_oracles) > 0
+      assert Model.stat(m_stat, :contracts) > 0
+    end
+  end
+end

--- a/test/integration/ae_mdw_web/controllers/stats_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/stats_controller_test.exs
@@ -107,7 +107,7 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
 
   describe "sum_stats" do
     test "when no subpath it gets stats in backwards direction", %{conn: conn} do
-      limit = 3
+      limit = 100
       last_gen = Util.last_gen()
 
       conn = get(conn, "/totalstats?limit=#{limit}")
@@ -117,7 +117,15 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
 
       assert response["data"]
              |> Enum.zip(last_gen..0)
-             |> Enum.all?(fn {%{"height" => height}, index} -> height == index end)
+             |> Enum.each(fn {%{
+                                "height" => height,
+                                "sum_block_reward" => sum_block_reward,
+                                "sum_dev_reward" => sum_dev_reward
+                              }, index} ->
+               assert height == index
+               assert sum_block_reward > 0
+               assert sum_dev_reward > 0
+             end)
 
       conn_next = get(conn, response["next"])
       response_next = json_response(conn_next, 200)


### PR DESCRIPTION
## What

- replace `:mnesia.table_info` with `Util.count` to get correct number of existing objects/entries.
- fix select of internal transfers rewards by kind

## Why

fix #453 
refs #450 

## Validation steps

`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw/sync/stats_test.exs`