### PR TITLE
feat: /names/owned_by for inactive names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2046,12 +2046,18 @@ $ curl -s "https://mainnet.aeternity.io/mdw/name/auction/nikita.chain" | jq '.'
 
 ### Names for owner
 
-The endpoint `/names/owned_by/:account` returns names for a given owner.
+The endpoint `/names/owned_by/:account` returns names for a given owner (the active names by default).
 
 The reply has two keys:
 
-- active - listing active (not expired) names belonging to the owner
+- active - listing active (not expired) names belonging to the account
 - top_bid - listing auctions where the owner has placed the highest bid
+
+With paramter active=false, the endpoint returns the inactive names that were owned by the account when it had expired or had been revoked.
+
+In this case the reply has a single key:
+
+- inactive - listing of inactive names objects that belonged to the account
 
 Example below is fabricated, to present the shape of the responses:
 

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -486,7 +486,8 @@ defmodule AeMdw.Db.Model do
       AeMdw.Db.Model.ActiveName,
       AeMdw.Db.Model.InactiveName,
       AeMdw.Db.Model.AuctionOwner,
-      AeMdw.Db.Model.ActiveNameOwner
+      AeMdw.Db.Model.ActiveNameOwner,
+      AeMdw.Db.Model.InactiveNameOwner
     ]
   end
 
@@ -609,6 +610,7 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.InactiveName), do: :name
   def record(AeMdw.Db.Model.AuctionOwner), do: :owner
   def record(AeMdw.Db.Model.ActiveNameOwner), do: :owner
+  def record(AeMdw.Db.Model.InactiveNameOwner), do: :owner
   def record(AeMdw.Db.Model.ActiveOracleExpiration), do: :expiration
   def record(AeMdw.Db.Model.InactiveOracleExpiration), do: :expiration
   def record(AeMdw.Db.Model.ActiveOracle), do: :oracle

--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -95,7 +95,7 @@ defmodule AeMdwWeb.NameController do
   def owned_by(conn, %{"id" => owner} = params),
     do:
       handle_input(conn, fn ->
-        active? = params |> Map.get("active", "true") |> String.to_existing_atom()
+        active? = Map.get(params, "active", "true") == "true"
         owned_by_reply(conn, Validate.id!(owner, [:account_pubkey]), expand?(params), active?)
       end)
 

--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -27,8 +27,6 @@ defmodule AeMdwWeb.NameController do
   ##########
 
   @spec stream_plug_hook(Conn.t()) :: Conn.t()
-  def stream_plug_hook(%Plug.Conn{path_info: ["names", "owned_by" | _]} = conn),
-    do: conn
 
   def stream_plug_hook(%Plug.Conn{path_info: ["names", "active"]} = conn),
     do: conn
@@ -97,7 +95,8 @@ defmodule AeMdwWeb.NameController do
   def owned_by(conn, %{"id" => owner} = params),
     do:
       handle_input(conn, fn ->
-        owned_by_reply(conn, Validate.id!(owner, [:account_pubkey]), expand?(params))
+        active? = params |> Map.get("active", "true") |> String.to_existing_atom()
+        owned_by_reply(conn, Validate.id!(owner, [:account_pubkey]), expand?(params), active?)
       end)
 
   @spec auctions(Conn.t(), map()) :: Conn.t()
@@ -291,8 +290,8 @@ defmodule AeMdwWeb.NameController do
       raise ErrInput.NotFound, value: plain_name
   end
 
-  defp owned_by_reply(conn, owner_pk, expand?) do
-    %{actives: actives, top_bids: top_bids} = Name.owned_by(owner_pk)
+  defp owned_by_reply(conn, owner_pk, expand?, active?) do
+    query_res = Name.owned_by(owner_pk, active?)
 
     jsons = fn plains, source, locator ->
       for plain <- plains, reduce: [] do
@@ -304,16 +303,22 @@ defmodule AeMdwWeb.NameController do
       end
     end
 
-    actives = jsons.(actives, Model.ActiveName, &Name.locate/1)
+    if active? do
+      names = jsons.(query_res.names, Model.ActiveName, &Name.locate/1)
 
-    top_bids =
-      jsons.(
-        top_bids,
-        Model.AuctionBid,
-        &map_some(Name.locate_bid(&1), fn x -> {x, Model.AuctionBid} end)
-      )
+      top_bids =
+        jsons.(
+          query_res.top_bids,
+          Model.AuctionBid,
+          &map_some(Name.locate_bid(&1), fn x -> {x, Model.AuctionBid} end)
+        )
 
