### PR TITLE
fix: skip processing internal calls for Chain.* events

### DIFF
--- a/test/ae_mdw/db/sync/contract_test.exs
+++ b/test/ae_mdw/db/sync/contract_test.exs
@@ -72,13 +72,13 @@ defmodule AeMdw.Db.Sync.ContractTest do
       mutation_1 =
         MnesiaWriteMutation.new(
           Model.FnameIntContractCall,
-          Model.fname_int_contract_call(index: {"Call.amount", 3, 1})
+          Model.fname_int_contract_call(index: {"Call.amount", 3, 0})
         )
 
       mutation_2 =
         MnesiaWriteMutation.new(
           Model.FnameIntContractCall,
-          Model.fname_int_contract_call(index: {"Chain.clone", 3, 2})
+          Model.fname_int_contract_call(index: {"Call.amount", 3, 1})
         )
 
       with_mocks [


### PR DESCRIPTION
I hadn't realized back then, but the Chain.create and Chain.clone
events don't have a valid trasaction associated to them in the event
map info.