### PR TITLE
refactor: Mnesia to Database

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,6 +1,6 @@
 alias AeMdw.Db.Model
 alias AeMdw.Db.Name
 alias AeMdw.Db.Util
-alias AeMdw.Mnesia
+alias AeMdw.Database
 require Model
 require Ex2ms

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,8 +22,7 @@ By using Elixir for implementation, we can understand middleware as an
 application running alongside the AE node, via
 [](https://github.com/aeternity/ae_plugin).
 
-The extension of this decision is using the same database as AE node does -
-Mnesia.
+The extension of this decision is using the same database as AE node does (RocksDB).
 
 The benefits of these decisions were:
 
@@ -50,7 +49,7 @@ Image below depicts how these two large blocks fit together.
 
 By merging the database types of AE node and Middleware, we can save a
 significant amount of space and work with both datasets in the same way - using
-Mnesia transactions and working with similar data model - sets of records.
+RocksDB transactions and working with similar data model - sets of records.
 
 The Middleware keeps track of several distinct types of information:
 
@@ -170,7 +169,7 @@ The database model of the table record is defined as:
 ```
 defrecord :time,
   [index: {-1, -1}, # as {micro block milliseconds, transaction index}
-  unused: nil # Mnesia entries must have "value" field
+  unused: nil # unused as RocksDB value
 ```
 
 Stored in table `Model.Time`.
@@ -190,7 +189,7 @@ The database model of the table record is defined as:
 ```
 defrecord :type,
   [index: {nil, -1}, # as {transaction type, transaction index}
-  unused: nil] # Mnesia entries must have "value" field
+  unused: nil] # unused as RocksDB value
 ```
 
 Stored in table `Model.Type`.

--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -13,7 +13,7 @@ defmodule AeMdw.Application do
   alias AeMdw.Db.Stream, as: DbStream
   alias AeMdw.EtsCache
   alias AeMdw.Extract
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.NodeHelper
   alias AeMdw.Util
 
@@ -227,14 +227,14 @@ defmodule AeMdw.Application do
     initial_token_supply = AeMdw.Node.token_supply_delta(0)
 
     :mnesia.transaction(fn ->
-      case Mnesia.read(Model.TotalStat, 0) do
+      case Database.read(Model.TotalStat, 0) do
         [m_total_stat] ->
           tot_sup = Model.total_stat(m_total_stat, :total_supply)
           tot_sup == initial_token_supply || raise "initial total supply doesn't match"
 
         [] ->
           m_total_stat = Model.total_stat(index: 0, total_supply: initial_token_supply)
-          Mnesia.write(Model.TotalStat, m_total_stat)
+          Database.write(Model.TotalStat, m_total_stat)
       end
     end)
 

--- a/lib/ae_mdw/auction_bids.ex
+++ b/lib/ae_mdw/auction_bids.ex
@@ -6,7 +6,7 @@ defmodule AeMdw.AuctionBids do
   alias AeMdw.Collection
   alias AeMdw.Db.Model
   alias AeMdw.Db.Name
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Names
   alias AeMdw.Txs
 
@@ -98,7 +98,7 @@ defmodule AeMdw.AuctionBids do
   defp bid_top_key(plain_name) do
     top_key = {plain_name, <<>>, <<>>, <<>>, <<>>}
 
-    case Mnesia.prev_key(@table, top_key) do
+    case Database.prev_key(@table, top_key) do
       {:ok, auction_bid_key} ->
         if elem(auction_bid_key, 0) == plain_name do
           {:ok, auction_bid_key}

--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -8,7 +8,7 @@ defmodule AeMdw.Blocks do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Util, as: DbUtil
   alias AeMdw.EtsCache
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Util
   alias AeMdw.Validate
 
@@ -27,8 +27,8 @@ defmodule AeMdw.Blocks do
   @type block :: map()
   @type cursor :: binary()
 
-  @typep direction :: Mnesia.direction()
-  @typep limit :: Mnesia.limit()
+  @typep direction :: Database.direction()
+  @typep limit :: Database.limit()
   @typep range :: {:gen, Range.t()} | nil
 
   @table Model.Block
@@ -46,7 +46,7 @@ defmodule AeMdw.Blocks do
   @spec fetch_blocks(direction(), range(), cursor() | nil, limit(), boolean()) ::
           {cursor() | nil, [block()], cursor() | nil}
   def fetch_blocks(direction, range, cursor, limit, sort_mbs?) do
-    {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
+    {:ok, {last_gen, -1}} = Database.last_key(AeMdw.Db.Model.Block)
 
     cursor = deserialize_cursor(cursor)
 
@@ -68,7 +68,7 @@ defmodule AeMdw.Blocks do
 
   @spec block_hash(height()) :: block_hash()
   def block_hash(height) do
-    Model.block(hash: hash) = Mnesia.fetch!(@table, {height, -1})
+    Model.block(hash: hash) = Database.fetch!(@table, {height, -1})
 
     hash
   end
@@ -105,7 +105,7 @@ defmodule AeMdw.Blocks do
     @table
     |> Collection.stream(:backward, nil, {gen, <<>>})
     |> Stream.take_while(&match?({^gen, _mb_index}, &1))
-    |> Enum.map(fn key -> Mnesia.fetch!(@table, key) end)
+    |> Enum.map(fn key -> Database.fetch!(@table, key) end)
     |> Enum.reverse()
     |> Enum.map(fn block -> Format.to_map(block) end)
   end

--- a/lib/ae_mdw/collection.ex
+++ b/lib/ae_mdw/collection.ex
@@ -1,16 +1,16 @@
 defmodule AeMdw.Collection do
   @moduledoc """
-  Basic module for dealing with paginated lists of items from Mnesia tables.
+  Basic module for dealing with paginated lists of items from Database tables.
   """
 
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Util
 
-  @typep table() :: Mnesia.table()
-  @typep direction() :: Mnesia.direction()
-  @typep cursor() :: Mnesia.cursor()
-  @typep limit() :: Mnesia.limit()
-  @typep key() :: Mnesia.key()
+  @typep table() :: Database.table()
+  @typep direction() :: Database.direction()
+  @typep cursor() :: Database.cursor()
+  @typep limit() :: Database.limit()
+  @typep key() :: Database.key()
   @typep scope() :: {key(), key()} | nil
 
   @type is_reversed?() :: boolean()
@@ -103,7 +103,7 @@ defmodule AeMdw.Collection do
           nil
 
         key ->
-          case Mnesia.next_key(tab, direction, key) do
+          case Database.next_key(tab, direction, key) do
             {:ok, next_key} -> {key, next_key}
             :none -> {key, :end_keys}
           end
@@ -118,7 +118,7 @@ defmodule AeMdw.Collection do
     end
   end
 
-  defp fetch_first_key(tab, direction, nil, nil), do: Mnesia.next_key(tab, direction, nil)
+  defp fetch_first_key(tab, direction, nil, nil), do: Database.next_key(tab, direction, nil)
 
   defp fetch_first_key(tab, direction, first, nil), do: fetch_first_key(tab, direction, first)
 
@@ -131,10 +131,10 @@ defmodule AeMdw.Collection do
     do: fetch_first_key(tab, :backward, min(first, cursor))
 
   defp fetch_first_key(tab, direction, candidate_cursor) do
-    if Mnesia.exists?(tab, candidate_cursor) do
+    if Database.exists?(tab, candidate_cursor) do
       {:ok, candidate_cursor}
     else
-      Mnesia.next_key(tab, direction, candidate_cursor)
+      Database.next_key(tab, direction, candidate_cursor)
     end
   end
 

--- a/lib/ae_mdw/contracts.ex
+++ b/lib/ae_mdw/contracts.ex
@@ -10,7 +10,7 @@ defmodule AeMdw.Contracts do
   alias AeMdw.Db.Stream.Query.Parser
   alias AeMdw.Db.Util, as: DBUtil
   alias AeMdw.Error.Input, as: ErrInput
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Db.Origin
   alias AeMdw.Txs
   alias AeMdw.Util
@@ -101,7 +101,7 @@ defmodule AeMdw.Contracts do
   def fetch_int_contract_calls(txi, fname) do
     @int_contract_call_table
     |> Collection.stream(:backward, {{txi + 1, @min_int}, {txi, @min_int}}, nil)
-    |> Stream.map(&Mnesia.fetch!(@int_contract_call_table, &1))
+    |> Stream.map(&Database.fetch!(@int_contract_call_table, &1))
     |> Stream.filter(&match?(Model.int_contract_call(fname: ^fname), &1))
   end
 
@@ -363,7 +363,7 @@ defmodule AeMdw.Contracts do
     |> Stream.filter(fn {_pk, _pos, call_txi, local_idx} ->
       {tx_type, _tx} =
         Model.IntContractCall
-        |> Mnesia.fetch!({call_txi, local_idx})
+        |> Database.fetch!({call_txi, local_idx})
         |> Model.int_contract_call(:tx)
         |> :aetx.specialize_type()
 
@@ -447,7 +447,7 @@ defmodule AeMdw.Contracts do
   defp fetch_tx_type(call_txi, local_idx) do
     {tx_type, _tx} =
       Model.IntContractCall
-      |> Mnesia.fetch!({call_txi, local_idx})
+      |> Database.fetch!({call_txi, local_idx})
       |> Model.int_contract_call(:tx)
       |> :aetx.specialize_type()
 

--- a/lib/ae_mdw/db/int_transfer.ex
+++ b/lib/ae_mdw/db/int_transfer.ex
@@ -6,7 +6,7 @@ defmodule AeMdw.Db.IntTransfer do
   alias AeMdw.Blocks
   alias AeMdw.Txs
   alias AeMdw.Db.Model
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Ex2ms
   require Model
@@ -71,9 +71,9 @@ defmodule AeMdw.Db.IntTransfer do
     target_kind_tx =
       Model.target_kind_int_transfer_tx(index: {target_pk, kind, {height, pos_txi}, ref_txi})
 
-    Mnesia.write(Model.IntTransferTx, int_tx)
-    Mnesia.write(Model.KindIntTransferTx, kind_tx)
-    Mnesia.write(Model.TargetKindIntTransferTx, target_kind_tx)
+    Database.write(Model.IntTransferTx, int_tx)
+    Database.write(Model.KindIntTransferTx, kind_tx)
+    Database.write(Model.TargetKindIntTransferTx, target_kind_tx)
   end
 
   @spec read_block_reward(Blocks.height()) :: pos_integer()
@@ -95,7 +95,7 @@ defmodule AeMdw.Db.IntTransfer do
       end
 
     Model.IntTransferTx
-    |> Mnesia.dirty_select(amount_spec)
+    |> Database.dirty_select(amount_spec)
     |> Enum.sum()
   end
 end

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -1,10 +1,10 @@
 defmodule AeMdw.Db.Model do
   @moduledoc """
-  Mnesia database model records.
+  Database database model records.
   """
   alias AeMdw.Blocks
   alias AeMdw.Contract
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Node
   alias AeMdw.Txs
 
@@ -758,12 +758,12 @@ defmodule AeMdw.Db.Model do
   def write_count(model, delta) do
     total = id_count(model, :count)
     model = id_count(model, count: total + delta)
-    Mnesia.write(AeMdw.Db.Model.IdCount, model)
+    Database.write(AeMdw.Db.Model.IdCount, model)
   end
 
   @spec update_count(tuple(), integer(), fun()) :: any()
   def update_count({_, _, _} = field_key, delta, empty_fn \\ fn -> :nop end) do
-    case Mnesia.read(AeMdw.Db.Model.IdCount, field_key, :write) do
+    case Database.read(AeMdw.Db.Model.IdCount, field_key, :write) do
       [] -> empty_fn.()
       [model] -> write_count(model, delta)
     end

--- a/lib/ae_mdw/db/mutations/key_blocks_mutation.ex
+++ b/lib/ae_mdw/db/mutations/key_blocks_mutation.ex
@@ -3,7 +3,7 @@ defmodule AeMdw.Db.KeyBlocksMutation do
   Writes key block full model for the current height and next_txi for next height.
   """
   alias AeMdw.Db.Model
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Txs
 
   require Model
@@ -11,11 +11,11 @@ defmodule AeMdw.Db.KeyBlocksMutation do
   defstruct [:key_block, :next_txi]
 
   @opaque t() :: %__MODULE__{
-            key_block: Mnesia.record(),
+            key_block: Database.record(),
             next_txi: Txs.txi()
           }
 
-  @spec new(Mnesia.record(), Txs.txi()) :: t()
+  @spec new(Database.record(), Txs.txi()) :: t()
   def new(m_block, next_txi) do
     %__MODULE__{key_block: m_block, next_txi: next_txi}
   end
@@ -23,10 +23,10 @@ defmodule AeMdw.Db.KeyBlocksMutation do
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{key_block: m_block, next_txi: next_txi}) do
     {height, -1} = Model.block(m_block, :index)
-    [next_kb] = Mnesia.read(Model.Block, {height + 1, -1})
+    [next_kb] = Database.read(Model.Block, {height + 1, -1})
 
-    Mnesia.write(Model.Block, m_block)
-    Mnesia.write(Model.Block, Model.block(next_kb, tx_index: next_txi))
+    Database.write(Model.Block, m_block)
+    Database.write(Model.Block, Model.block(next_kb, tx_index: next_txi))
   end
 end
 

--- a/lib/ae_mdw/db/mutations/mnesia_write_mutation.ex
+++ b/lib/ae_mdw/db/mutations/mnesia_write_mutation.ex
@@ -1,30 +1,30 @@
-defmodule AeMdw.Db.MnesiaWriteMutation do
+defmodule AeMdw.Db.DatabaseWriteMutation do
   @moduledoc """
   This is the most basic kind of transaction, it just inserts a record in a
   mnesia table.
   """
 
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   defstruct [:table, :record]
 
   @opaque t() :: %__MODULE__{
-            table: Mnesia.table(),
-            record: Mnesia.record()
+            table: Database.table(),
+            record: Database.record()
           }
 
-  @spec new(Mnesia.table(), Mnesia.record()) :: t()
+  @spec new(Database.table(), Database.record()) :: t()
   def new(table, record) do
     %__MODULE__{table: table, record: record}
   end
 
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{table: table, record: record}) do
-    Mnesia.write(table, record)
+    Database.write(table, record)
   end
 end
 
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.MnesiaWriteMutation do
+defimpl AeMdw.Db.Mutation, for: AeMdw.Db.DatabaseWriteMutation do
   def mutate(mutation) do
     @for.mutate(mutation)
   end

--- a/lib/ae_mdw/db/mutations/stats_mutation.ex
+++ b/lib/ae_mdw/db/mutations/stats_mutation.ex
@@ -4,7 +4,7 @@ defmodule AeMdw.Db.StatsMutation do
   """
 
   alias AeMdw.Db.Model
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Model
 
@@ -28,8 +28,8 @@ defmodule AeMdw.Db.StatsMutation do
         stat: stat,
         total_stat: total_stat
       }) do
-    Mnesia.write(Model.Stat, stat)
-    Mnesia.write(Model.TotalStat, total_stat)
+    Database.write(Model.Stat, stat)
+    Database.write(Model.TotalStat, total_stat)
   end
 end
 

--- a/lib/ae_mdw/db/mutations/write_field_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_field_mutation.ex
@@ -5,7 +5,7 @@ defmodule AeMdw.Db.WriteFieldMutation do
 
   alias AeMdw.Txs
   alias AeMdw.Db.Model
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Node
   alias AeMdw.Node.Db
 
@@ -31,7 +31,7 @@ defmodule AeMdw.Db.WriteFieldMutation do
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{tx_type: tx_type, pos: pos, pubkey: pubkey, txi: txi}) do
     m_field = Model.field(index: {tx_type, pos, pubkey, txi})
