### PR TITLE
feat: index AENS internal calls

### DIFF
--- a/lib/ae_mdw/db/mutations/name_claim_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_claim_mutation.ex
@@ -12,11 +12,9 @@ defmodule AeMdw.Db.NameClaimMutation do
   alias AeMdw.Ets
   alias AeMdw.Log
   alias AeMdw.Names
-  alias AeMdw.Node
   alias AeMdw.Node.Db
   alias AeMdw.Txs
   alias AeMdw.Util
-  alias AeMdw.Validate
 
   require Logger
   require Model
@@ -44,19 +42,16 @@ defmodule AeMdw.Db.NameClaimMutation do
           }
 
   @spec new(
-          tuple(),
+          Names.plain_name(),
+          Names.name_hash(),
+          Db.pubkey(),
+          Names.name_fee(),
+          boolean(),
           Txs.txi(),
-          Blocks.block_index()
+          Blocks.block_index(),
+          Names.auction_timeout()
         ) :: t()
-  def new(tx, txi, {height, _mbi} = block_index) do
-    plain_name = String.downcase(:aens_claim_tx.name(tx))
-    {:ok, name_hash} = :aens.get_name_hash(plain_name)
-    owner_pk = Validate.id!(:aens_claim_tx.account_id(tx))
-    name_fee = :aens_claim_tx.name_fee(tx)
-    proto_vsn = DbUtil.proto_vsn(height)
-    is_lima? = proto_vsn >= Node.lima_vsn()
-    timeout = :aec_governance.name_claim_bid_timeout(plain_name, proto_vsn)
-
+  def new(plain_name, name_hash, owner_pk, name_fee, is_lima?, txi, block_index, timeout) do
     %__MODULE__{
       plain_name: plain_name,
       name_hash: name_hash,

--- a/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
@@ -6,6 +6,7 @@ defmodule AeMdw.Db.NameTransferMutation do
   alias AeMdw.Blocks
   alias AeMdw.Db.Sync.Name
   alias AeMdw.Names
+  alias AeMdw.Node
   alias AeMdw.Node.Db
   alias AeMdw.Txs
 
@@ -18,10 +19,10 @@ defmodule AeMdw.Db.NameTransferMutation do
             block_index: Blocks.block_index()
           }
 
-  @spec new(tuple(), Txs.txi(), Blocks.block_index()) :: t()
-  def new(ns_transfer_tx, txi, block_index) do
-    name_hash = :aens_transfer_tx.name_id(ns_transfer_tx)
-    new_owner = :aens_transfer_tx.recipient_pubkey(ns_transfer_tx)
+  @spec new(Node.tx(), Txs.txi(), Blocks.block_index()) :: t()
+  def new(tx, txi, block_index) do
+    name_hash = :aens_transfer_tx.name_id(tx)
+    new_owner = :aens_transfer_tx.recipient_pubkey(tx)
 
     %__MODULE__{
       name_hash: name_hash,

--- a/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
@@ -18,8 +18,11 @@ defmodule AeMdw.Db.NameTransferMutation do
             block_index: Blocks.block_index()
           }
 
