### PR TITLE
feat: contract compilation info

### DIFF
--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -113,7 +113,7 @@ defmodule AeMdw.Contract do
     }
   end
 
-  @spec is_aex9?(DBN.pubkey() | ct_info()) :: boolean()
+  @spec is_aex9?(DBN.pubkey() | type_info()) :: boolean()
   def is_aex9?(pubkey) when is_binary(pubkey) do
     case get_info(pubkey) do
       {:ok, {type_info, _compiler_vsn, _source_hash}} -> is_aex9?(type_info)
@@ -134,7 +134,7 @@ defmodule AeMdw.Contract do
   end
 
   # AEVM
-  def is_aex9?(_),
+  def is_aex9?(_no_fcode),
     do: false
 
   # value of :aec_hash.blake2b_256_hash("Transfer")

--- a/lib/ae_mdw/db/sync/invalidate.ex
+++ b/lib/ae_mdw/db/sync/invalidate.ex
@@ -1,4 +1,5 @@
 defmodule AeMdw.Db.Sync.Invalidate do
+  # credo:disable-for-this-file
   alias AeMdw.Contract
   alias AeMdw.Db.Stream, as: DBS
   alias AeMdw.Db.Format

--- a/lib/ae_mdw/db/sync/invalidate.ex
+++ b/lib/ae_mdw/db/sync/invalidate.ex
@@ -310,11 +310,10 @@ defmodule AeMdw.Db.Sync.Invalidate do
           |> Stream.map(fn %{} = x ->
             ct_pk = Validate.id!(x.tx.contract_id)
 
-            with {:ok, ct_info} <- Contract.get_info(ct_pk),
-                 true <- Contract.is_aex9?(ct_info) do
+            if Contract.is_aex9?(ct_pk) do
               {{ct_pk, x.tx_index, -1}, Validate.id!(x.tx.owner_id), -1}
             else
-              _ -> nil
+              nil
             end
           end)
           |> Stream.filter(& &1)

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -227,11 +227,11 @@ defmodule AeMdw.Db.Sync.Transaction do
     ]
 
     case Contract.get_info(contract_pk) do
-      {:ok, contract_info} ->
+      {:ok, {type_info, _compiler_vsn, _source_hash}} ->
         call_rec = Contract.get_init_call_rec(contract_pk, tx, block_hash)
 
         aex9_meta_info =
-          if Contract.is_aex9?(contract_info) do
+          if Contract.is_aex9?(type_info) do
             Contract.aex9_meta_info(contract_pk)
           end
 


### PR DESCRIPTION
## What

Adds `compiler_version` and `source_hash` to `/txs` response when the tx is a `:contract_create_tx`.

## Why

Resolves #341

## Validation steps

`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/tx_controller_test.exs:79`
`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/tx_controller_test.exs:302`
`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/tx_controller_test.exs`

## Expected result
![image](https://user-images.githubusercontent.com/44991200/149007463-9719f1e9-5b7b-44e7-9a77-773735ccb587.png)
