### PR TITLE
perf: async task type and args as a key

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -76,14 +76,33 @@ defmodule AeMdw.Db.Contract do
     :ok
   end
 
-  @spec aex9_presence_exists?(pubkey(), pubkey(), integer() | nil) :: boolean()
-  def aex9_presence_exists?(contract_pk, account_pk, txi \\ nil) do
-    txi_search_prev = (txi && txi + 1) || nil
+  @spec aex9_presence_exists?(pubkey(), pubkey(), integer()) :: boolean()
+  def aex9_presence_exists?(contract_pk, account_pk, txi) do
+    txi_search_prev = txi + 1
 
     case :mnesia.prev(Model.Aex9AccountPresence, {account_pk, txi_search_prev, contract_pk}) do
       {^account_pk, _txi, ^contract_pk} -> true
       _other_key -> false
     end
+  end
+
+  @spec aex9_presence_exists?(pubkey(), pubkey()) :: boolean()
+  def aex9_presence_exists?(contract_pk, account_pk) do
+    0
+    |> Stream.unfold(fn
+      :found ->
+        nil
+
+      txi_search_next ->
+        case :mnesia.next(Model.Aex9AccountPresence, {account_pk, txi_search_next, contract_pk}) do
+          {^account_pk, _txi, ^contract_pk} -> {true, :found}
+          {^account_pk, next_txi, _contract_pk} -> {false, next_txi}
+          _not_found -> nil
+        end
+    end)
+    |> Enum.to_list()
+    |> List.last()
+    |> Kernel.||(false)
   end
 
   @spec call_write(integer(), integer(), Contract.fun_arg_res_or_error()) :: :ok

--- a/lib/ae_mdw/sync/async_tasks/consumer.ex
+++ b/lib/ae_mdw/sync/async_tasks/consumer.ex
@@ -102,7 +102,8 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
   #
   # Used by consumers only
   #
