### PR TITLE
fix: avoid loading block_hash for building oracle tree when syncing

### DIFF
--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -75,6 +75,13 @@ defmodule AeMdw.Blocks do
     end
   end
 
+  @spec block_hash(height()) :: block_hash()
+  def block_hash(height) do
+    Model.block(hash: hash) = Mnesia.fetch!(@table, {height, -1})
+
+    hash
+  end
+
   defp intersect_scopes(scopes, direction) do
     scopes
     |> Enum.reject(&is_nil/1)

--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -3,6 +3,7 @@ defmodule AeMdw.Db.Format do
   alias AeMdw.Node, as: AE
   alias :aeser_api_encoder, as: Enc
 
+  alias AeMdw.Blocks
   alias AeMdw.Contract
   alias AeMdw.Db.Model
   alias AeMdw.Db.Name
@@ -90,7 +91,8 @@ defmodule AeMdw.Db.Format do
     expire_height = Model.oracle(m_oracle, :expire)
 
     kbi = min(expire_height - 1, last_gen())
-    oracle_tree = AeMdw.Db.Oracle.oracle_tree!({kbi, -1})
+    block_hash = Blocks.block_hash(kbi)
+    oracle_tree = AeMdw.Db.Oracle.oracle_tree!(block_hash)
     oracle_rec = :aeo_state_tree.get_oracle(pk, oracle_tree)
 
     %{

--- a/lib/ae_mdw/db/oracle.ex
+++ b/lib/ae_mdw/db/oracle.ex
@@ -83,11 +83,9 @@ defmodule AeMdw.Db.Oracle do
     cache_through_delete(Model.InactiveOracleExpiration, {expire, pubkey})
   end
 
-  @spec oracle_tree!({pos_integer(), integer()}) :: tuple()
-  def oracle_tree!({_, _} = block_index) do
-    block_index
-    |> read_block!
-    |> Model.block(:hash)
+  @spec oracle_tree!(Blocks.block_hash()) :: tuple()
+  def oracle_tree!(block_hash) do
+    block_hash
     |> :aec_db.get_block_state()
     |> :aec_trees.oracles()
   end

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -378,11 +378,12 @@ defmodule AeMdw.Db.Sync.Transaction do
          type: :oracle_response_tx,
          tx: tx,
          txi: txi,
+         block_hash: block_hash,
          block_index: block_index
        }) do
     oracle_pk = :aeo_response_tx.oracle_pubkey(tx)
     query_id = :aeo_response_tx.query_id(tx)
-    o_tree = Oracle.oracle_tree!(block_index)
+    o_tree = Oracle.oracle_tree!(block_hash)
 
     try do
       fee =

--- a/lib/ae_mdw/oracles.ex
+++ b/lib/ae_mdw/oracles.ex
@@ -5,6 +5,7 @@ defmodule AeMdw.Oracles do
 
   require AeMdw.Db.Model
 
+  alias AeMdw.Blocks
   alias AeMdw.Collection
   alias AeMdw.Db.Format
   alias AeMdw.Db.Model
@@ -113,7 +114,8 @@ defmodule AeMdw.Oracles do
 
     kbi = min(expire_height - 1, last_gen)
 
-    oracle_tree = AeMdw.Db.Oracle.oracle_tree!({kbi, -1})
+    block_hash = Blocks.block_hash(kbi)
+    oracle_tree = AeMdw.Db.Oracle.oracle_tree!(block_hash)
     oracle_rec = :aeo_state_tree.get_oracle(pk, oracle_tree)
 
     %{

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -5,6 +5,7 @@ defmodule AeMdwWeb.OracleControllerTest do
 
   require AeMdw.Db.Model
 
+  alias AeMdw.Blocks
   alias AeMdw.Db.Model
   alias AeMdw.Db.Model.ActiveOracleExpiration
   alias AeMdw.Db.Model.InactiveOracleExpiration
@@ -18,6 +19,7 @@ defmodule AeMdwWeb.OracleControllerTest do
     test "it retrieves active oracles first", %{conn: conn} do
       Model.oracle(index: pk) = oracle = TS.oracle()
       encoded_pk = :aeser_api_encoder.encode(:oracle_pubkey, pk)
+      last_gen = TS.last_gen()
 
       with_mocks [
         {Mnesia, [],
@@ -32,16 +34,17 @@ defmodule AeMdwWeb.OracleControllerTest do
              InactiveOracleExpiration, :backward, nil ->
                :none
            end,
-           last_key: fn Block -> {:ok, TS.last_gen()} end,
-           fetch!: fn _tab, _oracle_pk -> oracle end
+           last_key: fn Block -> {:ok, last_gen} end,
+           fetch!: fn _tab, _pk -> oracle end
          ]},
-        {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
+        {Oracle, [], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
         {DbUtil, [],
          [
            last_gen!: fn -> 0 end,
            first_gen!: fn -> 0 end
-         ]}
+         ]},
+        {Blocks, [], [block_hash: fn _height -> "asd" end]}
       ] do
         assert %{"data" => [oracle1 | _rest] = oracles, "next" => next_uri} =
                  conn
@@ -78,13 +81,14 @@ defmodule AeMdwWeb.OracleControllerTest do
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> oracle end
          ]},
-        {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
+        {Oracle, [], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
         {DbUtil, [],
          [
            last_gen!: fn -> 0 end,
            first_gen!: fn -> 0 end
-         ]}
+         ]},
+        {Blocks, [], [block_hash: fn _height -> "asd" end]}
       ] do
         assert %{"data" => [oracle1, _oracle2, _oracle3, _oracle4], "next" => nil} =
                  conn
@@ -110,13 +114,14 @@ defmodule AeMdwWeb.OracleControllerTest do
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> oracle end
          ]},
-        {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
+        {Oracle, [], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
         {DbUtil, [],
          [
            last_gen!: fn -> 0 end,
            first_gen!: fn -> 0 end
-         ]}
+         ]},
+        {Blocks, [], [block_hash: fn _height -> "asd" end]}
       ] do
         assert %{"data" => [oracle1, _oracle2], "next" => nil} =
                  conn
@@ -143,13 +148,14 @@ defmodule AeMdwWeb.OracleControllerTest do
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> TS.oracle() end
          ]},
-        {Oracle, [], [oracle_tree!: fn _bi -> :aeo_state_tree.empty() end]},
+        {Oracle, [], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
         {DbUtil, [],
          [
            last_gen!: fn -> 0 end,
            first_gen!: fn -> 0 end
-         ]}
+         ]},
+        {Blocks, [], [block_hash: fn _height -> "asd" end]}
       ] do
         assert %{"next" => next_uri} = conn |> get("/oracles/active") |> json_response(200)
 


### PR DESCRIPTION
This was causing an error when the oracle register transaction was on
the same micro block as the oracle response transaction, because the
micro block was not found until the transaction was executed.