### PR TITLE
fix: name expiration after aens.update with name_ttl = 0

### DIFF
--- a/lib/ae_mdw/db/mutations/name_update_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_update_mutation.ex
@@ -9,18 +9,19 @@ defmodule AeMdw.Db.NameUpdateMutation do
   alias AeMdw.Node
   alias AeMdw.Txs
 
-  defstruct [:name_hash, :name_ttl, :pointers, :txi, :block_index]
+  defstruct [:name_hash, :name_ttl, :pointers, :txi, :block_index, :internal?]
 
   @opaque t() :: %__MODULE__{
             name_hash: Names.name_hash(),
             name_ttl: Names.ttl(),
             pointers: Names.pointers(),
             txi: Txs.txi(),
-            block_index: Blocks.block_index()
+            block_index: Blocks.block_index(),
+            internal?: boolean()
           }
 
-  @spec new(Node.tx(), Txs.txi(), Blocks.block_index()) :: t()
-  def new(tx, txi, block_index) do
+  @spec new(Node.tx(), Txs.txi(), Blocks.block_index(), boolean()) :: t()
+  def new(tx, txi, block_index, internal? \\ false) do
     name_hash = :aens_update_tx.name_hash(tx)
     name_ttl = :aens_update_tx.name_ttl(tx)
     pointers = :aens_update_tx.pointers(tx)
@@ -30,7 +31,8 @@ defmodule AeMdw.Db.NameUpdateMutation do
       name_ttl: name_ttl,
       pointers: pointers,
       txi: txi,
-      block_index: block_index
+      block_index: block_index,
+      internal?: internal?
     }
   end
 
@@ -40,9 +42,10 @@ defmodule AeMdw.Db.NameUpdateMutation do
         name_ttl: name_ttl,
         pointers: pointers,
         txi: txi,
-        block_index: block_index
+        block_index: block_index,
+        internal?: internal?
       }) do
-    Name.update(name_hash, name_ttl, pointers, txi, block_index)
+    Name.update(name_hash, name_ttl, pointers, txi, block_index, internal?)
   end
 end
 

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -147,7 +147,7 @@ defmodule AeMdw.Db.Sync.Contract do
 
       {{:internal_call_tx, "AENS.update"}, %{info: aetx}} ->
         {:name_update_tx, tx} = :aetx.specialize_type(aetx)
-        NameUpdateMutation.new(tx, call_txi, block_index)
+        NameUpdateMutation.new(tx, call_txi, block_index, true)
 
       {{:internal_call_tx, "AENS.transfer"}, %{info: aetx}} ->
         {:name_transfer_tx, tx} = :aetx.specialize_type(aetx)


### PR DESCRIPTION
## What

Don't expire a name on update with `name_ttl` = 0 after `AENS.update` internall call.

## Why

Fixes #490 

PS: The contract call with the AENS.update internal call has succeeded. 
https://mainnet.aeternity.io/mdw/txi/23198023