-    Mnesia.write(Model.Field, m_field)
+    Database.write(Model.Field, m_field)
     Model.incr_count({tx_type, pos, pubkey})
   end
 end

--- a/lib/ae_mdw/db/mutations/write_fields_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_fields_mutation.ex
@@ -4,7 +4,7 @@ defmodule AeMdw.Db.WriteFieldsMutation do
   """
 
   alias AeMdw.Blocks
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Node
   alias AeMdw.Db.Model
   alias AeMdw.Txs
@@ -42,7 +42,7 @@ defmodule AeMdw.Db.WriteFieldsMutation do
 
   defp write_field(tx_type, pos, pubkey, txi) do
     m_field = Model.field(index: {tx_type, pos, pubkey, txi})
-    Mnesia.write(Model.Field, m_field)
+    Database.write(Model.Field, m_field)
     Model.incr_count({tx_type, pos, pubkey})
   end
 

--- a/lib/ae_mdw/db/mutations/write_tx_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_tx_mutation.ex
@@ -5,7 +5,7 @@ defmodule AeMdw.Db.WriteTxMutation do
 
   alias AeMdw.Blocks
   alias AeMdw.Db.Model
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Node
   alias AeMdw.Txs
 
@@ -35,11 +35,11 @@ defmodule AeMdw.Db.WriteTxMutation do
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{tx: tx, type: type, txi: txi, mb_time: mb_time, inner_tx?: inner_tx?}) do
     if not inner_tx? do
-      Mnesia.write(Model.Tx, tx)
+      Database.write(Model.Tx, tx)
     end
 
-    Mnesia.write(Model.Type, Model.type(index: {type, txi}))
-    Mnesia.write(Model.Time, Model.time(index: {mb_time, txi}))
+    Database.write(Model.Type, Model.type(index: {type, txi}))
+    Database.write(Model.Time, Model.time(index: {mb_time, txi}))
   end
 end
 

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -9,7 +9,7 @@ defmodule AeMdw.Db.Name do
   alias AeMdw.Db.IntTransfer
   alias AeMdw.Ets
   alias AeMdw.Log
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Names
   alias AeMdw.Validate
 
@@ -212,7 +212,7 @@ defmodule AeMdw.Db.Name do
         {:pointee, {^pk, {bi, txi}, k}, :_} -> {bi, txi, k}
       end
 
-    Mnesia.dirty_select(Model.Pointee, mspec)
+    Database.dirty_select(Model.Pointee, mspec)
   end
 
   def pointees(pk) do
@@ -305,12 +305,12 @@ defmodule AeMdw.Db.Name do
   # for use inside mnesia TX - caches writes & deletes in the same TX
   def cache_through_write(table, record) do
     :ets.insert(:name_sync_cache, {{table, elem(record, 1)}, record})
-    Mnesia.write(table, record)
+    Database.write(table, record)
   end
 
   def cache_through_delete(table, key) do
     :ets.delete(:name_sync_cache, {table, key})
-    Mnesia.delete(table, key)
+    Database.delete(table, key)
   end
 
   def cache_through_delete_inactive(nil), do: nil

--- a/lib/ae_mdw/db/oracle.ex
+++ b/lib/ae_mdw/db/oracle.ex
@@ -9,7 +9,7 @@ defmodule AeMdw.Db.Oracle do
   alias AeMdw.Db.OraclesExpirationMutation
   alias AeMdw.Db.OracleResponseMutation
   alias AeMdw.Log
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Node
   alias AeMdw.Txs
 
@@ -69,13 +69,13 @@ defmodule AeMdw.Db.Oracle do
   @spec cache_through_write(atom(), tuple()) :: :ok
   def cache_through_write(table, record) do
     :ets.insert(:oracle_sync_cache, {{table, elem(record, 1)}, record})
-    Mnesia.write(table, record)
+    Database.write(table, record)
   end
 
   @spec cache_through_delete(atom(), cache_key()) :: :ok
   def cache_through_delete(table, key) do
     :ets.delete(:oracle_sync_cache, {table, key})
-    Mnesia.delete(table, key)
+    Database.delete(table, key)
   end
 
   @spec cache_through_delete_inactive(nil | tuple()) :: :ok

--- a/lib/ae_mdw/db/sync/block_index.ex
+++ b/lib/ae_mdw/db/sync/block_index.ex
@@ -6,7 +6,7 @@ defmodule AeMdw.Db.Sync.BlockIndex do
 
   alias AeMdw.Db.Sync
   alias AeMdw.Db.Model
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   import AeMdw.{Sigil, Util, Db.Util}
 
@@ -42,7 +42,7 @@ defmodule AeMdw.Db.Sync.BlockIndex do
     ^height = :aec_headers.height(kh)
     :key = :aec_headers.type(kh)
     kb_model = Model.block(index: {height, -1}, hash: hash)
-    Mnesia.write(table, kb_model)
+    Database.write(table, kb_model)
     :aec_headers.prev_key_hash(kh)
   end
 

--- a/lib/ae_mdw/db/sync/invalidate.ex
+++ b/lib/ae_mdw/db/sync/invalidate.ex
@@ -6,7 +6,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Sync
   alias AeMdw.Log
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Node, as: AE
   alias AeMdw.Validate
 
@@ -190,7 +190,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
   end
 
   def origin_keys_range(from_txi, to_txi) do
-    case Mnesia.dirty_next(Model.RevOrigin, {from_txi, :_, nil}) do
+    case Database.dirty_next(Model.RevOrigin, {from_txi, :_, nil}) do
       :"$end_of_table" ->
         {[], []}
 
@@ -211,7 +211,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
 
   def aex9_key_dels(from_txi) do
     {aex9_keys, aex9_sym_keys, aex9_rev_keys} =
-      case Mnesia.dirty_next(Model.RevAex9Contract, {from_txi, nil, nil, nil}) do
+      case Database.dirty_next(Model.RevAex9Contract, {from_txi, nil, nil, nil}) do
         :"$end_of_table" ->
           {[], [], []}
 
@@ -240,7 +240,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
 
   def aex9_transfer_key_dels(from_txi) do
     {aex9_tr_keys, aex9_rev_tr_keys, aex9_idx_tr_keys} =
-      case Mnesia.dirty_next(Model.IdxAex9Transfer, {from_txi, 0, nil, nil, 0}) do
+      case Database.dirty_next(Model.IdxAex9Transfer, {from_txi, 0, nil, nil, 0}) do
         :"$end_of_table" ->
           {[], [], []}
 
@@ -270,7 +270,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
 
   def aex9_account_presence_key_dels(from_txi) do
     {aex9_presence_keys, idx_aex9_presence_keys} =
-      case Mnesia.dirty_next(Model.IdxAex9AccountPresence, {from_txi, nil, nil}) do
+      case Database.dirty_next(Model.IdxAex9AccountPresence, {from_txi, nil, nil}) do
         :"$end_of_table" ->
           {[], []}
 
@@ -345,7 +345,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
 
   def contract_log_key_dels(from_txi) do
     {log_keys, data_log_keys, evt_log_keys, idx_log_keys} =
-      case Mnesia.dirty_next(Model.IdxContractLog, {from_txi, 0, nil, 0}) do
+      case Database.dirty_next(Model.IdxContractLog, {from_txi, 0, nil, 0}) do
         :"$end_of_table" ->
           {[], [], [], []}
 
@@ -383,7 +383,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
 
   def contract_call_key_dels(from_txi) do
     contract_call_keys =
-      case Mnesia.dirty_next(Model.ContractCall, {from_txi, 0}) do
+      case Database.dirty_next(Model.ContractCall, {from_txi, 0}) do
         :"$end_of_table" ->
           []
 
@@ -403,7 +403,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
   def int_contract_call_key_dels(from_txi) do
     {int_keys, grp_keys, fname_keys, fname_grp_keys, id_keys, grp_id_keys, id_fname_keys,
      grp_id_fname_keys} =
-      case Mnesia.dirty_next(Model.IntContractCall, {from_txi, -1}) do
+      case Database.dirty_next(Model.IntContractCall, {from_txi, -1}) do
         :"$end_of_table" ->
           {[], [], [], [], [], [], [], []}
 
@@ -466,7 +466,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
 
   def int_transfer_tx_key_dels(prev_kbi) do
     {int_keys, kind_keys, target_keys} =
-      case Mnesia.dirty_next(Model.IntTransferTx, {prev_kbi, -2}) do
+      case Database.dirty_next(Model.IntTransferTx, {prev_kbi, -2}) do
         :"$end_of_table" ->
           {[], [], []}
 

--- a/lib/ae_mdw/db/sync/origin.ex
+++ b/lib/ae_mdw/db/sync/origin.ex
@@ -7,7 +7,7 @@ defmodule AeMdw.Db.Sync.Origin do
   alias AeMdw.Node.Db, as: NodeDb
   alias AeMdw.Db.Model
   alias AeMdw.Db.Mutation
-  alias AeMdw.Db.MnesiaWriteMutation
+  alias AeMdw.Db.DatabaseWriteMutation
   alias AeMdw.Db.WriteFieldMutation
   alias AeMdw.Txs
 
@@ -25,8 +25,8 @@ defmodule AeMdw.Db.Sync.Origin do
     m_rev_origin = Model.rev_origin(index: {txi, tx_type, pubkey})
 
     [
-      MnesiaWriteMutation.new(Model.Origin, m_origin),
-      MnesiaWriteMutation.new(Model.RevOrigin, m_rev_origin),
+      DatabaseWriteMutation.new(Model.Origin, m_origin),
+      DatabaseWriteMutation.new(Model.RevOrigin, m_rev_origin),
       WriteFieldMutation.new(tx_type, pos, pubkey, txi)
     ]
   end

--- a/lib/ae_mdw/db/sync/stats.ex
+++ b/lib/ae_mdw/db/sync/stats.ex
@@ -9,7 +9,7 @@ defmodule AeMdw.Db.Sync.Stats do
   alias AeMdw.Db.StatsMutation
   alias AeMdw.Db.Util
   alias AeMdw.Ets
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Model
 
@@ -62,7 +62,7 @@ defmodule AeMdw.Db.Sync.Stats do
 
     current_contracts =
       Model.ContractCall
-      |> Mnesia.dirty_all_keys()
+      |> Database.dirty_all_keys()
       |> Enum.map(fn {create_txi, _call_txi} -> create_txi end)
       |> Enum.uniq()
       |> length()

--- a/lib/ae_mdw/mnesia.ex
+++ b/lib/ae_mdw/mnesia.ex
@@ -1,6 +1,6 @@
-defmodule AeMdw.Mnesia do
+defmodule AeMdw.Database do
   @moduledoc """
