### PR TITLE
refactor: extract range independently of the direction requested

### DIFF
--- a/lib/ae_mdw/collection.ex
+++ b/lib/ae_mdw/collection.ex
@@ -33,7 +33,12 @@ defmodule AeMdw.Collection do
   """
   @spec stream(table(), direction(), scope(), cursor()) :: Enumerable.t()
   def stream(tab, direction, scope, cursor) do
-    {first, last} = scope || {nil, nil}
+    {first, last} =
+      case {scope, direction} do
+        {nil, _dir} -> {nil, nil}
+        {s, :forward} -> s
+        {{last, first}, :backward} -> {first, last}
+      end
 
     case fetch_first_key(tab, direction, first, cursor) do
       {:ok, first_key} -> unfold_stream(tab, direction, first_key, last)

--- a/lib/ae_mdw/oracles.ex
+++ b/lib/ae_mdw/oracles.ex
@@ -9,9 +9,10 @@ defmodule AeMdw.Oracles do
   alias AeMdw.Collection
   alias AeMdw.Db.Format
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Util
+  alias AeMdw.Db.Util, as: DBUtil
   alias AeMdw.Mnesia
   alias AeMdw.Node
+  alias AeMdw.Util
 
   @type cursor :: binary()
   # This needs to be an actual type like AeMdw.Db.Oracle.t()
@@ -35,11 +36,7 @@ defmodule AeMdw.Oracles do
           nil
 
         {:gen, %Range{first: first_gen, last: last_gen}} ->
-          if direction == :forward do
-            {{first_gen, <<>>}, {last_gen, <<>>}}
-          else
-            {{first_gen, nil}, {last_gen, nil}}
-          end
+          {{first_gen, Util.min_bin()}, {last_gen, Util.max_256bit_bin()}}
       end
 
     active_stream =
@@ -151,5 +148,5 @@ defmodule AeMdw.Oracles do
   end
 
   defp expand_txi(bi_txi, false), do: bi_txi
-  defp expand_txi(bi_txi, true), do: Format.to_map(Util.read_tx!(bi_txi))
+  defp expand_txi(bi_txi, true), do: Format.to_map(DBUtil.read_tx!(bi_txi))
 end

--- a/lib/ae_mdw/stats.ex
+++ b/lib/ae_mdw/stats.ex
@@ -27,7 +27,7 @@ defmodule AeMdw.Stats do
   def fetch_stats(direction, range, cursor, limit) do
     {:ok, last_gen} = Mnesia.last_key(AeMdw.Db.Model.Stat)
 
-    range_scope = deserialize_scope(range)
+    range_scope = deserialize_scope(range, direction)
 
     cursor_scope =
       case deserialize_cursor(cursor) do
@@ -53,7 +53,7 @@ defmodule AeMdw.Stats do
   def fetch_sum_stats(direction, range, cursor, limit) do
     {:ok, last_gen} = Mnesia.last_key(AeMdw.Db.Model.SumStat)
 
-    range_scope = deserialize_scope(range)
+    range_scope = deserialize_scope(range, direction)
 
     cursor_scope =
       case deserialize_cursor(cursor) do
@@ -121,8 +121,11 @@ defmodule AeMdw.Stats do
     end
   end
 
-  defp deserialize_scope(nil), do: nil
+  defp deserialize_scope(nil, _direction), do: nil
 
-  defp deserialize_scope({:gen, %Range{first: first_gen, last: last_gen}}),
+  defp deserialize_scope({:gen, %Range{first: first_gen, last: last_gen}}, :forward),
     do: {first_gen, last_gen}
+
+  defp deserialize_scope({:gen, %Range{first: first_gen, last: last_gen}}, :backward),
+    do: {last_gen, first_gen}
 end

--- a/lib/ae_mdw/util.ex
+++ b/lib/ae_mdw/util.ex
@@ -273,9 +273,20 @@ defmodule AeMdw.Util do
     )
   end
 
+  @spec max_256bit_int() :: integer()
   def max_256bit_int(),
     do: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 
+  @spec max_256bit_bin() :: binary()
+  def max_256bit_bin(), do: <<max_256bit_int()::256>>
+
+  @spec min_int() :: integer()
+  def min_int(), do: -100
+
+  @spec min_bin() :: binary()
+  def min_bin(), do: <<>>
+
+  @spec contains_unicode?(binary()) :: boolean()
   def contains_unicode?(string) do
     string
     |> String.codepoints()
@@ -290,6 +301,7 @@ defmodule AeMdw.Util do
     )
   end
 
+  @spec with_sync_off(fun()) :: :ok
   def with_sync_off(fun) when is_function(fun, 0) do
     try do
       AeMdw.Application.sync(false)

--- a/lib/ae_mdw_web/plugs/paginated_plug.ex
+++ b/lib/ae_mdw_web/plugs/paginated_plug.ex
@@ -57,7 +57,7 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
   defp extract_direction_and_scope(%{"range_or_dir" => range}) do
     case extract_range(range) do
       {:ok, first, last} when first <= last -> {:ok, :forward, {:gen, first..last}}
-      {:ok, first, last} -> {:ok, :backward, {:gen, first..last}}
+      {:ok, first, last} -> {:ok, :backward, {:gen, last..first}}
       {:error, reason} -> {:error, reason}
     end
   end
@@ -68,7 +68,7 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
 
     case extract_range(range) do
       {:ok, first, last} when first <= last -> {:ok, :forward, {scope_type, first..last}}
-      {:ok, first, last} -> {:ok, :backward, {scope_type, first..last}}
+      {:ok, first, last} -> {:ok, :backward, {scope_type, last..first}}
       {:error, reason} -> {:error, reason}
     end
   end
@@ -79,7 +79,7 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
   defp extract_direction_and_scope(%{"range" => range}) do
     case extract_range(range) do
       {:ok, first, last} when first <= last -> {:ok, :forward, {:gen, first..last}}
-      {:ok, first, last} -> {:ok, :backward, {:gen, first..last}}
+      {:ok, first, last} -> {:ok, :backward, {:gen, last..first}}
       {:error, reason} -> {:error, reason}
     end
   end


### PR DESCRIPTION
This simplifies pagination code a bit for us be able to fetch the same
stream of resources with the same scope, independently of the
direction.