-  @spec run_supervised(Model.async_tasks_record(), boolean()) :: {Task.t(), term()}
+  @spec run_supervised(Model.async_tasks_record(), boolean()) ::
+          {Task.t() | nil, :timer.tref() | nil}
   def run_supervised(m_task, is_long? \\ false) do
     task =
       Task.Supervisor.async_nolink(
@@ -149,8 +150,8 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
   end
 
   @spec set_done(Model.async_tasks_record(), boolean()) :: :ok
-  defp set_done(Model.async_tasks(index: index), is_long?) do
-    Producer.notify_consumed(index, is_long?)
+  defp set_done(Model.async_tasks(index: index, args: args), is_long?) do
+    Producer.notify_consumed(index, args, is_long?)
   end
 
   @spec schedule_demand() :: :ok

--- a/lib/ae_mdw/sync/async_tasks/consumer.ex
+++ b/lib/ae_mdw/sync/async_tasks/consumer.ex
@@ -103,7 +103,7 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
   # Used by consumers only
   #
   @spec run_supervised(Model.async_tasks_record(), boolean()) ::
-          {Task.t() | nil, :timer.tref() | nil}
+          {Task.t(), :timer.tref() | nil}
   def run_supervised(m_task, is_long? \\ false) do
     task =
       Task.Supervisor.async_nolink(

--- a/lib/ae_mdw/sync/async_tasks/producer.ex
+++ b/lib/ae_mdw/sync/async_tasks/producer.ex
@@ -13,8 +13,6 @@ defmodule AeMdw.Sync.AsyncTasks.Producer do
   require Model
   require Logger
 
-  @typep task_index() :: {pos_integer(), atom()}
-
   @max_buffer_size 100
 
   @spec start_link(any()) :: GenServer.on_start()
@@ -43,9 +41,9 @@ defmodule AeMdw.Sync.AsyncTasks.Producer do
     GenServer.call(__MODULE__, :dequeue)
   end
 
-  @spec notify_consumed(task_index(), boolean()) :: :ok
-  def notify_consumed(task_index, is_long?) do
-    Store.set_done(task_index)
+  @spec notify_consumed(Store.task_index(), Store.task_args(), boolean()) :: :ok
+  def notify_consumed(task_index, task_args, is_long?) do
+    Store.set_done(task_index, task_args)
     Stats.update_consumed(is_long?)
 
     if is_long?, do: Log.info("Long task finished: #{inspect(task_index)}")

--- a/lib/ae_mdw/sync/async_tasks/store.ex
+++ b/lib/ae_mdw/sync/async_tasks/store.ex
@@ -78,7 +78,7 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
   #
   # Private functions
   #
-  def cache_tasks_by_args() do
+  defp cache_tasks_by_args() do
     {:atomic, indexed_args_records} =
       :mnesia.transaction(fn ->
         args_spec =

--- a/lib/ae_mdw/sync/async_tasks/store.ex
+++ b/lib/ae_mdw/sync/async_tasks/store.ex
@@ -9,17 +9,24 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
   require Ex2ms
   require Model
 
-  @typep task_index() :: {pos_integer(), atom()}
+  @type task_index() :: {pos_integer(), atom()}
+  @type task_args() :: list()
+
+  @processing_tab :async_tasks_processing
+  @args_tab :async_tasks_args
 
   @spec init() :: :ok
   def init do
-    :ets.new(:async_tasks_processing, [:named_table, :set, :public])
+    :ets.new(@processing_tab, [:named_table, :set, :public])
+    :ets.new(@args_tab, [:named_table, :set, :public])
     :ok
   end
 
   @spec reset() :: :ok
   def reset do
-    :ets.delete_all_objects(:async_tasks_processing)
+    :ets.delete_all_objects(@processing_tab)
+    :ets.delete_all_objects(@args_tab)
+    cache_tasks_by_args()
     :ok
   end
 
@@ -31,10 +38,9 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
       end
 
     {m_tasks, _cont} = Util.select(Model.AsyncTasks, any_spec, max_amount)
-    m_tasks = dedup_records(m_tasks)
 
     Enum.filter(m_tasks, fn Model.async_tasks(index: index) ->
-      not :ets.member(:async_tasks_processing, index)
+      not :ets.member(@processing_tab, index)
     end)
   end
 
@@ -45,6 +51,7 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
         index = {System.system_time(), task_type}
         m_task = Model.async_tasks(index: index, args: args)
         :mnesia.write(Model.AsyncTasks, m_task, :write)
+        :ets.insert(@args_tab, {{task_type, args}})
       end
     end)
 
@@ -53,44 +60,39 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
 
   @spec set_processing(task_index()) :: :ok
   def set_processing(task_index) do
-    :ets.insert(:async_tasks_processing, {task_index})
+    :ets.insert(@processing_tab, {task_index})
     :ok
   end
 
-  @spec set_done(task_index()) :: :ok
-  def set_done(task_index) do
+  @spec set_done(task_index(), task_args()) :: :ok
+  def set_done({_ts, task_type} = task_index, args) do
     :mnesia.sync_transaction(fn ->
       :mnesia.delete(Model.AsyncTasks, task_index, :write)
     end)
 
-    :ets.delete_object(:async_tasks_processing, task_index)
+    :ets.delete_object(@processing_tab, task_index)
+    :ets.delete(@args_tab, {task_type, args})
     :ok
   end
 
   #
   # Private functions
   #
-  defp is_enqueued?(task_type, args) do
-    exists_spec =
-      Ex2ms.fun do
-        {:_, {:_, ^task_type}, ^args} -> true
-      end
+  def cache_tasks_by_args() do
+    {:atomic, indexed_args_records} =
+      :mnesia.transaction(fn ->
+        args_spec =
+          Ex2ms.fun do
+            Model.async_tasks(index: {_ts, task_type}, args: args) -> {{task_type, args}}
+          end
 
-    case :mnesia.select(Model.AsyncTasks, exists_spec, 1, :read) do
-      {[true], _cont} -> true
-      {[], _cont} -> false
-    end
-  end
-
-  defp dedup_records(tasks) do
-    tasks
-    |> Enum.group_by(fn Model.async_tasks(args: args) -> args end)
-    |> Enum.map(fn {_args, [first | to_delete]} ->
-      Enum.each(to_delete, fn Model.async_tasks(index: index) ->
-        :mnesia.dirty_delete(Model.AsyncTasks, index)
+        :mnesia.select(Model.AsyncTasks, args_spec)
       end)
 
-      first
-    end)
+    :ets.insert(@args_tab, indexed_args_records)
+  end
+
+  defp is_enqueued?(task_type, args) do
+    :ets.member(@args_tab, {task_type, args})
   end
 end

--- a/test/ae_mdw/sync/async_tasks/store_test.exs
+++ b/test/ae_mdw/sync/async_tasks/store_test.exs
@@ -1,7 +1,5 @@
-defmodule Integration.AeMdw.Sync.AsyncTasks.StoreTest do
+defmodule AeMdw.Sync.AsyncTasks.StoreTest do
   use ExUnit.Case
-
-  @moduletag :integration
 
   alias AeMdw.Db.Model
   alias AeMdw.Sync.AsyncTasks.Store
@@ -10,33 +8,33 @@ defmodule Integration.AeMdw.Sync.AsyncTasks.StoreTest do
   require Ex2ms
 
   @task_type :update_aex9_presence
-  @contract_pk <<123_456::256>>
+  @args1 [<<123_456::256>>]
+  @args2 [<<123_457::256>>]
 
   describe "save_new/2 and fetch_unprocessed/1 success" do
     test "for an unprocessed task" do
       on_exit(fn ->
-        setup_delete_async_task([@contract_pk])
+        setup_delete_async_task(@args1)
       end)
 
-      Store.save_new(@task_type, [@contract_pk])
-      Store.save_new(@task_type, [@contract_pk])
+      Store.save_new(@task_type, @args1)
+      Store.save_new(@task_type, @args1)
       tasks = Store.fetch_unprocessed(1000)
 
-      assert 1 ==
-               Enum.count(tasks, fn Model.async_tasks(args: args) -> args == [@contract_pk] end)
+      assert 1 == Enum.count(tasks, fn Model.async_tasks(args: args) -> args == @args1 end)
     end
 
     test "for a task being processed" do
       on_exit(fn ->
-        setup_delete_async_task([@contract_pk])
+        setup_delete_async_task(@args2)
       end)
 
-      Store.save_new(@task_type, [@contract_pk])
+      Store.save_new(@task_type, @args2)
       tasks_before = Store.fetch_unprocessed(1000)
 
       assert Model.async_tasks(index: task_index) =
                Enum.find(tasks_before, fn Model.async_tasks(args: args) ->
-                 args == [@contract_pk]
+                 args == @args2
                end)
 
       Store.set_processing(task_index)
@@ -44,7 +42,7 @@ defmodule Integration.AeMdw.Sync.AsyncTasks.StoreTest do
 
       assert nil ==
                Enum.find(tasks_after, fn Model.async_tasks(args: args) ->
-                 args == [@contract_pk]
+                 args == @args2
                end)
     end
   end

--- a/test/integration/ae_mdw/sync/async_tasks/producer_consumer_test.exs
+++ b/test/integration/ae_mdw/sync/async_tasks/producer_consumer_test.exs
@@ -7,6 +7,7 @@ defmodule Integration.AeMdw.Sync.AsyncTasks.ProducerConsumerTest do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Util
   alias AeMdw.Sync.AsyncTasks.Producer
+  alias AeMdw.Sync.AsyncTasks
   alias AeMdw.Validate
 
   require Ex2ms
@@ -19,7 +20,7 @@ defmodule Integration.AeMdw.Sync.AsyncTasks.ProducerConsumerTest do
   test "enqueue, dequeue and aex9 presence update success" do
     # setup
     exists_before? =
-      :mnesia.async_dirty(fn -> Contract.aex9_presence_exists?(@contract_pk, @account_pk, -1) end)
+      :mnesia.async_dirty(fn -> Contract.aex9_presence_exists?(@contract_pk, @account_pk) end)
 
     on_exit(fn ->
       if not exists_before?, do: setup_delete_aex9_presence(@contract_pk, @account_pk)
@@ -27,23 +28,53 @@ defmodule Integration.AeMdw.Sync.AsyncTasks.ProducerConsumerTest do
 
     if exists_before?, do: setup_delete_aex9_presence(@contract_pk, @account_pk)
 
-    # enqueue/dequeue
+    # check async enqueue and sync dequeue
     args = [@contract_pk]
     Producer.enqueue(@task_type, args)
     Producer.enqueue(@task_type, args)
-    assert Model.async_tasks(index: index, args: ^args) = task = Producer.dequeue()
-    assert Util.read(Model.AsyncTasks, index) == [task]
+    Producer.commit_enqueued()
+
+    assert index =
+             Enum.reduce_while(1..50, nil, fn _i, nil ->
+               Process.sleep(20)
+               task = Producer.dequeue()
+
+               if task do
+                 assert Model.async_tasks(index: index, args: ^args) = task
+                 assert [task] == Util.read(Model.AsyncTasks, index)
+
+                 {:halt, index}
+               else
+                 {:cont, nil}
+               end
+             end)
 
     # discard task as if processed
-    Producer.notify_consumed(index, false)
+    Producer.notify_consumed(index, args, false)
     assert nil == Producer.dequeue()
 
-    # enqueue and check that was processed
+    # enqueue and check that the async task was processed
     Producer.enqueue(@task_type, args)
-    Process.sleep(3500)
-    assert Util.read(Model.AsyncTasks, index) == []
+    Producer.commit_enqueued()
 
-    assert :mnesia.async_dirty(fn -> Contract.aex9_presence_exists?(@contract_pk, @account_pk) end)
+    [{_id, pid, _type, _mod}] =
+      AsyncTasks.Supervisor
+      |> Supervisor.which_children()
+      |> Enum.filter(fn {id, _pid, _type, _mod} ->
+        id == "Elixir.AeMdw.Sync.AsyncTasks.Consumer1"
+      end)
+
+    assert Enum.reduce_while(1..50, false, fn _i, _acc ->
+             Process.send(pid, :demand, [:noconnect])
+             Process.sleep(100)
+
+             exists? =
+               :mnesia.async_dirty(fn ->
+                 Contract.aex9_presence_exists?(@contract_pk, @account_pk)
+               end)
+
+             if exists?, do: {:halt, true}, else: {:cont, false}
+           end)
   end
 
   defp setup_delete_aex9_presence(contract_pk, account_pk) do


### PR DESCRIPTION
## What

Indexes the async tasks by task type and `args` (these two attributes define the work to be peformed).

## Why
Currently, for lower volume of `UpdateAex9Presence` and `DeriveAex9Presence`, the task `args` (e.g `contract_pk`) is used to check if an async task already exists to avoid duplicate processing. However, the task `args` is not a key/index for async tasks.

With #437 and DEX, the volume of async tasks will increase justifying another index (in memory only).

PS: The current async task index is used for ordering to avoid task processing starvation.

## Validation steps

`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw/sync/async_tasks/producer_consumer_test.exs`