-  Mnesia wrapper to provide a simpler API.
+  Database wrapper to provide a simpler API.
 
   In order to iterate throught collections of records we use the
   concept of "cursor". A cursor is just a key of any given table that
@@ -50,6 +50,22 @@ defmodule AeMdw.Mnesia do
 
   @spec dirty_select(table(), list()) :: [term()]
   def dirty_select(table, fun), do: :mnesia.dirty_select(table, fun)
+
+  @spec all_keys(table()) :: [key()]
+  def all_keys(table) do
+    :mnesia.all_keys(table)
+  end
+
+  @doc """
+  Previous key from transaction (before commit).
+  """
+  @spec dirty_prev_key(table(), key()) :: {:ok, key()} | :none
+  def dirty_prev_key(tab, key) do
+    case :mnesia.prev(tab, key) do
+      @end_token -> :none
+      prev_key -> {:ok, prev_key}
+    end
+  end
 
   @spec last_key(table(), term()) :: term()
   def last_key(tab, default) do

--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -12,7 +12,7 @@ defmodule AeMdw.Names do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Util, as: DBUtil
   alias AeMdw.Collection
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Txs
   alias AeMdw.Util
 
@@ -146,7 +146,7 @@ defmodule AeMdw.Names do
 
   @spec fetch_previous_list(plain_name()) :: [name()]
   def fetch_previous_list(plain_name) do