-  @spec new(Names.name_hash(), Db.pubkey(), Txs.txi(), Blocks.block_index()) :: t()
-  def new(name_hash, new_owner, txi, block_index) do
+  @spec new(tuple(), Txs.txi(), Blocks.block_index()) :: t()
+  def new(ns_transfer_tx, txi, block_index) do
+    name_hash = :aens_transfer_tx.name_id(ns_transfer_tx)
+    new_owner = :aens_transfer_tx.recipient_pubkey(ns_transfer_tx)
+
     %__MODULE__{
       name_hash: name_hash,
       new_owner: new_owner,

--- a/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
@@ -21,7 +21,7 @@ defmodule AeMdw.Db.NameTransferMutation do
 
   @spec new(Node.tx(), Txs.txi(), Blocks.block_index()) :: t()
   def new(tx, txi, block_index) do
-    name_hash = :aens_transfer_tx.name_id(tx)
+    name_hash = :aens_transfer_tx.name_hash(tx)
     new_owner = :aens_transfer_tx.recipient_pubkey(tx)
 
     %__MODULE__{

--- a/lib/ae_mdw/db/mutations/name_update_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_update_mutation.ex
@@ -18,9 +18,12 @@ defmodule AeMdw.Db.NameUpdateMutation do
             block_index: Blocks.block_index()
           }
 
-  @spec new(Names.name_hash(), Names.ttl(), Names.pointers(), Txs.txi(), Blocks.block_index()) ::
-          t()
-  def new(name_hash, name_ttl, pointers, txi, block_index) do
+  @spec new(tuple(), Txs.txi(), Blocks.block_index()) :: t()
+  def new(tx, txi, block_index) do
+    name_hash = :aens_update_tx.name_hash(tx)
+    name_ttl = :aens_update_tx.name_ttl(tx)
+    pointers = :aens_update_tx.pointers(tx)
+
     %__MODULE__{
       name_hash: name_hash,
       name_ttl: name_ttl,

--- a/lib/ae_mdw/db/mutations/name_update_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_update_mutation.ex
@@ -6,6 +6,7 @@ defmodule AeMdw.Db.NameUpdateMutation do
   alias AeMdw.Blocks
   alias AeMdw.Db.Sync.Name
   alias AeMdw.Names
+  alias AeMdw.Node
   alias AeMdw.Txs
 
   defstruct [:name_hash, :name_ttl, :pointers, :txi, :block_index]
@@ -18,7 +19,7 @@ defmodule AeMdw.Db.NameUpdateMutation do
             block_index: Blocks.block_index()
           }
 
-  @spec new(tuple(), Txs.txi(), Blocks.block_index()) :: t()
+  @spec new(Node.tx(), Txs.txi(), Blocks.block_index()) :: t()
   def new(tx, txi, block_index) do
     name_hash = :aens_update_tx.name_hash(tx)
     name_ttl = :aens_update_tx.name_ttl(tx)

--- a/lib/ae_mdw/db/mutations/write_field_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_field_mutation.ex
@@ -12,13 +12,14 @@ defmodule AeMdw.Db.WriteFieldMutation do
 
   defstruct [:tx_type, :pos, :pubkey, :txi]
 
+  @type pos() :: non_neg_integer() | nil
+
   @typep tx_type() ::
            :contract_create_tx
            | :channel_create_tx
            | :ga_attach_tx
            | :oracle_register_tx
            | :name_claim_tx
-  @typep pos() :: non_neg_integer() | nil
 
   @opaque t() :: %__MODULE__{
             tx_type: tx_type(),

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -222,17 +222,21 @@ defmodule AeMdw.Db.Name do
     end
   end
 
-  def ownership(m_name) do
-    [{{_, _}, last_claim_txi} | _] = Model.name(m_name, :claims)
+  def ownership(
+        Model.name(
+          claims: [{{_height, _mbi}, last_claim_txi} | _other],
+          transfers: transfers,
+          owner: owner
+        )
+      ) do
     %{tx: %{account_id: orig_owner}} = Format.to_raw_map(read_tx!(last_claim_txi))
 
-    case Model.name(m_name, :transfers) do
-      [] ->
+    case List.first(transfers) do
+      nil ->
         %{original: orig_owner, current: orig_owner}
 
-      [{{_, _}, last_transfer_txi} | _] ->
-        %{tx: %{recipient_id: curr_owner}} = Format.to_raw_map(read_tx!(last_transfer_txi))
-        %{original: orig_owner, current: curr_owner}
+      _any_transfer ->
+        %{original: orig_owner, current: :aeser_api_encoder.encode(:account_pubkey, owner)}
     end
   end
 

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -7,7 +7,12 @@ defmodule AeMdw.Db.Sync.Contract do
   alias AeMdw.Db.MnesiaWriteMutation
   alias AeMdw.Db.Model
   alias AeMdw.Db.Mutation
+  alias AeMdw.Db.NameUpdateMutation
+  alias AeMdw.Db.NameTransferMutation
+  alias AeMdw.Db.NameRevokeMutation
+  alias AeMdw.Db.OracleRegisterMutation
   alias AeMdw.Db.Origin
+  alias AeMdw.Db.Sync.Name
   alias AeMdw.Node.Db
   alias AeMdw.Sync.AsyncTasks
   alias AeMdw.Txs
@@ -44,8 +49,10 @@ defmodule AeMdw.Db.Sync.Contract do
     :ok
   end
 
-  @spec events_mutations([Contract.event()], Txs.txi(), Txs.txi()) :: [Mutation.t()]
-  def events_mutations(events, call_txi, create_txi) do
+  @spec events_mutations([Contract.event()], Blocks.block_index(), Txs.txi(), Txs.txi()) :: [
+          Mutation.t()
+        ]
+  def events_mutations(events, block_index, call_txi, create_txi) do
     shifted_events = events |> Enum.drop(1) |> Enum.concat([nil])
 
     # This function relies on a property that every Chain.clone and Chain.create
@@ -79,7 +86,8 @@ defmodule AeMdw.Db.Sync.Contract do
         DBContract.int_call_write_mutations(create_txi, call_txi, i, fname, tx)
       end)
 
-    chain_mutations ++ non_chain_mutations
+    chain_mutations ++
+      oracle_and_name_mutations(events, block_index, call_txi) ++ non_chain_mutations
   end
 
   @spec get_txi(Db.pubkey()) :: integer()
@@ -98,5 +106,44 @@ defmodule AeMdw.Db.Sync.Contract do
             txi
         end
     end
+  end
+
+  defp oracle_and_name_mutations(events, {height, _mbi} = block_index, call_txi) do
+    events
+    |> Enum.filter(fn
+      {{:internal_call_tx, "Oracle.register"}, _info} -> true
+      {{:internal_call_tx, "AENS.update"}, _info} -> true
+      {{:internal_call_tx, "AENS.transfer"}, _info} -> true
+      {{:internal_call_tx, "AENS.revoke"}, _info} -> true
+      _int_call -> false
+    end)
+    |> Enum.map(fn
+      {{:internal_call_tx, "Oracle.register"}, %{info: aetx}} ->
+        {:oracle_register_tx, tx} = :aetx.specialize_type(aetx)
+        oracle_pk = :aeo_register_tx.account_pubkey(tx)
+        delta_ttl = :aeo_utils.ttl_delta(height, :aeo_register_tx.oracle_ttl(tx))
+        expire = height + delta_ttl
+
+        OracleRegisterMutation.new(oracle_pk, block_index, expire, call_txi)
+
+      {{:internal_call_tx, "AENS.claim"}, %{info: aetx, tx_hash: tx_hash}} ->
+        {:name_claim_tx, tx} = :aetx.specialize_type(aetx)
+        Name.name_claim_mutations(tx, tx_hash, block_index, call_txi)
+
+      {{:internal_call_tx, "AENS.update"}, %{info: aetx}} ->
+        {:name_update_tx, tx} = :aetx.specialize_type(aetx)
+        NameUpdateMutation.new(tx, call_txi, block_index)
+
+      {{:internal_call_tx, "AENS.transfer"}, %{info: aetx}} ->
+        {:name_transfer_tx, tx} = :aetx.specialize_type(aetx)
+        NameTransferMutation.new(tx, call_txi, block_index)
+
+      {{:internal_call_tx, "AENS.revoke"}, %{info: aetx}} ->
+        {:name_revoke_tx, tx} = :aetx.specialize_type(aetx)
+
+        tx
+        |> :aens_revoke_tx.name_hash()
+        |> NameRevokeMutation.new(call_txi, block_index)
+    end)
   end
 end

--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -4,6 +4,7 @@ defmodule AeMdw.Db.Sync.Name do
   alias AeMdw.Blocks
   alias AeMdw.Db.Format
   alias AeMdw.Db.Model
+  alias AeMdw.Db.Mutation
   alias AeMdw.Db.Name
   alias AeMdw.Db.NameClaimMutation
   alias AeMdw.Db.Sync.Origin
@@ -29,9 +30,7 @@ defmodule AeMdw.Db.Sync.Name do
   import AeMdw.Ets
   import AeMdw.Util
 
-  @spec name_claim_mutations(Node.tx(), Txs.tx_hash(), Blocks.block_index(), Txs.txi()) :: [
-          Mutation.t()
-        ]
+  @spec name_claim_mutations(Node.tx(), any(), Blocks.block_index(), Txs.txi()) :: [Mutation.t()]
   def name_claim_mutations(tx, tx_hash, block_index, txi) do
     {:ok, name_hash} =
       tx

--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -30,7 +30,9 @@ defmodule AeMdw.Db.Sync.Name do
   import AeMdw.Ets
   import AeMdw.Util
 
-  @spec name_claim_mutations(Node.tx(), any(), Blocks.block_index(), Txs.txi()) :: [Mutation.t()]
+  @spec name_claim_mutations(Node.tx(), Txs.tx_hash(), Blocks.block_index(), Txs.txi()) :: [
+          Mutation.t()
+        ]
   def name_claim_mutations(tx, tx_hash, {height, _mbi} = block_index, txi) do
     plain_name = String.downcase(:aens_claim_tx.name(tx))
     {:ok, name_hash} = :aens.get_name_hash(plain_name)

--- a/lib/ae_mdw/db/sync/origin.ex
+++ b/lib/ae_mdw/db/sync/origin.ex
@@ -9,6 +9,7 @@ defmodule AeMdw.Db.Sync.Origin do
   alias AeMdw.Db.Mutation
   alias AeMdw.Db.MnesiaWriteMutation
   alias AeMdw.Db.WriteFieldMutation
+  alias AeMdw.Txs
 
   require Model
 

--- a/lib/ae_mdw/db/sync/origin.ex
+++ b/lib/ae_mdw/db/sync/origin.ex
@@ -13,15 +13,13 @@ defmodule AeMdw.Db.Sync.Origin do
 
   require Model
 
-  # @type origin_mutations :: [MnesiaWriteMutation.t() | WriteFieldMutation.t()]
-
   @spec origin_mutations(
           Node.tx_type(),
           WriteFieldMutation.pos(),
           NodeDb.pubkey(),
           Txs.txi(),
           Txs.tx_hash()
-        ) :: Mutation.t()
+        ) :: [Mutation.t()]
   def origin_mutations(tx_type, pos, pubkey, txi, tx_hash) do
     m_origin = Model.origin(index: {tx_type, pubkey, txi}, tx_id: tx_hash)
     m_rev_origin = Model.rev_origin(index: {txi, tx_type, pubkey})

