### PR TITLE
fix: name update expiring a name

### DIFF
--- a/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
@@ -10,11 +10,12 @@ defmodule AeMdw.Db.NameTransferMutation do
   alias AeMdw.Node.Db
   alias AeMdw.Txs
 
-  defstruct [:name_hash, :new_owner, :txi, :block_index]
+  defstruct [:name_hash, :new_owner, :new_ttl, :txi, :block_index]
 
   @opaque t() :: %__MODULE__{
             name_hash: Names.name_hash(),
             new_owner: Db.pubkey(),
+            new_ttl: pos_integer(),
             txi: Txs.txi(),
             block_index: Blocks.block_index()
           }
@@ -23,10 +24,12 @@ defmodule AeMdw.Db.NameTransferMutation do
   def new(tx, txi, block_index) do
     name_hash = :aens_transfer_tx.name_hash(tx)
     new_owner = :aens_transfer_tx.recipient_pubkey(tx)
+    new_ttl = :aens_transfer_tx.ttl(tx)
 
     %__MODULE__{
       name_hash: name_hash,
       new_owner: new_owner,
+      new_ttl: new_ttl,
       txi: txi,
       block_index: block_index
     }
@@ -36,10 +39,11 @@ defmodule AeMdw.Db.NameTransferMutation do
   def mutate(%__MODULE__{
         name_hash: name_hash,
         new_owner: new_owner,
+        new_ttl: new_ttl,
         txi: txi,
         block_index: block_index
       }) do
-    Name.transfer(name_hash, new_owner, txi, block_index)
+    Name.transfer(name_hash, new_owner, new_ttl, txi, block_index)
   end
 end
 


### PR DESCRIPTION
## What

~~Handles `:aens_transfer_tx` ttl.~~

## Why

~~Names expiration is not taking it into account causing a sync **blocker** issue (but maybe not the only cause).~~
~~Fixes #485~~

## Validation steps

0. Add this sleep after this line [sync_generation](https://github.com/aeternity/ae_mdw/blob/2040900421f1ed2294a83b1d2743eecc697d92bd/lib/ae_mdw/db/sync/transaction.ex#L160):
`if height == 42319 || height == 42320, do: Process.sleep(60_000)`
1. Restart sync from 0
2. Check that after height 42320 [`test.test`](http://localhost:4000/name/test.test) has a new expire equal to this [name_transfer ttl](https://mainnet.test.aeternity.art/mdw/txs/forward?cursor=720073&limit=1&type=name_transfer).