-    case Mnesia.fetch(@table_inactive, plain_name) do
+    case Database.fetch(@table_inactive, plain_name) do
       {:ok, name} ->
         name
         |> Stream.unfold(fn
@@ -185,7 +185,7 @@ defmodule AeMdw.Names do
   end
 
   defp render(plain_name, is_active?, expand?) do
-    name = Mnesia.fetch!(if(is_active?, do: @table_active, else: @table_inactive), plain_name)
+    name = Database.fetch!(if(is_active?, do: @table_active, else: @table_inactive), plain_name)
 
     name_hash =
       case :aens.get_name_hash(plain_name) do

--- a/lib/ae_mdw/oracles.ex
+++ b/lib/ae_mdw/oracles.ex
@@ -10,7 +10,7 @@ defmodule AeMdw.Oracles do
   alias AeMdw.Db.Format
   alias AeMdw.Db.Model
   alias AeMdw.Db.Util, as: DBUtil
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Node
   alias AeMdw.Util
 
@@ -39,7 +39,7 @@ defmodule AeMdw.Oracles do
           {{first_gen, Util.min_bin()}, {last_gen, Util.max_256bit_bin()}}
       end
 
-    {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
+    {:ok, {last_gen, -1}} = Database.last_key(AeMdw.Db.Model.Block)
 
     {prev_cursor, expiration_keys, next_cursor} =
       fn direction ->
@@ -72,7 +72,7 @@ defmodule AeMdw.Oracles do
           {cursor() | nil, [oracle()], cursor() | nil}
   def fetch_active_oracles(pagination, cursor, expand?) do
     cursor = deserialize_cursor(cursor)
-    {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
+    {:ok, {last_gen, -1}} = Database.last_key(AeMdw.Db.Model.Block)
 
     {prev_cursor, exp_keys, next_cursor} =
       Collection.paginate(
@@ -89,7 +89,7 @@ defmodule AeMdw.Oracles do
           {cursor() | nil, [oracle()], cursor() | nil}
   def fetch_inactive_oracles(pagination, cursor, expand?) do
     cursor = deserialize_cursor(cursor)
-    {:ok, {last_gen, -1}} = Mnesia.last_key(AeMdw.Db.Model.Block)
+    {:ok, {last_gen, -1}} = Database.last_key(AeMdw.Db.Model.Block)
 
     {prev_cursor, exp_keys, next_cursor} =
       Collection.paginate(
@@ -113,7 +113,7 @@ defmodule AeMdw.Oracles do
       register: {{register_height, _mbi}, register_txi},
       extends: extends,
       previous: _previous
-    ) = Mnesia.fetch!(if(is_active?, do: @table_active, else: @table_inactive), oracle_pk)
+    ) = Database.fetch!(if(is_active?, do: @table_active, else: @table_inactive), oracle_pk)
 
     kbi = min(expire_height - 1, last_gen)
 

--- a/lib/ae_mdw/stats.ex
+++ b/lib/ae_mdw/stats.ex
@@ -6,7 +6,7 @@ defmodule AeMdw.Stats do
   alias AeMdw.Blocks
   alias AeMdw.Db.Format
   alias AeMdw.Db.Model
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Util
 
   require Model
@@ -16,8 +16,8 @@ defmodule AeMdw.Stats do
   @type cursor() :: binary() | nil
 
   @typep height() :: Blocks.height()
-  @typep direction() :: Mnesia.direction()
-  @typep limit() :: Mnesia.limit()
+  @typep direction() :: Database.direction()
+  @typep limit() :: Database.limit()
   @typep range() :: {:gen, Range.t()} | nil
 
   @table Model.Stat
@@ -25,7 +25,7 @@ defmodule AeMdw.Stats do
 
   @spec fetch_stats(direction(), range(), cursor(), limit()) :: {cursor(), [stat()], cursor()}
   def fetch_stats(direction, range, cursor, limit) do
-    {:ok, last_gen} = Mnesia.last_key(AeMdw.Db.Model.Stat)
+    {:ok, last_gen} = Database.last_key(AeMdw.Db.Model.Stat)
 
     {range_first, range_last} =
       case range do
@@ -47,7 +47,7 @@ defmodule AeMdw.Stats do
   @spec fetch_sum_stats(direction(), range(), cursor(), limit()) ::
           {cursor(), [sum_stat()], cursor()}
   def fetch_sum_stats(direction, range, cursor, limit) do
-    {:ok, last_gen} = Mnesia.last_key(AeMdw.Db.Model.TotalStat)
+    {:ok, last_gen} = Database.last_key(AeMdw.Db.Model.TotalStat)
 
     {range_first, range_last} =
       case range do
@@ -67,10 +67,10 @@ defmodule AeMdw.Stats do
   end
 
   @spec fetch_stat!(height()) :: stat()
-  def fetch_stat!(height), do: render_stat(Mnesia.fetch!(@table, height))
+  def fetch_stat!(height), do: render_stat(Database.fetch!(@table, height))
 
   @spec fetch_sum_stat!(height()) :: sum_stat()
-  def fetch_sum_stat!(height), do: render_sum_stat(Mnesia.fetch!(@sum_table, height))
+  def fetch_sum_stat!(height), do: render_sum_stat(Database.fetch!(@sum_table, height))
 
   defp render_stats(gens), do: Enum.map(gens, &fetch_stat!/1)
 

--- a/lib/ae_mdw/sync/async_tasks/store.ex
+++ b/lib/ae_mdw/sync/async_tasks/store.ex
@@ -5,7 +5,7 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
 
   alias AeMdw.Db.Model
   alias AeMdw.Db.Util
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Ex2ms
   require Model
@@ -51,7 +51,7 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
       if not is_enqueued?(task_type, args) do
         index = {System.system_time(), task_type}
         m_task = Model.async_tasks(index: index, args: args)
-        Mnesia.write(Model.AsyncTasks, m_task)
+        Database.write(Model.AsyncTasks, m_task)
         :ets.insert(@args_tab, {{task_type, args}})
       end
     end)
@@ -68,7 +68,7 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
   @spec set_done(task_index(), task_args()) :: :ok
   def set_done({_ts, task_type} = task_index, args) do
     :mnesia.sync_transaction(fn ->
-      Mnesia.delete(Model.AsyncTasks, task_index)
+      Database.delete(Model.AsyncTasks, task_index)
     end)
 
     :ets.delete_object(@processing_tab, task_index)

--- a/lib/ae_mdw/util.ex
+++ b/lib/ae_mdw/util.ex
@@ -3,7 +3,7 @@ defmodule AeMdw.Util do
   @moduledoc false
 
   alias AeMdw.Blocks
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   def id(x), do: x
 
@@ -219,7 +219,7 @@ defmodule AeMdw.Util do
     end
   end
 
-  @spec opposite_dir(Mnesia.direction()) :: Mnesia.direction()
+  @spec opposite_dir(Database.direction()) :: Database.direction()
   def opposite_dir(:backward), do: :forward
   def opposite_dir(:forward), do: :backward
 
@@ -229,10 +229,10 @@ defmodule AeMdw.Util do
   """
   @spec build_gen_pagination(
           Blocks.height() | nil,
-          Mnesia.direction(),
+          Database.direction(),
           Blocks.height(),
           Blocks.height(),
-          Mnesia.limit()
+          Database.limit()
         ) ::
           {:ok, Blocks.height() | nil, Enumerable.t(), Blocks.height() | nil} | :error
 

--- a/lib/mix/tasks/migrate_db.ex
+++ b/lib/mix/tasks/migrate_db.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.MigrateDb do
 
   alias AeMdw.Db.Model
   alias AeMdw.Db.Util
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Log
 
   @table Model.Migrations
@@ -88,7 +88,7 @@ defmodule Mix.Tasks.MigrateDb do
     {:ok, _} = apply(module, :run, [from_startup?])
 
     :mnesia.sync_dirty(fn ->
-      Mnesia.write(@table, {@record_name, version, DateTime.utc_now()})
+      Database.write(@table, {@record_name, version, DateTime.utc_now()})
     end)
 
     Log.info("applied version #{version}")

--- a/priv/migrations/20210826171900_reindex_remote_logs.ex
+++ b/priv/migrations/20210826171900_reindex_remote_logs.ex
@@ -7,7 +7,7 @@ defmodule AeMdw.Migrations.ReindexRemoteLogs do
   alias AeMdw.Db.Origin
   alias AeMdw.Db.Util
   alias AeMdw.Log
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Model
   require Ex2ms
@@ -117,7 +117,7 @@ defmodule AeMdw.Migrations.ReindexRemoteLogs do
 
         # credo:disable-for-next-line
         if is_integer(new_create_txi) and new_create_txi > 0 do
-          :ok = Mnesia.write(Model.ContractLog, log_record)
+          :ok = Database.write(Model.ContractLog, log_record)
           acc + 1
         else
           acc

--- a/priv/migrations/20211124092400_reindex_int_transfers_acc_index.ex
+++ b/priv/migrations/20211124092400_reindex_int_transfers_acc_index.ex
@@ -18,7 +18,7 @@ defmodule AeMdw.Migrations.ReindexIntTransfersAccIndex do
   """
 
   alias AeMdw.Db.Model
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Logger
 
@@ -51,7 +51,7 @@ defmodule AeMdw.Migrations.ReindexIntTransfersAccIndex do
   end
 
   defp run(_from_startup?, true) do
-    {{last_gen, _txi}, _kind, _account_pk, _ref_txi} = Mnesia.dirty_last(@int_transfer_table)
+    {{last_gen, _txi}, _kind, _account_pk, _ref_txi} = Database.dirty_last(@int_transfer_table)
     batches_count = div(last_gen + @gen_batches_size - 1, @gen_batches_size)
 
     log("processing #{batches_count} batches of #{@gen_batches_size} generations")
@@ -96,7 +96,7 @@ defmodule AeMdw.Migrations.ReindexIntTransfersAccIndex do
           nil
 
         key ->
-          next_key = Mnesia.dirty_next(@int_transfer_table, key)
+          next_key = Database.dirty_next(@int_transfer_table, key)
           {next_key, next_key}
       end)
       |> Stream.reject(&match?(@end_token, &1))
@@ -109,7 +109,7 @@ defmodule AeMdw.Migrations.ReindexIntTransfersAccIndex do
       :mnesia.transaction(fn ->
         keys
         |> Stream.each(fn target_kind_tx ->
-          Mnesia.write(@target_kind_int_transfer_table, target_kind_tx)
+          Database.write(@target_kind_int_transfer_table, target_kind_tx)
         end)
         |> Enum.count()
       end)

--- a/priv/migrations/20211220163202_index_ga_attach_txs.ex
+++ b/priv/migrations/20211220163202_index_ga_attach_txs.ex
@@ -9,7 +9,7 @@ defmodule AeMdw.Migrations.IndexGaAttachTxs do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Sync.Transaction
   alias AeMdw.Log
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Sync.Supervisor, as: SyncSup
 
   require Model
@@ -61,7 +61,7 @@ defmodule AeMdw.Migrations.IndexGaAttachTxs do
     {:atomic, bi_txs_list} =
       :mnesia.transaction(fn ->
         Enum.map(txi_list, fn txi ->
-          [Model.tx(id: hash, block_index: bi)] = Mnesia.read(Model.Tx, txi)
+          [Model.tx(id: hash, block_index: bi)] = Database.read(Model.Tx, txi)
           {bi, hash, txi}
         end)
       end)
@@ -108,15 +108,15 @@ defmodule AeMdw.Migrations.IndexGaAttachTxs do
         end)
       end)
 