--- a/lib/ae_mdw/db/sync/origin.ex
+++ b/lib/ae_mdw/db/sync/origin.ex
@@ -1,0 +1,34 @@
+defmodule AeMdw.Db.Sync.Origin do
+  @moduledoc """
+  Generates a list of Origin related mutations to map a transactions object/pubkey to a txi and inversely too.
+  """
+
+  alias AeMdw.Node
+  alias AeMdw.Node.Db, as: NodeDb
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Mutation
+  alias AeMdw.Db.MnesiaWriteMutation
+  alias AeMdw.Db.WriteFieldMutation
+
+  require Model
+
+  # @type origin_mutations :: [MnesiaWriteMutation.t() | WriteFieldMutation.t()]
+
+  @spec origin_mutations(
+          Node.tx_type(),
+          WriteFieldMutation.pos(),
+          NodeDb.pubkey(),
+          Txs.txi(),
+          Txs.tx_hash()
+        ) :: Mutation.t()
+  def origin_mutations(tx_type, pos, pubkey, txi, tx_hash) do
+    m_origin = Model.origin(index: {tx_type, pubkey, txi}, tx_id: tx_hash)
+    m_rev_origin = Model.rev_origin(index: {txi, tx_type, pubkey})
+
+    [
+      MnesiaWriteMutation.new(Model.Origin, m_origin),
+      MnesiaWriteMutation.new(Model.RevOrigin, m_rev_origin),
+      WriteFieldMutation.new(tx_type, pos, pubkey, txi)
+    ]
+  end
+end

