### PR TITLE
perf: mnesia table count based on keys

### DIFF
--- a/lib/ae_mdw/db/util.ex
+++ b/lib/ae_mdw/db/util.ex
@@ -94,7 +94,7 @@ defmodule AeMdw.Db.Util do
     do: :mnesia.async_dirty(fn -> :mnesia.select(cont) end)
 
   def count(table),
-    do: :mnesia.foldl(fn _, c -> c + 1 end, 0, table)
+    do: :mnesia.dirty_all_keys(table) |> length()
 
   def ensure_key!(tab, getter) do
     case apply(__MODULE__, getter, [tab]) do


### PR DESCRIPTION
## What

Changes table count to use the number of keys.

## Why

Solves this test timeout and the alternative of `:mnesia.table_info` returns 0 after starting the Mdw:
```
  1) test new_mutation/2 with all_cached? = false and 1 block reward (Integration.AeMdw.Db.Sync.StatsTest)
     test/integration/ae_mdw/sync/stats_test.exs:16
     ** (ExUnit.TimeoutError) test timed out after 60000ms. You can change the timeout:
```

## Validation steps
`elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw/sync/stats_test.exs:16`