-    json(conn, %{"active" => actives, "top_bid" => top_bids})
+      json(conn, %{"active" => names, "top_bid" => top_bids})
+    else
+      names = jsons.(query_res.names, Model.InactiveName, &Name.locate/1)
+
+      json(conn, %{"inactive" => names})
+    end
   end
 
   ##########

--- a/priv/migrations/20220113112001_inactive_name_owner.ex
+++ b/priv/migrations/20220113112001_inactive_name_owner.ex
@@ -1,0 +1,38 @@
+defmodule AeMdw.Migrations.InactiveNameOwner do
+  @moduledoc """
+  Indexes InactiveNameOwner based on owner field for names in InactiveName table.
+  """
+  alias AeMdw.Db.Model
+  alias AeMdw.Log
+
+  require Ex2ms
+  require Model
+
+  @doc """
+  Writes {account_pk, create_txi, contract_pk} aex9 presence and deletes old ones with txi = -1.
+  """
+  @spec run(boolean()) :: {:ok, {pos_integer(), pos_integer()}}
+  def run(_from_start?) do
+    begin = DateTime.utc_now()
+
+    indexed_count = :mnesia.sync_dirty(fn ->
+      any_spec =
+        Ex2ms.fun do
+          record -> record
+        end
+
+      Model.InactiveName
+      |> :mnesia.select(any_spec, :read)
+      |> Enum.map(fn Model.name(index: plain_name, owner: owner) ->
+        m_owner = Model.owner(index: {owner, plain_name})
+        :mnesia.write(Model.InactiveNameOwner, m_owner, :write)
+      end)
+      |> Enum.count()
+    end)
+
+    duration = DateTime.diff(DateTime.utc_now(), begin)
+    Log.info("Indexed #{indexed_count} records in #{duration}s")
+
+    {:ok, {indexed_count, duration}}
+  end
+end

--- a/priv/migrations/20220113112001_inactive_name_owner.ex
+++ b/priv/migrations/20220113112001_inactive_name_owner.ex
@@ -11,7 +11,7 @@ defmodule AeMdw.Migrations.InactiveNameOwner do
   @doc """
   Writes {account_pk, create_txi, contract_pk} aex9 presence and deletes old ones with txi = -1.
   """
-  @spec run(boolean()) :: {:ok, {pos_integer(), pos_integer()}}
+  @spec run(boolean()) :: {:ok, {non_neg_integer(), non_neg_integer()}}
   def run(_from_start?) do
     begin = DateTime.utc_now()
 

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -771,15 +771,27 @@ defmodule AeMdwWeb.NameControllerTest do
   end
 
   describe "owned_by" do
-    test "get name information for given acount/owner", %{conn: conn} do
+    test "get active names for given account/owner", %{conn: conn} do
       id = "ak_2VMBcnJQgzQQeQa6SgCgufYiRqgvoY9dXHR11ixqygWnWGfSah"
       owner_id = Validate.id!(id)
 
       with_mocks [
-        {Name, [], [owned_by: fn ^owner_id -> %{actives: [], top_bids: []} end]}
+        {Name, [], [owned_by: fn ^owner_id, true -> %{names: [], top_bids: []} end]}
       ] do
         assert %{"active" => [], "top_bid" => []} =
                  conn |> get("/names/owned_by/#{id}") |> json_response(200)
+      end
+    end
+
+    test "get inactive names for given account/owner", %{conn: conn} do
+      id = "ak_2VMBcnJQgzQQeQa6SgCgufYiRqgvoY9dXHR11ixqygWnWGfSah"
+      owner_id = Validate.id!(id)
+
+      with_mocks [
+        {Name, [], [owned_by: fn ^owner_id, false -> %{names: []} end]}
+      ] do
+        assert %{"inactive" => []} =
+                 conn |> get("/names/owned_by/#{id}?active=false") |> json_response(200)
       end
     end
 


### PR DESCRIPTION
## What

Add/handle `active` parameter on `/name/owned_by` to return active or inactive names (last ownership of expired or revoked names).

## Why

Resolves #157 

## Validation steps

`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/name_controller_test.exs:544`
`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw_web/controllers/name_controller_test.exs`