--- a/lib/ae_mdw/log.ex
+++ b/lib/ae_mdw/log.ex
@@ -8,7 +8,7 @@ defmodule AeMdw.Log do
 
   @spec info(String.t()) :: :ok
   def info(msg),
-    do: Logger.info(msg, sync: true)
+    do: Logger.info(msg)
 
   @spec warn(String.t()) :: :ok
   def warn(msg),

--- a/test/integration/ae_mdw/db/sync/contract_test.exs
+++ b/test/integration/ae_mdw/db/sync/contract_test.exs
@@ -1,0 +1,74 @@
+defmodule AeMdw.Db.Sync.ContractTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  alias AeMdw.Contract
+  alias AeMdw.Node.Db, as: NodeDb
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.NameTransferMutation
+  alias AeMdw.Db.NameUpdateMutation
+  alias AeMdw.Db.Sync
+
+  require Model
+
+  describe "events_mutations/4" do
+    test "creates name transfer mutation" do
+      {"AENS.transfer", call_txi, _local_idx} =
+        :mnesia.dirty_next(Model.FnameIntContractCall, {"AENS.transfer", -1, -1})
+
+      [Model.tx(block_index: {height, mbi} = block_index, id: tx_hash)] =
+        :mnesia.dirty_read(Model.Tx, call_txi)
+
+      {_key_block, micro_blocks} = NodeDb.get_blocks(height)
+
+      event_mutations =
+        micro_blocks
+        |> Enum.at(mbi)
+        |> Contract.get_grouped_events()
+        |> Map.fetch!(tx_hash)
+        |> Sync.Contract.events_mutations(block_index, call_txi, -1)
+        |> List.flatten()
+
+      assert Enum.any?(event_mutations, fn
+               %NameTransferMutation{
+                 txi: ^call_txi,
+                 block_index: ^block_index
+               } ->
+                 true
+
+               %{} ->
+                 false
+             end)
+    end
+
+    test "creates name update mutation" do
+      {"AENS.update", call_txi, _local_idx} =
+        :mnesia.dirty_next(Model.FnameIntContractCall, {"AENS.update", -1, -1})
+
+      [Model.tx(block_index: {height, mbi} = block_index, id: tx_hash)] =
+        :mnesia.dirty_read(Model.Tx, call_txi)
+
+      {_key_block, micro_blocks} = NodeDb.get_blocks(height)
+
+      event_mutations =
+        micro_blocks
+        |> Enum.at(mbi)
+        |> Contract.get_grouped_events()
+        |> Map.fetch!(tx_hash)
+        |> Sync.Contract.events_mutations(block_index, call_txi, -1)
+        |> List.flatten()
+
+      assert Enum.any?(event_mutations, fn
+               %NameUpdateMutation{
+                 txi: ^call_txi,
+                 block_index: ^block_index
+               } ->
+                 true
+
+               %{} ->
+                 false
+             end)
+    end
+  end
+end

