### PR TITLE
feat: add encoded query_id on query txs

### DIFF
--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -453,8 +453,13 @@ defmodule AeMdw.Db.Format do
   def custom_encode(:oracle_response_tx, tx, _tx_rec, _signed_tx, _block_hash),
     do: update_in(tx, ["tx", "response"], &maybe_base64/1)
 
-  def custom_encode(:oracle_query_tx, tx, _tx_rec, _signed_tx, _block_hash) do
-    update_in(tx, ["tx", "query"], &Base.encode64/1)
+  def custom_encode(:oracle_query_tx, tx, tx_rec, _signed_tx, _block_hash) do
+    query_id = :aeo_query_tx.query_id(tx_rec)
+    query_id = Enc.encode(:oracle_query_id, query_id)
+
+    tx
+    |> update_in(["tx", "query"], &Base.encode64/1)
+    |> put_in(["tx", "query_id"], query_id)
   end
 
   def custom_encode(:ga_attach_tx, tx, tx_rec, _signed_tx, _block_hash) do

--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,7 @@ defmodule AeMdw.MixProject do
           :aens_transfer_tx,
           :aeo_extend_tx,
           :aeo_query,
+          :aeo_query_tx,
           :aeo_register_tx,
           :aeo_response_tx,
           :aeo_state_tree,


### PR DESCRIPTION
This is because core serialization doesn't return the query_id by
default: https://github.com/aeternity/aeternity/blob/master/apps/aeoracle/src/aeo_query_tx.erl#L254

ref #381
ref #60