### PR TITLE
perf: remove duplicate logging

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -78,10 +78,6 @@ config :logger, :info,
   path: "#{Path.join(File.cwd!(), "log/info.log")}",
   format: "$date $time $metadata[$level] $message\n"
 
-config :logger, :sync,
-  path: "#{Path.join(File.cwd!(), "log/sync.log")}",
-  metadata_filter: [sync: true]
-
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -76,7 +76,8 @@ config :logger,
 
 config :logger, :info,
   path: "#{Path.join(File.cwd!(), "log/info.log")}",
-  format: "$date $time $metadata[$level] $message\n"
+  format: "$date $time $metadata[$level] $message\n",
+  sync_threshold: 100
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/lib/ae_mdw/log.ex
+++ b/lib/ae_mdw/log.ex
@@ -8,16 +8,16 @@ defmodule AeMdw.Log do
 
   @spec info(String.t()) :: :ok
   def info(msg),
-    do: Logger.info(msg, sync: true)
+    do: Logger.info(msg)
 
   @spec warn(String.t()) :: :ok
   def warn(msg),
-    do: Logger.warn(msg, sync: true)
+    do: Logger.warn(msg)
 
   @spec error(String.t() | exception()) :: :ok
   def error(msg) when is_binary(msg),
-    do: Logger.error(msg, sync: true)
+    do: Logger.error(msg)
 
   def error(msg),
-    do: Logger.error(inspect(msg, sync: true))
+    do: Logger.error(inspect(msg))
 end

--- a/priv/migrations/20211124092400_reindex_int_transfers_acc_index.ex
+++ b/priv/migrations/20211124092400_reindex_int_transfers_acc_index.ex
@@ -116,5 +116,5 @@ defmodule AeMdw.Migrations.ReindexIntTransfersAccIndex do
     indexed_count
   end
 
-  defp log(msg), do: Logger.info("[ReindexIntTransfersAccIndex migration] #{msg}", sync: true)
+  defp log(msg), do: Logger.info("[ReindexIntTransfersAccIndex migration] #{msg}")
 end


### PR DESCRIPTION
## What/Why

- removes log/sync.log because all info is present in log/info.log
- increases Logger threshold to enter in synchronous mode (when it slows down mdw sync process)