--- a/test/integration/ae_mdw/db/sync/contract_test.exs
+++ b/test/integration/ae_mdw/db/sync/contract_test.exs
@@ -1,4 +1,4 @@
-defmodule AeMdw.Db.Sync.ContractTest do
+defmodule Integration.AeMdw.Db.Sync.ContractTest do
   use ExUnit.Case, async: false
 
   @moduletag :integration

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -459,8 +459,16 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
   end
 
   describe "name" do
-    test "get name info by name", %{conn: conn} do
+    test "get info by plain name", %{conn: conn} do
       name = "wwwbeaconoidcom.chain"
+      conn = get(conn, "/name/#{name}")
+
+      assert json_response(conn, 200) ==
+               TestUtil.handle_input(fn -> get_name(Validate.plain_name!(name)) end)
+    end
+
+    test "get by plain name a name with transfer by internal call", %{conn: conn} do
+      name = "888888888888.chain"
       conn = get(conn, "/name/#{name}")
 
       assert json_response(conn, 200) ==


### PR DESCRIPTION
## Why

Resolves #408

## Validation steps

`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw/db/sync/contract_test.exs`

Note: Please notice that name internal calls cannot be migrated because the effect of every operation depends on the state of the name at the microblock that it happened. It cannot neither be discard if old because name record tracks a history of all operations. For these reasons this feature requires a **full sync**.