-    Mnesia.transaction(txs_mutations)
+    Database.transaction(txs_mutations)
 
     new_contracts_count = length(txs_mutations)
 
     {:atomic, :ok} =
       :mnesia.transaction(fn ->
-        [Model.stat(contracts: contracts) = m_stat] = Mnesia.read(Model.Stat, height + 1)
+        [Model.stat(contracts: contracts) = m_stat] = Database.read(Model.Stat, height + 1)
         new_m_stat = Model.stat(m_stat, contracts: contracts + new_contracts_count)
-        Mnesia.write(Model.Stat, new_m_stat)
+        Database.write(Model.Stat, new_m_stat)
       end)
 
     new_contracts_count

--- a/priv/migrations/20211224162001_reindex_aex9_account_presence.ex
+++ b/priv/migrations/20211224162001_reindex_aex9_account_presence.ex
@@ -2,6 +2,7 @@ defmodule AeMdw.Migrations.IndexAex9AccountPresenceWithCreateTxi do
   @moduledoc """
   Indexes Aex9AccountPresence with `create_txi` for every {account_pk, contract_pk} pair.
   """
+  alias AeMdw.Database
   alias AeMdw.Db.Contract
   alias AeMdw.Db.Model
   alias AeMdw.Db.Origin
@@ -19,7 +20,7 @@ defmodule AeMdw.Migrations.IndexAex9AccountPresenceWithCreateTxi do
     {:atomic, pairs_to_update} =
       :mnesia.transaction(fn ->
         Model.Aex9AccountPresence
-        |> :mnesia.all_keys()
+        |> Database.all_keys()
         |> Enum.into(MapSet.new(), fn {account_pk, _txi, contract_pk} ->
           {account_pk, contract_pk}
         end)

--- a/priv/migrations/20220113112001_inactive_name_owner.ex
+++ b/priv/migrations/20220113112001_inactive_name_owner.ex
@@ -4,7 +4,7 @@ defmodule AeMdw.Migrations.InactiveNameOwner do
   """
   alias AeMdw.Db.Model
   alias AeMdw.Log
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Ex2ms
   require Model
@@ -27,7 +27,7 @@ defmodule AeMdw.Migrations.InactiveNameOwner do
         |> :mnesia.select(any_spec, :read)
         |> Enum.map(fn Model.name(index: plain_name, owner: owner) ->
           m_owner = Model.owner(index: {owner, plain_name})
-          Mnesia.write(Model.InactiveNameOwner, m_owner)
+          Database.write(Model.InactiveNameOwner, m_owner)
         end)
         |> Enum.count()
       end)

--- a/priv/migrations/20220117033300_index_oracle_register.ex
+++ b/priv/migrations/20220117033300_index_oracle_register.ex
@@ -6,7 +6,7 @@ defmodule AeMdw.Migrations.IndexOracleRegister do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Oracle
   alias AeMdw.Db.OracleRegisterMutation
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Node, as: AE
   alias AeMdw.Log
 
@@ -32,12 +32,12 @@ defmodule AeMdw.Migrations.IndexOracleRegister do
 
     mutations =
       Model.FnameIntContractCall
-      |> Mnesia.dirty_select(oracle_register_mspec)
+      |> Database.dirty_select(oracle_register_mspec)
       |> Enum.map(fn call_txi ->
         [Model.tx(block_index: {kbi, mbi} = block_index, id: tx_hash)] =
-          Mnesia.dirty_read(Model.Tx, call_txi)
+          Database.dirty_read(Model.Tx, call_txi)
 
-        # Model.block(hash: block_hash) = Mnesia.dirty_read(Model.Block, {kbi, -1})
+        # Model.block(hash: block_hash) = Database.dirty_read(Model.Block, {kbi, -1})
         {_key_block, micro_blocks} = AE.Db.get_blocks(kbi)
 
         {{:internal_call_tx, "Oracle.register"}, %{info: aetx}} =
@@ -65,7 +65,7 @@ defmodule AeMdw.Migrations.IndexOracleRegister do
       end)
       |> Enum.reject(&is_nil/1)
 
-    Mnesia.transaction(mutations)
+    Database.transaction(mutations)
 
     duration = DateTime.diff(DateTime.utc_now(), begin)
     indexed_count = length(mutations)

--- a/test/ae_mdw/db/sync/contract_test.exs
+++ b/test/ae_mdw/db/sync/contract_test.exs
@@ -3,7 +3,7 @@ defmodule AeMdw.Db.Sync.ContractTest do
 
   alias AeMdw.Db.Model
 
-  alias AeMdw.Db.MnesiaWriteMutation
+  alias AeMdw.Db.DatabaseWriteMutation
   alias AeMdw.Db.Sync.Contract
   alias AeMdw.Node
 
@@ -29,13 +29,13 @@ defmodule AeMdw.Db.Sync.ContractTest do
       ]
 
       mutation_1 =
-        MnesiaWriteMutation.new(
+        DatabaseWriteMutation.new(
           Model.IdIntContractCall,
           Model.id_int_contract_call(index: {account_id, 1, 3, 0})
         )
 
       mutation_2 =
-        MnesiaWriteMutation.new(
+        DatabaseWriteMutation.new(
           Model.IdIntContractCall,
           Model.id_int_contract_call(index: {account_id, 1, 3, 1})
         )
@@ -70,13 +70,13 @@ defmodule AeMdw.Db.Sync.ContractTest do
       ]
 
       mutation_1 =
-        MnesiaWriteMutation.new(
+        DatabaseWriteMutation.new(
           Model.FnameIntContractCall,
           Model.fname_int_contract_call(index: {"Call.amount", 3, 0})
         )
 
       mutation_2 =
-        MnesiaWriteMutation.new(
+        DatabaseWriteMutation.new(
           Model.FnameIntContractCall,
           Model.fname_int_contract_call(index: {"Call.amount", 3, 1})
         )

--- a/test/ae_mdw/db/sync/transaction_test.exs
+++ b/test/ae_mdw/db/sync/transaction_test.exs
@@ -3,6 +3,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
 
   alias AeMdw.Node, as: AE
 
+  alias AeMdw.Database
   alias AeMdw.Db.Sync.Transaction
   alias AeMdw.Db.Model
   alias AeMdw.Db.Mutation
@@ -108,6 +109,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
   end
 
   defp query_spend_tx_field_index(pubkey, pos) do
-    :mnesia.prev(Model.Field, {:spend_tx, pos, pubkey, nil})
+    {:ok, index} = Database.dirty_prev_key(Model.Field, {:spend_tx, pos, pubkey, nil})
+    index
   end
 end

--- a/test/ae_mdw/sync/async_tasks/stats_test.exs
+++ b/test/ae_mdw/sync/async_tasks/stats_test.exs
@@ -3,7 +3,7 @@ defmodule AeMdw.Sync.AsyncTasks.StatsTest do
 
   alias AeMdw.Db.Model
   alias AeMdw.Sync.AsyncTasks.Stats
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Model
 
@@ -20,8 +20,8 @@ defmodule AeMdw.Sync.AsyncTasks.StatsTest do
 
     test "with pending db records" do
       db_pending_count = 10
-      existing_keys = Mnesia.dirty_all_keys(Model.AsyncTasks)
-      existing_tasks = Enum.flat_map(existing_keys, &Mnesia.dirty_read(Model.AsyncTasks, &1))
+      existing_keys = Database.dirty_all_keys(Model.AsyncTasks)
+      existing_tasks = Enum.flat_map(existing_keys, &Database.dirty_read(Model.AsyncTasks, &1))
 
       keys_to_delete =
         if length(existing_keys) > db_pending_count do
@@ -31,7 +31,7 @@ defmodule AeMdw.Sync.AsyncTasks.StatsTest do
           existing_keys
           |> Enum.take(delete_count)
           |> Enum.each(fn key ->
-            Mnesia.dirty_delete(Model.AsyncTasks, key)
+            Database.dirty_delete(Model.AsyncTasks, key)
           end)
 
           []
@@ -42,15 +42,15 @@ defmodule AeMdw.Sync.AsyncTasks.StatsTest do
           Enum.map(1..insert_count, fn i ->
             index = {System.system_time() + i, :update_aex9_presence}
             m_task = Model.async_tasks(index: index, args: [<<i::256>>])
-            Mnesia.dirty_write(Model.AsyncTasks, m_task)
+            Database.dirty_write(Model.AsyncTasks, m_task)
             index
           end)
         end
 
       on_exit(fn ->
         :mnesia.sync_dirty(fn ->
-          Enum.each(keys_to_delete, &Mnesia.delete(Model.AsyncTasks, &1))
-          Enum.each(existing_tasks, &Mnesia.write(Model.AsyncTasks, &1))
+          Enum.each(keys_to_delete, &Database.delete(Model.AsyncTasks, &1))
+          Enum.each(existing_tasks, &Database.write(Model.AsyncTasks, &1))
         end)
       end)
 

--- a/test/ae_mdw/sync/async_tasks/store_test.exs
+++ b/test/ae_mdw/sync/async_tasks/store_test.exs
@@ -2,7 +2,7 @@ defmodule AeMdw.Sync.AsyncTasks.StoreTest do
   use ExUnit.Case
 
   alias AeMdw.Db.Model
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Sync.AsyncTasks.Store
 
   require Model
@@ -59,7 +59,7 @@ defmodule AeMdw.Sync.AsyncTasks.StoreTest do
     :mnesia.sync_dirty(fn ->
       Model.AsyncTasks
       |> :mnesia.select(task_mspec)
-      |> Enum.each(&Mnesia.delete(Model.AsyncTasks, &1))
+      |> Enum.each(&Database.delete(Model.AsyncTasks, &1))
     end)
   end
 end

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -11,7 +11,7 @@ defmodule AeMdwWeb.NameControllerTest do
   alias AeMdw.Db.Model.Tx
   alias AeMdw.Db.Name
   alias AeMdw.Db.Util, as: DbUtil
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Validate
   alias AeMdw.TestSamples, as: TS
   alias AeMdw.Txs
@@ -27,7 +27,7 @@ defmodule AeMdwWeb.NameControllerTest do
       next_exp_key = TS.name_expiration_key(1)
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              ActiveNameExpiration, :backward, nil ->
@@ -83,7 +83,7 @@ defmodule AeMdwWeb.NameControllerTest do
       limit = 3
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              ActiveName, :forward, _exp_key ->
@@ -144,7 +144,7 @@ defmodule AeMdwWeb.NameControllerTest do
       {_exp, plain_name} = key1 = TS.name_expiration_key(0)
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              ActiveNameExpiration, :backward, nil -> {:ok, key1}
@@ -188,7 +188,7 @@ defmodule AeMdwWeb.NameControllerTest do
   describe "inactive_names" do
     test "get inactive names with default limit", %{conn: conn} do
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              InactiveNameExpiration, :backward, nil ->
@@ -242,7 +242,7 @@ defmodule AeMdwWeb.NameControllerTest do
       limit = 6
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              InactiveNameExpiration, :forward, _exp_key ->
@@ -289,7 +289,7 @@ defmodule AeMdwWeb.NameControllerTest do
       limit = 3
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              InactiveName, :forward, nil -> {:ok, TS.plain_name(0)}
@@ -350,7 +350,7 @@ defmodule AeMdwWeb.NameControllerTest do
       {_exp, plain_name} = expiration_key = TS.name_expiration_key(0)
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            fetch: fn InactiveName, ^plain_name -> :not_found end,
            prev_key: fn AuctionBid, _key ->
@@ -391,7 +391,7 @@ defmodule AeMdwWeb.NameControllerTest do
       {_exp, plain_name} = expiration_key = TS.name_expiration_key(0)
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            fetch: fn InactiveName, ^plain_name -> :not_found end,
            prev_key: fn AuctionBid, _key ->
@@ -432,7 +432,7 @@ defmodule AeMdwWeb.NameControllerTest do
       {_exp, plain_name} = expiration_key = TS.name_expiration_key(0)
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            fetch: fn InactiveName, ^plain_name -> :not_found end,
            prev_key: fn AuctionBid, _key ->
@@ -484,7 +484,7 @@ defmodule AeMdwWeb.NameControllerTest do
       conn: conn
     } do
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              ActiveNameExpiration, :backward, nil ->
@@ -530,7 +530,7 @@ defmodule AeMdwWeb.NameControllerTest do
       limit = 2
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              ActiveNameExpiration, :backward, nil ->
@@ -581,7 +581,7 @@ defmodule AeMdwWeb.NameControllerTest do
       first_key = TS.plain_name(0)
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              ActiveName, :forward, nil -> {:ok, first_key}

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -11,7 +11,7 @@ defmodule AeMdwWeb.OracleControllerTest do
   alias AeMdw.Db.Model.InactiveOracleExpiration
   alias AeMdw.Db.Model.Block
   alias AeMdw.Db.Oracle
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.TestSamples, as: TS
 
   describe "oracles" do
@@ -21,7 +21,7 @@ defmodule AeMdwWeb.OracleControllerTest do
       last_gen = TS.last_gen()
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              ActiveOracleExpiration, :backward, nil ->
@@ -63,7 +63,7 @@ defmodule AeMdwWeb.OracleControllerTest do
       encoded_pk = :aeser_api_encoder.encode(:oracle_pubkey, pk)
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            next_key: fn
              ActiveOracleExpiration, :backward, nil -> {:ok, {1, "a"}}
@@ -99,7 +99,7 @@ defmodule AeMdwWeb.OracleControllerTest do
       encoded_pk = :aeser_api_encoder.encode(:oracle_pubkey, pk)
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> oracle end,
@@ -121,7 +121,7 @@ defmodule AeMdwWeb.OracleControllerTest do
 
         assert %{"oracle" => ^encoded_pk} = oracle1
 
-        assert_called(Mnesia.last_key(Block))
+        assert_called(Database.last_key(Block))
       end
     end
 
@@ -131,7 +131,7 @@ defmodule AeMdwWeb.OracleControllerTest do
       next_cursor_query_value = "#{next_cursor_exp}-#{next_cursor_pk_encoded}"
 
       with_mocks [
-        {Mnesia, [],
+        {Database, [],
          [
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            next_key: fn ActiveOracleExpiration, _dir, _key -> {:ok, expiration_key} end,

--- a/test/integration/ae_mdw/db/sync/contract_test.exs
+++ b/test/integration/ae_mdw/db/sync/contract_test.exs
@@ -9,17 +9,17 @@ defmodule Integration.AeMdw.Db.Sync.ContractTest do
   alias AeMdw.Db.NameTransferMutation
   alias AeMdw.Db.NameUpdateMutation
   alias AeMdw.Db.Sync
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Model
 
   describe "events_mutations/4" do
     test "creates name transfer mutation" do
       {"AENS.transfer", call_txi, _local_idx} =
-        Mnesia.dirty_next(Model.FnameIntContractCall, {"AENS.transfer", -1, -1})
+        Database.dirty_next(Model.FnameIntContractCall, {"AENS.transfer", -1, -1})
 
       [Model.tx(block_index: {height, mbi} = block_index, id: tx_hash)] =
-        Mnesia.dirty_read(Model.Tx, call_txi)
+        Database.dirty_read(Model.Tx, call_txi)
 
       {_key_block, micro_blocks} = NodeDb.get_blocks(height)
 
@@ -45,10 +45,10 @@ defmodule Integration.AeMdw.Db.Sync.ContractTest do
 
     test "creates name update mutation" do
       {"AENS.update", call_txi, _local_idx} =
-        Mnesia.dirty_next(Model.FnameIntContractCall, {"AENS.update", -1, -1})
+        Database.dirty_next(Model.FnameIntContractCall, {"AENS.update", -1, -1})
 
       [Model.tx(block_index: {height, mbi} = block_index, id: tx_hash)] =
-        Mnesia.dirty_read(Model.Tx, call_txi)
+        Database.dirty_read(Model.Tx, call_txi)
 
       {_key_block, micro_blocks} = NodeDb.get_blocks(height)
 

--- a/test/integration/ae_mdw/sync/contract_call_mutation_test.exs
+++ b/test/integration/ae_mdw/sync/contract_call_mutation_test.exs
@@ -10,7 +10,7 @@ defmodule Integration.AeMdw.Db.ContractCallMutationTest do
   alias AeMdw.Db.Origin
   alias AeMdw.Db.Sync
   alias AeMdw.Db.Util
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Validate
   alias Support.AeMdw.Db.ContractTestUtil
 
@@ -166,10 +166,10 @@ defmodule Integration.AeMdw.Db.ContractCallMutationTest do
       assert {^name, ^symbol, ^decimals} = aex9_meta_info
 
       # delete if already synced
-      Mnesia.delete(Model.Aex9Contract, {name, symbol, txi, decimals})
-      Mnesia.delete(Model.Aex9ContractSymbol, {symbol, name, txi, decimals})
-      Mnesia.delete(Model.RevAex9Contract, {txi, name, symbol, decimals})
-      Mnesia.delete(Model.Aex9ContractPubkey, contract_pk)
+      Database.delete(Model.Aex9Contract, {name, symbol, txi, decimals})
+      Database.delete(Model.Aex9ContractSymbol, {symbol, name, txi, decimals})
+      Database.delete(Model.RevAex9Contract, {txi, name, symbol, decimals})
+      Database.delete(Model.Aex9ContractPubkey, contract_pk)
 
       call_mutation =
         ContractCallMutation.new(
@@ -189,14 +189,15 @@ defmodule Integration.AeMdw.Db.ContractCallMutationTest do
       m_rev_contract = Model.rev_aex9_contract(index: {txi, name, symbol, decimals})
       m_contract_pk = Model.aex9_contract_pubkey(index: contract_pk, txi: txi)
 
-      assert [^m_contract] = Mnesia.read(Model.Aex9Contract, {name, symbol, txi, decimals})
+      assert [^m_contract] = Database.read(Model.Aex9Contract, {name, symbol, txi, decimals})
 
       assert [^m_contract_sym] =
-               Mnesia.read(Model.Aex9ContractSymbol, {symbol, name, txi, decimals})
+               Database.read(Model.Aex9ContractSymbol, {symbol, name, txi, decimals})
 
-      assert [^m_rev_contract] = Mnesia.read(Model.RevAex9Contract, {txi, name, symbol, decimals})
+      assert [^m_rev_contract] =
+               Database.read(Model.RevAex9Contract, {txi, name, symbol, decimals})
 
-      assert [^m_contract_pk] = Mnesia.read(Model.Aex9ContractPubkey, contract_pk)
+      assert [^m_contract_pk] = Database.read(Model.Aex9ContractPubkey, contract_pk)
 
       :mnesia.abort(:rollback)
     end

--- a/test/integration/ae_mdw/sync/oracle_test.exs
+++ b/test/integration/ae_mdw/sync/oracle_test.exs
@@ -9,7 +9,7 @@ defmodule Integration.AeMdw.Db.Sync.OracleTest do
   alias AeMdw.Db.OracleExtendMutation
   alias AeMdw.Db.Sync
   alias AeMdw.Db.Util
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
 
   require Model
 
@@ -30,10 +30,10 @@ defmodule Integration.AeMdw.Db.Sync.OracleTest do
             ttl
           )
 
-        Mnesia.transaction([mutation])
+        Database.transaction([mutation])
 
         assert [Model.oracle(index: ^pubkey, expire: ^new_expiration)] =
-                 Mnesia.read(Model.ActiveOracle, pubkey)
+                 Database.read(Model.ActiveOracle, pubkey)
 
         :mnesia.abort(:rollback)
       end
@@ -52,9 +52,9 @@ defmodule Integration.AeMdw.Db.Sync.OracleTest do
             123
           )
 
-        Mnesia.transaction([mutation])
+        Database.transaction([mutation])
 
-        assert [] = Mnesia.read(Model.ActiveOracle, pubkey)
+        assert [] = Database.read(Model.ActiveOracle, pubkey)
 
         :mnesia.abort(:rollback)
       end
@@ -88,7 +88,7 @@ defmodule Integration.AeMdw.Db.Sync.OracleTest do
         m_oracle = Util.read!(Model.ActiveOracle, pubkey)
 
         m_old_exp = Model.expiration(index: {height - 1, pubkey})
-        Mnesia.write(Model.ActiveOracleExpiration, m_old_exp)
+        Database.write(Model.ActiveOracleExpiration, m_old_exp)
 
         (height - 1)
         |> Oracle.expirations_mutation()

--- a/test/support/ae_mdw/db/contract_test_util.ex
+++ b/test/support/ae_mdw/db/contract_test_util.ex
@@ -4,7 +4,7 @@ defmodule Support.AeMdw.Db.ContractTestUtil do
   """
 
   alias AeMdw.Node.Db
-  alias AeMdw.Mnesia
+  alias AeMdw.Database
   alias AeMdw.Db.Model
 
   require Model
@@ -21,8 +21,8 @@ defmodule Support.AeMdw.Db.ContractTestUtil do
     Model.Aex9AccountPresence
     |> :mnesia.select(presence_mspec)
     |> Enum.each(fn {account_pk, txi, contract_pk} ->
-      Mnesia.delete(Model.Aex9AccountPresence, {account_pk, txi, contract_pk})
-      Mnesia.delete(Model.IdxAex9AccountPresence, {txi, account_pk, contract_pk})
+      Database.delete(Model.Aex9AccountPresence, {account_pk, txi, contract_pk})
+      Database.delete(Model.IdxAex9AccountPresence, {txi, account_pk, contract_pk})
     end)
   end
 end


### PR DESCRIPTION
## What

Rename `AeMdw.Mnesia` to `AeMdw.Database`

## Why

Additional step to #529

## Additional notes

`dirty_prev_key` added and called dirty because it reads through the transaction (uncommitted data first) like `:mnesia.prev`.
The pre-existing `Database.prev_key` uses `:mnesia.dirty_prev` but despite this `:mnesia` name it reads directly from the database. 