### PR TITLE
feat: add /v2 routes to support versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Type groups for the transactions listed above are:
 
 `type` parameter:
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?type=channel_create&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?type=channel_create&limit=1" | jq '.'
 {
   "data": [
     {
@@ -337,13 +337,13 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?type=channel_create&limi
       "tx_index": 87
     }
   ],
-  "next": "/txs/forward?cursor=73270&limit=1&type=channel_create"
+  "next": "/v2/txs/forward?cursor=73270&limit=1&type=channel_create"
 }
 ```
 
 `type_group` parameter:
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?type_group=oracle&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?type_group=oracle&limit=1" | jq '.'
 {
   "data": [
     {
@@ -374,7 +374,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?type_group=oracle&limit=
       "tx_index": 8891
     }
   ],
-  "next": "/txs/forward?cursor=8892&limit=1&type_group=oracle"
+  "next": "/v2/txs/forward?cursor=8892&limit=1&type_group=oracle"
 }
 ```
 
@@ -398,7 +398,7 @@ With generic ids, it is possible to select also `create`/`register` transactions
 ###### Examples
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?contract=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?contract=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=2" | jq '.'
 {
   "data": [
     {
@@ -482,12 +482,12 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?contract=ct_2AfnEfCSZCTE
       "tx_index": 8395071
     }
   ],
-  "next": "/txs/forward?contract=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&cursor=8401663&limit=2"
+  "next": "/v2/txs/forward?contract=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&cursor=8401663&limit=2"
 }
 ```
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?oracle=ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?oracle=ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR&limit=1" | jq '.'
 {
   "data": [
     {
@@ -519,12 +519,12 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?oracle=ok_24jcHLTZQfsou7
       "tx_index": 600284
     }
   ],
-  "next": "/txs/forward?cursor=600286&limit=1&oracle=ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR"
+  "next": "/v2/txs/forward?cursor=600286&limit=1&oracle=ok_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR"
 }
 ```
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?channel=ch_22usvXSjYaDPdhecyhub7tZnYpHeCEZdscEEyhb2M4rHb58RyD&limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?channel=ch_22usvXSjYaDPdhecyhub7tZnYpHeCEZdscEEyhb2M4rHb58RyD&limit=2" | jq '.'
 {
   "data": [
     {
@@ -578,7 +578,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?channel=ch_22usvXSjYaDPd
       "tx_index": 94616
     }
   ],
-  "next": "/txs/forward?channel=ch_22usvXSjYaDPdhecyhub7tZnYpHeCEZdscEEyhb2M4rHb58RyD&cursor=94617&limit=2"
+  "next": "/v2/txs/forward?channel=ch_22usvXSjYaDPdhecyhub7tZnYpHeCEZdscEEyhb2M4rHb58RyD&cursor=94617&limit=2"
 }
 ```
 
@@ -657,7 +657,7 @@ For example, for a GAMetaTx with inner SpendTx, one might request with the follo
 
 with provided transaction type (`name_transfer`):
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?name_transfer.recipient_id=ak_idkx6m3bgRr7WiKXuB8EBYBoRqVsaSc6qo4dsd23HKgj3qiCF&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?name_transfer.recipient_id=ak_idkx6m3bgRr7WiKXuB8EBYBoRqVsaSc6qo4dsd23HKgj3qiCF&limit=1" | jq '.'
 {
   "data": [
     {
@@ -682,13 +682,13 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?name_transfer.recipient_
       "tx_index": 11700056
     }
   ],
-  "next": "/txs/forward?cursor=11734834&limit=1&name_transfer.recipient_id=ak_idkx6m3bgRr7WiKXuB8EBYBoRqVsaSc6qo4dsd23HKgj3qiCF"
+  "next": "/v2/txs/forward?cursor=11734834&limit=1&name_transfer.recipient_id=ak_idkx6m3bgRr7WiKXuB8EBYBoRqVsaSc6qo4dsd23HKgj3qiCF"
 }
 ```
 
 freestanding field `from_id`, and via `jq` extracting only tx_index and transaction type:
 ```
-curl -s "https://mainnet.aeternity.io/mdw/txs/backward?from_id=ak_ozzwBYeatmuN818LjDDDwRSiBSvrqt4WU7WvbGsZGVre72LTS&limit=5" | jq '.data | .[] | [.tx_index, .tx.type]'
+curl -s "https://mainnet.aeternity.io/mdw/v2/txs/backward?from_id=ak_ozzwBYeatmuN818LjDDDwRSiBSvrqt4WU7WvbGsZGVre72LTS&limit=5" | jq '.data | .[] | [.tx_index, .tx.type]'
 [
   98535,
   "ChannelForceProgressTx"
@@ -736,7 +736,7 @@ retrieve a new page of results.
 
 getting the first transaction:
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&limit=1" | jq '.'
 {
   "data": [
     {
@@ -761,14 +761,14 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?account=ak_E64bTuWTVj9Hu
       "tx_index": 1776073
     }
   ],
-  "next": "/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=1779354&limit=1",
-  "prev": "/txs/backward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=19813844&limit=1&rev=1"
+  "next": "/v2/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=1779354&limit=1",
+  "prev": "/v2/txs/backward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=19813844&limit=1&rev=1"
 }
 ```
 
 getting the next transaction by prepending host (https://mainnet.aeternity.io/mdw) to the continuation-URL from last request:
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=1779354&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=1779354&limit=1" | jq '.'
 {
   "data": [
     {
@@ -793,8 +793,8 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?account=ak_E64bTuWTVj9Hu
       "tx_index": 1779354
     }
   ],
-  "next": "/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=1779356&limit=1",
-  "prev": "/txs/backward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=1776073&limit=1&rev=1"
+  "next": "/v2/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=1779356&limit=1",
+  "prev": "/v2/txs/backward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&cursor=1776073&limit=1&rev=1"
 }
 ```
 
@@ -814,7 +814,7 @@ If `type` or `type_group` is provided, the transaction in the result set must be
 
 transactions where each transaction contains both accounts, no matter at which field:
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/backward?account=ak_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR&account=ak_zUQikTiUMNxfKwuAfQVMPkaxdPsXP8uAxnfn6TkZKZCtmRcUD&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/backward?account=ak_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR&account=ak_zUQikTiUMNxfKwuAfQVMPkaxdPsXP8uAxnfn6TkZKZCtmRcUD&limit=1" | jq '.'
 {
   "data": [
     {
@@ -840,14 +840,14 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/backward?account=ak_24jcHLTZQfso
       "tx_index": 1747960
     }
   ],
-  "next": "/txs/backward?account=ak_zUQikTiUMNxfKwuAfQVMPkaxdPsXP8uAxnfn6TkZKZCtmRcUD&cursor=17022424&limit=1",
+  "next": "/v2/txs/backward?account=ak_zUQikTiUMNxfKwuAfQVMPkaxdPsXP8uAxnfn6TkZKZCtmRcUD&cursor=17022424&limit=1",
   "prev": null
 }
 ```
 
 spend transactions between sender and recipient (transaction type = spend is deduced from the fields):
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?sender_id=ak_26dopN3U2zgfJG4Ao4J4ZvLTf5mqr7WAgLAq6WxjxuSapZhQg5&recipient_id=ak_r7wvMxmhnJ3cMp75D8DUnxNiAvXs8qcdfbJ1gUWfH8Ufrx2A2&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?sender_id=ak_26dopN3U2zgfJG4Ao4J4ZvLTf5mqr7WAgLAq6WxjxuSapZhQg5&recipient_id=ak_r7wvMxmhnJ3cMp75D8DUnxNiAvXs8qcdfbJ1gUWfH8Ufrx2A2&limit=1" | jq '.'
 {
   "data": [
     {
@@ -872,14 +872,14 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?sender_id=ak_26dopN3U2zg
       "tx_index": 9
     }
   ],
-  "next": "/txs/forward?cursor=41&limit=1&recipient_id=ak_r7wvMxmhnJ3cMp75D8DUnxNiAvXs8qcdfbJ1gUWfH8Ufrx2A2&sender_id=ak_26dopN3U2zgfJG4Ao4J4ZvLTf5mqr7WAgLAq6WxjxuSapZhQg5",
+  "next": "/v2/txs/forward?cursor=41&limit=1&recipient_id=ak_r7wvMxmhnJ3cMp75D8DUnxNiAvXs8qcdfbJ1gUWfH8Ufrx2A2&sender_id=ak_26dopN3U2zgfJG4Ao4J4ZvLTf5mqr7WAgLAq6WxjxuSapZhQg5",
   "prev": null
 }
 ```
 
 name related transactions for account:
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&type_group=name" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/forward?account=ak_E64bTuWTVj9Hu5EQSgyTGZp27diFKohTQWw3AYnmgVSWCnfnD&type_group=name" | jq '.'
 {
   "data": [
     {
@@ -1129,7 +1129,7 @@ This design decouples query construction and actual consumption of the result se
 ### Get transaction by hash
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/tx/th_zATv7B4RHS45GamShnWgjkvcrQfZUWQkZ8gk1RD4m2uWLJKnq" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/tx/th_zATv7B4RHS45GamShnWgjkvcrQfZUWQkZ8gk1RD4m2uWLJKnq" | jq '.'
 {
   "block_hash": "mh_2kE3N7GCaeAiowu1a7dopJygxQfxvRXYCNy7Pc657arjCa8PPe",
   "block_height": 257058,
@@ -1157,7 +1157,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/tx/th_zATv7B4RHS45GamShnWgjkvcrQfZUW
 ### Get transaction by index
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txi/10000000" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txi/10000000" | jq '.'
 {
   "block_hash": "mh_2J4A4f7RJ4oVKKCFmBEDMQpqacLZFtJ5oBvx3fUUABmLv5SUZH",
   "block_height": 240064,
@@ -1187,14 +1187,14 @@ $ curl -s "https://mainnet.aeternity.io/mdw/txi/10000000" | jq '.'
 #### All transactions
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/count" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/count" | jq '.'
 11921825
 ```
 
 #### Transactions by type/field for ID
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/txs/count/ak_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/txs/count/ak_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR" | jq '.'
 {
   "channel_create_tx": {
     "responder_id": 74
@@ -1248,7 +1248,7 @@ A generation can be understood as key block and micro blocks containing transact
 ### Single block by hash
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/block/kh_uoTGwc4HPzEW9qmiQR1zmVVdHmzU6YmnVvdFe6HvybJJRj7V6" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/block/kh_uoTGwc4HPzEW9qmiQR1zmVVdHmzU6YmnVvdFe6HvybJJRj7V6" | jq '.'
 {
   "beneficiary": "ak_2MR38Zf355m6JtP13T3WEcUcSLVLCxjGvjk6zG95S2mfKohcSS",
   "hash": "kh_uoTGwc4HPzEW9qmiQR1zmVVdHmzU6YmnVvdFe6HvybJJRj7V6",
@@ -1267,7 +1267,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/block/kh_uoTGwc4HPzEW9qmiQR1zmVVdHmz
 ```
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/block/mh_25TNGuEkVGckfrH3rVwHiUsm2GFB17mKFEF3hYHR3zQrVXCRrp" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/block/mh_25TNGuEkVGckfrH3rVwHiUsm2GFB17mKFEF3hYHR3zQrVXCRrp" | jq '.'
 {
   "hash": "mh_25TNGuEkVGckfrH3rVwHiUsm2GFB17mKFEF3hYHR3zQrVXCRrp",
   "height": 123003,
@@ -1287,7 +1287,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/block/mh_25TNGuEkVGckfrH3rVwHiUsm2GF
 Key block of the whole generation can be identified by one non-negative integer (height).
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/blocki/1234" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/blocki/1234" | jq '.'
 {
   "beneficiary": "ak_2RGTeERHPm9zCo9EsaVAh8tDcsetFSVsD9VVi5Dk1n94wF3EKm",
   "hash": "kh_2L9i7dMqrYiUs6um71kwnZsNDqD9xBbD71EiVoWFtbMUKs2Tka",
@@ -1308,7 +1308,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/blocki/1234" | jq '.'
 Micro block is identified by height and sequence id (order) withing the generation, starting from 0.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/blocki/300000/0" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/blocki/300000/0" | jq '.'
 {
   "hash": "mh_2Nyaoy9CCPa8WBfzGbWXy5rd6AahJpBFxyXM9MMpCrvCqpkFj",
   "height": 300000,
@@ -1550,7 +1550,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/v2/blocks/101125-101125" | jq '.'
 Numeric range:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/blocks/100000-100100?limit=3" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/blocks/100000-100100?limit=3" | jq '.'
 {
   "data": [
     {
@@ -1736,7 +1736,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/blocks/100000-100100?limit=3" | jq '
       "version": 3
     }
   ],
-  "next": "/blocks/100000-100100?cursor=100003&limit=3",
+  "next": "/v2/blocks/100000-100100?cursor=100003&limit=3",
   "prev": null
 }
 ```
@@ -1760,7 +1760,7 @@ Due to this reason, all name endpoints except `name/pointers` and `name/pointees
 ### Name Resolution
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/name/bear.test" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/name/bear.test" | jq '.'
 {
   "active": false,
   "hash": "nm_2aGpF2uJp1wDpuHoNDhhSztpoQr43dAjzZ5SyvfD2RSKTVmL6X",
@@ -1814,7 +1814,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/name/bear.test" | jq '.'
 It's possible to use encoded hash as well:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/name/nm_MwcgT7ybkVYnKFV6bPqhwYq2mquekhZ2iDNTunJS2Rpz3Njuj" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/name/nm_MwcgT7ybkVYnKFV6bPqhwYq2mquekhZ2iDNTunJS2Rpz3Njuj" | jq '.'
 {
   "active": true,
   "hash": "nm_MwcgT7ybkVYnKFV6bPqhwYq2mquekhZ2iDNTunJS2Rpz3Njuj",
@@ -1847,7 +1847,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/name/nm_MwcgT7ybkVYnKFV6bPqhwYq2mque
 If there's no suffix (`.chain` or `.test`), `.chain` is added by default:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/name/aeternity" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/name/aeternity" | jq '.'
 {
   "active": true,
   "hash": "nm_S4ofw6861biSJrXgHuJPo7VotLbrY8P9ngTLvgrRwbDEA3svc",
@@ -1891,7 +1891,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/name/aeternity" | jq '.'
 If the name is currently in auction, the reply has different shape:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/name/help" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/name/help" | jq '.'
 {
   "active": false,
   "hash": "nm_2WoR2PCFXeLiLQH8C7GVbGpU57qDBqkQbPvaML8w3ijMQiei7E",
@@ -1933,7 +1933,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/name/help" | jq '.'
 With `expand` parameter, notice how `claims` and `updates` have the transaction detail inlined:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/name/cryptobase.chain?expand" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/name/cryptobase.chain?expand" | jq '.'
 {
   "active": true,
   "hash": "nm_2vAFLnmRbsQTNeZi9PzFgVWY6Un9rszFDaE3ubYqk1oJURxJ97",
@@ -2015,7 +2015,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/name/cryptobase.chain?expand" | jq '
 Auction specific name resolution is available behind endpoint `name/auction/:id`:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/name/auction/nikita.chain" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/name/auction/nikita.chain" | jq '.'
 {
   "active": false,
   "hash": "nm_2s2gjxQFYzcShL9gva2jWvzZ7mHPe4m6X6pqbyuSipZKCg1DLV",
@@ -2071,7 +2071,7 @@ In this case the reply has a single key:
 Example below is fabricated, to present the shape of the responses:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/owned_by/ak_25BWMx4An9mmQJNPSwJisiENek3bAGadze31Eetj4K4JJC8VQN" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names/owned_by/ak_25BWMx4An9mmQJNPSwJisiENek3bAGadze31Eetj4K4JJC8VQN" | jq '.'
 {
   "active": [
     {
@@ -2189,7 +2189,7 @@ The parameter `limit` (by default = 10) is optional, and limits the number of el
 #### All names
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names?limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names?limit=2" | jq '.'
 {
   "data": [
     {
@@ -2331,7 +2331,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/names?limit=2" | jq '.'
       "status": "name"
     }
   ],
-  "next": "/names?by=expiration&cursor=703645-jiangjiajia.chain&direction=backward&expand=false&limit=2",
+  "next": "/v2/names?by=expiration&cursor=703645-jiangjiajia.chain&direction=backward&expand=false&limit=2",
   "prev": null
 }
 ```
@@ -2342,7 +2342,7 @@ For demonstration, they are ordered by `expiration` with direction `forward`.
 This means, we list from oldest to newest expired names.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/inactive?by=expiration&direction=forward&limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names/inactive?by=expiration&direction=forward&limit=2" | jq '.'
 {
   "data": [
     {
@@ -2400,7 +2400,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/names/inactive?by=expiration&directi
       "status": "name"
     }
   ],
-  "next": "/names/inactive?cursor=16117-philippsdk1.test&direction=forward&expand=false&limit=2",
+  "next": "/v2/names/inactive?cursor=16117-philippsdk1.test&direction=forward&expand=false&limit=2",
   "prev": null
 }
 ```
@@ -2411,7 +2411,7 @@ For demonstration, they are sorted by `name`.
 Without `direction` parameter, default value `backward` is used.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/active?by=name&limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names/active?by=name&limit=2" | jq '.'
 {
   "data": [
     {
@@ -2483,7 +2483,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/names/active?by=name&limit=2" | jq '
       "status": "name"
     }
   ],
-  "next": "/names/active?cursor=zz.chain&direction=backward&expand=false&limit=2",
+  "next": "/v2/names/active?cursor=zz.chain&direction=backward&expand=false&limit=2",
   "prev": null
 }
 ```
@@ -2493,7 +2493,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/names/active?by=name&limit=2" | jq '
 Without ordering parameters, the first auction in reply set expires the latest.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/auctions?limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names/auctions?limit=2" | jq '.'
 {
   "data": [
     {
@@ -2573,7 +2573,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/names/auctions?limit=2" | jq '.'
       "status": "auction"
     }
   ],
-  "next": "/names/auctions?cursor=548763-svs.chain&direction=backward&expand=false&limit=2",
+  "next": "/v2/names/auctions?cursor=548763-svs.chain&direction=backward&expand=false&limit=2",
   "prev": null
 }
 ```
@@ -2581,7 +2581,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/names/auctions?limit=2" | jq '.'
 To show auctions starting with the one expiring the earliest:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/auctions?by=expiration&direction=forward&limit=2" | jq '.data [] .info.auction_end'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names/auctions?by=expiration&direction=forward&limit=2" | jq '.data [] .info.auction_end'
 300490
 300636
 ```
@@ -2589,7 +2589,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/names/auctions?by=expiration&directi
 Or, ordered by name, from the begining:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/auctions?by=name&direction=forward&limit=1000" | jq '.data [] .name'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names/auctions?by=name&direction=forward&limit=1000" | jq '.data [] .name'
 "0.chain"
 "5.chain"
 "6.chain"
@@ -2617,7 +2617,7 @@ Prefix searching of names is possible via `/names/search` endpoint.
 By default, the prefix search will find names in any of the lifecycle states - auction, active, inactive.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/search/xxxxxx" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names/search/xxxxxx" | jq '.'
 [
   {
     "active": false,
@@ -2671,7 +2671,7 @@ Via the `only` parameter, it's possible to search for a name in particular lifec
 The parameter can be repeated:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/search/aaa?only=auction&only=inactive" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names/search/aaa?only=auction&only=inactive" | jq '.'
 [
   {
     "active": false,
@@ -2746,7 +2746,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/names/search/aaa?only=auction&only=i
 This endpoint also accepts the `expand` parameter:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/search/asdf?expand" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/names/search/asdf?expand" | jq '.'
 [
   {
     "active": false,
@@ -2856,7 +2856,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/names/search/asdf?expand" | jq '.'
 This is basically a restricted reply from `name/:id` endpoint, returning just pointers.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/name/pointers/wwwbeaconoidcom.chain" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/name/pointers/wwwbeaconoidcom.chain" | jq '.'
 {
   "account_pubkey": "ak_2HNsyfhFYgByVq8rzn7q4hRbijsa8LP1VN192zZwGm1JRYnB5C"
 }
@@ -2867,7 +2867,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/name/pointers/wwwbeaconoidcom.chain"
 Returns names pointing to a particular pubkey, partitioned into `active` and `inactive` sets.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/name/pointees/ak_2HNsyfhFYgByVq8rzn7q4hRbijsa8LP1VN192zZwGm1JRYnB5C" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/name/pointees/ak_2HNsyfhFYgByVq8rzn7q4hRbijsa8LP1VN192zZwGm1JRYnB5C" | jq '.'
 {
   "active": {
     "account_pubkey": [
@@ -2897,7 +2897,7 @@ A paginable contract log endpoint allows querying of the contract logs using sev
 
 Example output of
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/forward?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/logs/forward?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=1" | jq '.'
 {
   "data": [
     {
@@ -2916,7 +2916,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/forward?contract_id=c
       "log_idx": 0
     }
   ],
-  "next": "contracts/logs/gen/0-370592?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=1&page=2"
+  "next": "/v2contracts/logs/gen/0-370592?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=1&page=2"
 }
 ```
 
@@ -2988,7 +2988,7 @@ For demonstration, we will use `limit` parameter to limit the amount of output.
 Listing the first contract log in the chain:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/forward?limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/logs/forward?limit=1" | jq '.'
 {
   "data": [
     {
@@ -3007,14 +3007,14 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/forward?limit=1" | jq
       "log_idx": 0
     }
   ],
-  "next": "contracts/logs/gen/0-370592?limit=1&page=2"
+  "next": "/v2contracts/logs/gen/0-370592?limit=1&page=2"
 }
 ```
 
 Listing the last (to date) contract log in the chain:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/backward?limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/logs/backward?limit=1" | jq '.'
 {
   "data": [
     {
@@ -3034,7 +3034,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/backward?limit=1" | j
       "log_idx": 2
     }
   ],
-  "next": "contracts/logs/gen/370592-0?limit=1&page=2",
+  "next": "/v2contracts/logs/gen/370592-0?limit=1&page=2",
   "prev": null
 }
 ```
@@ -3042,7 +3042,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/backward?limit=1" | j
 Listing contract logs in range between generations 200000 and 210000:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/gen/200000-210000?limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/logs/gen/200000-210000?limit=1" | jq '.'
 {
   "data": [
     {
@@ -3061,7 +3061,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/gen/200000-210000?lim
       "log_idx": 0
     }
   ],
-  "next": "contracts/logs/gen/200000-210000?limit=1&page=2",
+  "next": "/v2contracts/logs/gen/200000-210000?limit=1&page=2",
   "prev": null
 }
 ```
@@ -3069,7 +3069,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/gen/200000-210000?lim
 Listing contract logs in generation 250109 only:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/gen/250109?limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/logs/gen/250109?limit=1" | jq '.'
 {
   "data": [
     {
@@ -3088,7 +3088,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/gen/250109?limit=1" |
       "log_idx": 0
     }
   ],
-  "next": "contracts/logs/gen/250109-250109?limit=1&page=2",
+  "next": "/v2contracts/logs/gen/250109-250109?limit=1&page=2",
   "prev": null
 }
 ```
@@ -3096,7 +3096,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/gen/250109?limit=1" |
 Listing contract logs from transaction index 15000000 downto 5000000 - e.g. backwards (note descending call_txi):
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/txi/15000000-5000000?limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/logs/txi/15000000-5000000?limit=2" | jq '.'
 {
   "data": [
     {
@@ -3130,7 +3130,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/txi/15000000-5000000?
       "log_idx": 0
     }
   ],
-  "next": "contracts/logs/txi/15000000-5000000?limit=2&page=2",
+  "next": "/v2contracts/logs/txi/15000000-5000000?limit=2&page=2",
   "prev": null
 }
 ```
@@ -3152,7 +3152,7 @@ Without provided range or direction, the logs are listed from newest to latest.
 Listing latest logs for given contract:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/logs?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=2" | jq '.'
 {
   "data": [
     {
@@ -3186,7 +3186,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs?contract_id=ct_2AfnEf
       "log_idx": 0
     }
   ],
-  "next": "contracts/logs/txi/19626064-0?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=2&page=2",
+  "next": "/v2contracts/logs/txi/19626064-0?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=2&page=2",
   "prev": null
 }
 ```
@@ -3195,7 +3195,7 @@ Listing first logs where data field points to `aeternity.com`:
 (The value of data parameter needs to be URL encoded, which is not visible in this example)
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/forward?data=aeternity.com&limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/logs/forward?data=aeternity.com&limit=2" | jq '.'
 {
   "data": [
     {
@@ -3227,7 +3227,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/forward?data=aeternit
       "log_idx": 0
     }
   ],
-  "next": "contracts/logs/gen/0-370592?data=aeternity.com&limit=2&page=2",
+  "next": "/v2contracts/logs/gen/0-370592?data=aeternity.com&limit=2&page=2",
   "prev": null
 }
 ```
@@ -3235,7 +3235,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs/forward?data=aeternit
 Listing the last "TipReceived" event:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs?event=TipReceived&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/logs?event=TipReceived&limit=1" | jq '.'
 {
   "data": [
     {
@@ -3254,7 +3254,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/logs?event=TipReceived&lim
       "log_idx": 0
     }
   ],
-  "next": "contracts/logs/txi/19626064-0?event=TipReceived&limit=1&page=2",
+  "next": "/v2contracts/logs/txi/19626064-0?event=TipReceived&limit=1&page=2",
   "prev": null
 }
 ```
@@ -3272,7 +3272,7 @@ Besides specifying of scope and direction as with other streaming endpoints (via
 #### Using contract id
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/calls?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/calls?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=1" | jq '.'
 {
   "data": [
     {
@@ -3297,7 +3297,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/calls?contract_id=ct_2AfnE
       "micro_index": 9
     }
   ],
-  "next": "contracts/calls/txi/20309127-0?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=1&page=2",
+  "next": "/v2contracts/calls/txi/20309127-0?contract_id=ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z&limit=1&page=2",
   "prev": null
 }
 ```
@@ -3305,7 +3305,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/calls?contract_id=ct_2AfnE
 #### Using function prefix
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/calls/forward?function=Oracle&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/calls/forward?function=Oracle&limit=1" | jq '.'
 {
   "data": [
     {
@@ -3338,7 +3338,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/calls/forward?function=Ora
       "micro_index": 0
     }
   ],
-  "next": "contracts/calls/gen/0-403807?function=Oracle&limit=1&page=2",
+  "next": "/v2contracts/calls/gen/0-403807?function=Oracle&limit=1&page=2",
   "prev": null
 }
 ```
@@ -3352,7 +3352,7 @@ Following ID fields are recognized: account_id, caller_id, channel_id, commitmen
 Contract_id field is inaccessible via this lookup, as when present in query, it filters only contracts with given contract id and doesn't look into internal transaction's fields.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/contracts/calls?recipient_id=ak_23bfFKQ1vuLeMxyJuCrMHiaGg5wc7bAobKNuDadf8tVZUisKWs&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/contracts/calls?recipient_id=ak_23bfFKQ1vuLeMxyJuCrMHiaGg5wc7bAobKNuDadf8tVZUisKWs&limit=1" | jq '.'
 {
   "data": [
     {
@@ -3377,7 +3377,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/contracts/calls?recipient_id=ak_23bf
       "micro_index": 11
     }
   ],
-  "next": "contracts/calls/txi/20309760-0?limit=1&page=2&recipient_id=ak_23bfFKQ1vuLeMxyJuCrMHiaGg5wc7bAobKNuDadf8tVZUisKWs",
+  "next": "/v2contracts/calls/txi/20309760-0?limit=1&page=2&recipient_id=ak_23bfFKQ1vuLeMxyJuCrMHiaGg5wc7bAobKNuDadf8tVZUisKWs",
   "prev": null
 }
 ```
@@ -3406,7 +3406,7 @@ Besides specifying of scope and direction as with other streaming endpoints (via
 ### Listing internal transfers in range
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/transfers/gen/50002-70000?limit=3" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/transfers/gen/50002-70000?limit=3" | jq '.'
 {
   "data": [
     {
@@ -3431,7 +3431,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/transfers/gen/50002-70000?limit=3" |
       "ref_txi": 1516090
     }
   ],
-  "next": "/transfers/gen/50002-70000?cursor=6KO30C1I5GOJAC9M60SJ2936CLILUR3FCDLLURJ1DLII85B36T6B4BDUUA3PPOSNFT2NRAQ67SAGJVNC35N46VHNTU4SU3V14GOJAC9M60SJ2&limit=3",
+  "next": "/v2/transfers/gen/50002-70000?cursor=6KO30C1I5GOJAC9M60SJ2936CLILUR3FCDLLURJ1DLII85B36T6B4BDUUA3PPOSNFT2NRAQ67SAGJVNC35N46VHNTU4SU3V14GOJAC9M60SJ2&limit=3",
   "prev": null
 }
 ```
@@ -3439,7 +3439,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/transfers/gen/50002-70000?limit=3" |
 ### Listing internal transfers of a specific kind
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/transfers/forward?kind=reward_dev&limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/transfers/forward?kind=reward_dev&limit=2" | jq '.'
 {
   "data": [
     {
@@ -3457,7 +3457,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/transfers/forward?kind=reward_dev&li
       "ref_txi": null
     }
   ],
-  "next": "/transfers/forward?cursor=74O3IE1J5GMJ293ICLRM2SJ4BTI6ATH4LJOO0LBKD1ROVHB90J0E1JU8HBJ58RP6B4GUU5E9MUST24PSDM428B9H&kind=reward_dev&limit=2",
+  "next": "/v2/transfers/forward?cursor=74O3IE1J5GMJ293ICLRM2SJ4BTI6ATH4LJOO0LBKD1ROVHB90J0E1JU8HBJ58RP6B4GUU5E9MUST24PSDM428B9H&kind=reward_dev&limit=2",
   "prev": null
 }
 ```
@@ -3465,7 +3465,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/transfers/forward?kind=reward_dev&li
 ### Listing internal transfers related to specific account
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/transfers/backward?account=ak_7myFYvagcqh8AtWEuHL4zKDGfJj5bmacNZS8RoUh5qmam1a3J&limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/transfers/backward?account=ak_7myFYvagcqh8AtWEuHL4zKDGfJj5bmacNZS8RoUh5qmam1a3J&limit=1" | jq '.'
 {
   "data": [
     {
@@ -3476,7 +3476,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/transfers/backward?account=ak_7myFYv
       "ref_txi": 1680384
     }
   ],
-  "next": "/transfers/backward?account=ak_7myFYvagcqh8AtWEuHL4zKDGfJj5bmacNZS8RoUh5qmam1a3J&cursor=6KOJ4CHH5GOJCDHG70PJG936CLILUR3FCDLLURJ1DLII83R2BN0S5LH5TCGCSOIPLQM6D3RI7C7ICPVL44G939G2DR91PR6U4GOJCDHG70PJG&limit=1",
+  "next": "/v2/transfers/backward?account=ak_7myFYvagcqh8AtWEuHL4zKDGfJj5bmacNZS8RoUh5qmam1a3J&cursor=6KOJ4CHH5GOJCDHG70PJG936CLILUR3FCDLLURJ1DLII83R2BN0S5LH5TCGCSOIPLQM6D3RI7C7ICPVL44G939G2DR91PR6U4GOJCDHG70PJG&limit=1",
   "prev": null
 }
 ```
@@ -3494,7 +3494,7 @@ For the same reason as Names, all oracle endpoints support `expand` parameter (e
 ### Oracle resolution
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/oracle/ok_R7cQfVN15F5ek1wBSYaMRjW2XbMRKx7VDQQmbtwxspjZQvmPM" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/oracle/ok_R7cQfVN15F5ek1wBSYaMRjW2XbMRKx7VDQQmbtwxspjZQvmPM" | jq '.'
 {
   "active": false,
   "active_from": 4660,
@@ -3515,7 +3515,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/oracle/ok_R7cQfVN15F5ek1wBSYaMRjW2Xb
 Provided `expand` parameter replaces transaction indices in `extends` and `register` fields:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/oracle/ok_R7cQfVN15F5ek1wBSYaMRjW2XbMRKx7VDQQmbtwxspjZQvmPM?expand" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/oracle/ok_R7cQfVN15F5ek1wBSYaMRjW2XbMRKx7VDQQmbtwxspjZQvmPM?expand" | jq '.'
 {
   "active": false,
   "active_from": 4660,
@@ -3597,7 +3597,7 @@ The parameter `limit` (by default = 10) is optional, and limits the number of el
 #### All oracles
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/oracles?direction=forward&limit=1&expand" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/oracles?direction=forward&limit=1&expand" | jq '.'
 {
   "data": [
     {
@@ -3663,7 +3663,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/oracles?direction=forward&limit=1&ex
       }
     }
   ],
-  "next": "/oracles?cursor=6894-ok_R7cQfVN15F5ek1wBSYaMRjW2XbMRKx7VDQQmbtwxspjZQvmPM&direction=forward&expand=true&limit=1",
+  "next": "/v2/oracles?cursor=6894-ok_R7cQfVN15F5ek1wBSYaMRjW2XbMRKx7VDQQmbtwxspjZQvmPM&direction=forward&expand=true&limit=1",
   "prev": null
 }
 ```
@@ -3671,7 +3671,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/oracles?direction=forward&limit=1&ex
 #### Inactive oracles
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/oracles/inactive?limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/oracles/inactive?limit=1" | jq '.'
 {
   "data": [
     {
@@ -3688,7 +3688,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/oracles/inactive?limit=1" | jq '.'
       "register": 15198855
     }
   ],
-  "next": "/oracles/inactive?cursor=507223-ok_26QSujxMBhg67YhbgvjQvsFfGdBrK9ddG4rENEGUq2EdsyfMTC&direction=backward&expand=false&limit=1",
+  "next": "/v2/oracles/inactive?cursor=507223-ok_26QSujxMBhg67YhbgvjQvsFfGdBrK9ddG4rENEGUq2EdsyfMTC&direction=backward&expand=false&limit=1",
   "prev": null
 }
 ```
@@ -3696,7 +3696,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/oracles/inactive?limit=1" | jq '.'
 #### Active oracles
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/oracles/active?limit=1&expand" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/oracles/active?limit=1&expand" | jq '.'
 {
   "data": [
     {
@@ -3740,7 +3740,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/oracles/active?limit=1&expand" | jq 
       }
     }
   ],
-  "next": "/oracles/active?cursor=1289003-ok_f9vDQvr1cFAQAesYA16vjvBX9TFeWUB4Gb7WJkwfYSkL1CpDx&direction=backward&expand=true&limit=1",
+  "next": "/v2/oracles/active?cursor=1289003-ok_f9vDQvr1cFAQAesYA16vjvBX9TFeWUB4Gb7WJkwfYSkL1CpDx&direction=backward&expand=true&limit=1",
   "prev": null
 }
 ```
@@ -3760,7 +3760,7 @@ These endpoints optional parameters:
 ### AEX9 tokens by name
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/by_name" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/by_name" | jq '.'
 [
   {
     "decimals": 18,
@@ -3810,7 +3810,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/by_name" | jq '.'
 Or, listing tokens with prefix = "ae", along with all contract create transaction ids:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/by_name?prefix=ae&all" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/by_name?prefix=ae&all" | jq '.'
 [
   {
     "decimals": 18,
@@ -3872,7 +3872,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/by_name?prefix=ae&all" | jq '.'
 Note, that for both endpoints - `by_name` and `by_symbol` - if the querying part (`prefix` or `exact`) contains unicode or a space character, it needs to be URL encoded:
 
 ```
-$ curl -s "http://18.157.58.152/mdw/aex9/by_name?exact=%F0%9D%9D%BA%20Token" | jq '.'
+$ curl -s "http://18.157.58.152/mdw/v2/aex9/by_name?exact=%F0%9D%9D%BA%20Token" | jq '.'
 [
   {
     "contract_id": "ct_eW2aiba4vXEwmyGEu7vxvDt6396Zvr6jQYUcoyfe9W9V7KGqr",
@@ -3895,7 +3895,7 @@ $ curl -s "http://18.157.58.152/mdw/aex9/by_name?exact=%F0%9D%9D%BA%20Token" | j
 
 Example with exact parameter:
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/by_symbol?exact=TNT" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/by_symbol?exact=TNT" | jq '.'
 [
   {
     "contract_id": "ct_6ZuwbMgcNDaryXTnrLMiPFW2ogE9jxAzz1874BToE81ksWek6",
@@ -3947,7 +3947,7 @@ Its presence or binding it to `true` will use the latest micro block for retriev
 ### AEX9 contract balance for account
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balance/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA/ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balance/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA/ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48" | jq '.'
 {
   "account_id": "ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48",
   "amount": 49999999999906850000000000,
@@ -3960,7 +3960,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balance/ct_RDRJC5EySx4TcLtGRWYr
 ### AEX9 contract balance for account at block
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balance/hash/mh_2NkfQ9p29EQtqL6YQAuLpneTRPxEKspNYLKXeexZ664ZJo7fcw/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA/ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balance/hash/mh_2NkfQ9p29EQtqL6YQAuLpneTRPxEKspNYLKXeexZ664ZJo7fcw/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA/ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48" | jq '.'
 {
   "account_id": "ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48",
   "amount": 49999999999906850000000000,
@@ -3974,7 +3974,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balance/hash/mh_2NkfQ9p29EQtqL6
 
 Single integer identifies the generation:
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balance/gen/350700/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA/ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balance/gen/350700/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA/ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48" | jq '.'
 {
   "account_id": "ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48",
   "contract_id": "ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA",
@@ -3991,7 +3991,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balance/gen/350700/ct_RDRJC5EyS
 A range can be provided as well:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balance/gen/350620-350623/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA/ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balance/gen/350620-350623/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA/ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48" | jq '.'
 {
   "account_id": "ak_Yc8Lr64xGiBJfm2Jo8RQpR1gwTY8KMqqXk8oWiVC9esG8ce48",
   "contract_id": "ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA",
@@ -4023,7 +4023,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balance/gen/350620-350623/ct_RD
 ### AEX9 contract balances
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balances/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA" | jq '.'
 {
   "amounts": {
     "ak_2MHJv6JcdcfpNvu4wRDZXWzq8QSxGbhUfhMLR7vUPzRFYsDFw6": 4050000000000,
@@ -4040,7 +4040,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/ct_RDRJC5EySx4TcLtGRWY
 ### AEX9 contract balances at block
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/hash/kh_2Ya2fM9brRoBQpxR3xz4K39hTqmjiMJ7GfSu3LbCmxLYjX5cHV/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balances/hash/kh_2Ya2fM9brRoBQpxR3xz4K39hTqmjiMJ7GfSu3LbCmxLYjX5cHV/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA" | jq '.'
 {
   "amounts": {
     "ak_2MHJv6JcdcfpNvu4wRDZXWzq8QSxGbhUfhMLR7vUPzRFYsDFw6": 4050000000000,
@@ -4057,7 +4057,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/hash/kh_2Ya2fM9brRoBQp
 ### AEX9 contract balances at height or range of heights
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/gen/350580/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balances/gen/350580/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA" | jq '.'
 {
   "contract_id": "ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA",
   "range": [
@@ -4078,7 +4078,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/gen/350580/ct_RDRJC5Ey
 Or, with range:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/gen/350600-350603/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balances/gen/350600-350603/ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA" | jq '.'
 {
   "contract_id": "ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA",
   "range": [
@@ -4131,7 +4131,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/gen/350600-350603/ct_R
 In all account specific balance endpoints, the values of `block_hash`/`tx_hash`/`tx_index` show the last time of when (in what block, transaction) was the balance in a listed contract updated.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/account/ak_CNcf2oywqbgmVg3FfKdbHQJfB959wrVwqfzSpdWVKZnep7nj4" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balances/account/ak_CNcf2oywqbgmVg3FfKdbHQJfB959wrVwqfzSpdWVKZnep7nj4" | jq '.'
 [
   {
     "amount": 5e+26,
@@ -4163,7 +4163,7 @@ The awareness that the contract is created by some account comes from syncing, w
 ### AEX 9 contract balances for account at height
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/gen/334201/account/ak_CNcf2oywqbgmVg3FfKdbHQJfB959wrVwqfzSpdWVKZnep7nj4" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balances/gen/334201/account/ak_CNcf2oywqbgmVg3FfKdbHQJfB959wrVwqfzSpdWVKZnep7nj4" | jq '.'
 [
   {
     "amount": 5e+26,
@@ -4180,7 +4180,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/gen/334201/account/ak_
 ### AEX 9 contract balances for account at block
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/hash/mh_kkKtNk2GAgJKjar9ro6amr6AugG9eLP9RL7wUSmdRqjBZrRq9/account/ak_CNcf2oywqbgmVg3FfKdbHQJfB959wrVwqfzSpdWVKZnep7nj4" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/aex9/balances/hash/mh_kkKtNk2GAgJKjar9ro6amr6AugG9eLP9RL7wUSmdRqjBZrRq9/account/ak_CNcf2oywqbgmVg3FfKdbHQJfB959wrVwqfzSpdWVKZnep7nj4" | jq '.'
 [
   {
     "amount": 5e+26,
@@ -4208,7 +4208,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/aex9/balances/hash/mh_kkKtNk2GAgJKja
 To show a statistics for a given height, we can use "stats" endpoint:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/stats?limit=1" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/stats?limit=1" | jq '.'
 {
   "data": [
     {
@@ -4223,14 +4223,14 @@ $ curl -s "https://mainnet.aeternity.io/mdw/stats?limit=1" | jq '.'
       "inactive_oracles": 18
     }
   ],
-  "next": "stats/gen/419209-0?limit=1&page=2"
+  "next": "/v2/stats/gen/419209-0?limit=1&page=2"
 }
 ```
 
 Aggregated (sumarized) statistics are also available, showing the total sum of rewards and the token supply:
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/totalstats/gen/421454-0?limit=1&page=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/v2/totalstats/gen/421454-0?limit=1&page=2" | jq '.'
 {
   "data": [
     {
@@ -4240,11 +4240,20 @@ $ curl -s "https://mainnet.aeternity.io/mdw/totalstats/gen/421454-0?limit=1&page
       "total_token_supply": 2.718122171075295e+31
     }
   ],
-  "next": "totalstats/gen/421454-0?limit=1&page=3"
+  "next": "/v2/totalstats/gen/421454-0?limit=1&page=3"
 }
 ```
 
 These endpoints allows pagination, with typical `forward/backward` direction or scope denoted by `gen/from-to`.
+
+## Migrating to v2
+
+Most routes will remain the same, and can be updated by only appending the `/v2` prefix to them.
+
+This is a list of the exceptions together with the changes that need to be done:
+
+* `/blocks/:range` route was deleted and either `/v2/blocks/gen/:range` or `/v2/blocks/:direction` should be used instead.
+* `/blocks/gen/:range`, `/blocks/gen/:direction` - Each block now has a list of micro_blocks sorted by time, instead of it being a map.
 
 
 ## Websocket interface
@@ -4278,7 +4287,7 @@ In order to differentiate, please check the "source" field on [Publishing Messag
 The websocket interface accepts JSON - encoded commands to subscribe and unsubscribe, and answers these with the list of subscriptions. A session will look like this:
 
 ```
-wscat -c wss://mainnet.aeternity.io/mdw/websocket
+wscat -c wss://mainnet.aeternity.io/mdw/v2/websocket
 
 connected (press CTRL+C to quit)
 > {"op":"Subscribe", "payload": "KeyBlocks"}

--- a/lib/ae_mdw_web/controllers/block_controller.ex
+++ b/lib/ae_mdw_web/controllers/block_controller.ex
@@ -360,7 +360,7 @@ defmodule AeMdwWeb.BlockController do
   end
 
   swagger_path :blocks do
-    get("/blocks/{range_or_dir}")
+    get("/v2/blocks/{range_or_dir}")
     description("Get multiple generations.")
     produces(["application/json"])
     deprecated(false)
@@ -452,6 +452,9 @@ defmodule AeMdwWeb.BlockController do
   end
 
   @spec swagger_path_blocki(map()) :: binary()
+  def swagger_path_blocki(%{path: <<"/v2", rest::binary>>} = route),
+    do: swagger_path_blocki_kbi(Map.put(route, :path, rest))
+
   def swagger_path_blocki(%{path: "/blocki/{kbi}"} = route), do: swagger_path_blocki_kbi(route)
 
   def swagger_path_blocki(%{path: "/blocki/{kbi}/{mbi}"} = route),

--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -859,6 +859,10 @@ defmodule AeMdwWeb.TxController do
   end
 
   # credo:disable-for-next-line
+  def swagger_path_txs(%{path: <<"/v2", rest::binary>>} = route),
+    do: swagger_path_txs(Map.put(route, :path, rest))
+
+  # credo:disable-for-next-line
   def swagger_path_txs(%{path: "/txs/{direction}"} = route), do: swagger_path_txs_direction(route)
 
   # credo:disable-for-next-line

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -9,6 +9,72 @@ defmodule AeMdwWeb.Router do
 
   @scopes ["gen", "txi"]
 
+  @shared_routes [
+    {"/block/:hash", AeMdwWeb.BlockController, :block},
+    {"/blocki/:kbi", AeMdwWeb.BlockController, :blocki},
+    {"/blocki/:kbi/:mbi", AeMdwWeb.BlockController, :blocki},
+    {"/tx/:hash", AeMdwWeb.TxController, :tx},
+    {"/txi/:index", AeMdwWeb.TxController, :txi},
+    {"/txs/count", AeMdwWeb.TxController, :count},
+    {"/txs/count/:id", AeMdwWeb.TxController, :count_id},
+    {"/txs/:direction", AeMdwWeb.TxController, :txs},
+    {"/txs/:scope_type/:range", AeMdwWeb.TxController, :txs},
+    {"/name/auction/:id", AeMdwWeb.NameController, :auction},
+    {"/name/pointers/:id", AeMdwWeb.NameController, :pointers},
+    {"/name/pointees/:id", AeMdwWeb.NameController, :pointees},
+    {"/name/:id", AeMdwWeb.NameController, :name},
+    {"/names/search/:prefix", AeMdwWeb.NameController, :search},
+    {"/names/owned_by/:id", AeMdwWeb.NameController, :owned_by},
+    {"/names/auctions", AeMdwWeb.NameController, :auctions},
+    {"/names/auctions/:scope_type/:range", AeMdwWeb.NameController, :auctions},
+    {"/names/inactive", AeMdwWeb.NameController, :inactive_names},
+    {"/names/inactive/:scope_type/:range", AeMdwWeb.NameController, :inactive_names},
+    {"/names/active", AeMdwWeb.NameController, :active_names},
+    {"/names/active/:scope_type/:range", AeMdwWeb.NameController, :active_names},
+    {"/names", AeMdwWeb.NameController, :names},
+    {"/names/:scope_type/:range", AeMdwWeb.NameController, :names},
+    {"/oracle/:id", AeMdwWeb.OracleController, :oracle},
+    {"/oracles/inactive", AeMdwWeb.OracleController, :inactive_oracles},
+    {"/oracles/active", AeMdwWeb.OracleController, :active_oracles},
+    {"/oracles", AeMdwWeb.OracleController, :oracles},
+    {"/oracles/inactive/gen/:range", AeMdwWeb.OracleController, :inactive_oracles},
+    {"/oracles/active/gen/:range", AeMdwWeb.OracleController, :active_oracles},
+    {"/oracles/gen/:range", AeMdwWeb.OracleController, :oracles},
+    {"/aex9/by_contract/:id", AeMdwWeb.Aex9Controller, :by_contract},
+    {"/aex9/by_name", AeMdwWeb.Aex9Controller, :by_names},
+    {"/aex9/by_symbol", AeMdwWeb.Aex9Controller, :by_symbols},
+    {"/aex9/balance/gen/:range/:contract_id/:account_id", AeMdwWeb.Aex9Controller,
+     :balance_range},
+    {"/aex9/balance/hash/:blockhash/:contract_id/:account_id", AeMdwWeb.Aex9Controller,
+     :balance_for_hash},
+    {"/aex9/balance/:contract_id/:account_id", AeMdwWeb.Aex9Controller, :balance},
+    {"/aex9/balances/gen/:height/account/:account_id", AeMdwWeb.Aex9Controller, :balances},
+    {"/aex9/balances/hash/:blockhash/account/:account_id", AeMdwWeb.Aex9Controller, :balances},
+    {"/aex9/balances/account/:account_id", AeMdwWeb.Aex9Controller, :balances},
+    {"/aex9/balances/gen/:range/:contract_id", AeMdwWeb.Aex9Controller, :balances_range},
+    {"/aex9/balances/hash/:blockhash/:contract_id", AeMdwWeb.Aex9Controller, :balances_for_hash},
+    {"/aex9/balances/:contract_id", AeMdwWeb.Aex9Controller, :balances},
+    {"/aex9/transfers/from/:sender", AeMdwWeb.Aex9Controller, :transfers_from},
+    {"/aex9/transfers/to/:recipient", AeMdwWeb.Aex9Controller, :transfers_to},
+    {"/aex9/transfers/from-to/:sender/:recipient", AeMdwWeb.Aex9Controller, :transfers_from_to},
+    {"/contracts/logs", AeMdwWeb.ContractController, :logs},
+    {"/contracts/logs/:direction", AeMdwWeb.ContractController, :logs},
+    {"/contracts/logs/:scope_type/:range", AeMdwWeb.ContractController, :logs},
+    {"/contracts/calls", AeMdwWeb.ContractController, :calls},
+    {"/contracts/calls/:direction", AeMdwWeb.ContractController, :calls},
+    {"/contracts/calls/:scope_type/:range", AeMdwWeb.ContractController, :calls},
+    {"/transfers/:scope_type/:range", AeMdwWeb.TransferController, :transfers},
+    {"/transfers/:direction", AeMdwWeb.TransferController, :transfers},
+    {"/transfers", AeMdwWeb.TransferController, :transfers},
+    {"/stats/", AeMdwWeb.StatsController, :stats},
+    {"/stats/:direction", AeMdwWeb.StatsController, :stats},
+    {"/stats/:scope_type/:range", AeMdwWeb.StatsController, :stats},
+    {"/totalstats/", AeMdwWeb.StatsController, :sum_stats},
+    {"/totalstats/:direction", AeMdwWeb.StatsController, :sum_stats},
+    {"/totalstats/:scope_type/:range", AeMdwWeb.StatsController, :sum_stats},
+    {"/status", AeMdwWeb.UtilController, :status}
+  ]
+
   pipeline :api do
     plug DataStreamPlug, paginables: @paginables, scopes: @scopes
     plug :accepts, ["json"]
@@ -32,101 +98,23 @@ defmodule AeMdwWeb.Router do
   scope "/", AeMdwWeb do
     pipe_through :api
 
-    get "/block/:hash", BlockController, :block
-    get "/blocki/:kbi", BlockController, :blocki
-    get "/blocki/:kbi/:mbi", BlockController, :blocki
+    scope "/v2" do
+      Enum.each(@shared_routes, fn {path, controller, fun} ->
+        get(path, controller, fun, alias: false)
+      end)
 
-    # for continuation link only
+      # v2-only routes
+      get "/blocks/gen/:range", BlockController, :blocks_v2
+      get "/blocks/:range_or_dir", BlockController, :blocks_v2
+    end
+
+    Enum.each(@shared_routes, fn {path, controller, fun} ->
+      get(path, controller, fun, alias: false)
+    end)
+
+    # v1-only routes
     get "/blocks/gen/:range", BlockController, :blocks
-    get "/v2/blocks/gen/:range", BlockController, :blocks_v2
-
-    # by default no scope_type needed
     get "/blocks/:range_or_dir", BlockController, :blocks
-    get "/v2/blocks/:range_or_dir", BlockController, :blocks_v2
-
-    get "/tx/:hash", TxController, :tx
-    get "/txi/:index", TxController, :txi
-
-    get "/txs/count", TxController, :count
-    get "/txs/count/:id", TxController, :count_id
-    get "/txs/:direction", TxController, :txs
-    get "/txs/:scope_type/:range", TxController, :txs
-
-    get "/name/auction/:id", NameController, :auction
-    get "/name/pointers/:id", NameController, :pointers
-    get "/name/pointees/:id", NameController, :pointees
-    get "/name/:id", NameController, :name
-
-    get "/names/search/:prefix", NameController, :search
-    get "/names/owned_by/:id", NameController, :owned_by
-
-    get "/names/auctions", NameController, :auctions
-    get "/names/auctions/:scope_type/:range", NameController, :auctions
-
-    get "/names/inactive", NameController, :inactive_names
-    get "/names/inactive/:scope_type/:range", NameController, :inactive_names
-
-    get "/names/active", NameController, :active_names
-    get "/names/active/:scope_type/:range", NameController, :active_names
-
-    get "/names", NameController, :names
-    get "/names/:scope_type/:range", NameController, :names
-
-    get "/oracle/:id", OracleController, :oracle
-
-    get "/oracles/inactive", OracleController, :inactive_oracles
-    get "/oracles/active", OracleController, :active_oracles
-    get "/oracles", OracleController, :oracles
-
-    get "/oracles/inactive/gen/:range", OracleController, :inactive_oracles
-    get "/oracles/active/gen/:range", OracleController, :active_oracles
-    get "/oracles/gen/:range", OracleController, :oracles
-
-    get "/aex9/by_contract/:id", Aex9Controller, :by_contract
-    get "/aex9/by_name", Aex9Controller, :by_names
-    get "/aex9/by_symbol", Aex9Controller, :by_symbols
-
-    get "/aex9/balance/gen/:range/:contract_id/:account_id", Aex9Controller, :balance_range
-
-    get "/aex9/balance/hash/:blockhash/:contract_id/:account_id",
-        Aex9Controller,
-        :balance_for_hash
-
-    get "/aex9/balance/:contract_id/:account_id", Aex9Controller, :balance
-
-    get "/aex9/balances/gen/:height/account/:account_id", Aex9Controller, :balances
-    get "/aex9/balances/hash/:blockhash/account/:account_id", Aex9Controller, :balances
-    get "/aex9/balances/account/:account_id", Aex9Controller, :balances
-
-    get "/aex9/balances/gen/:range/:contract_id", Aex9Controller, :balances_range
-    get "/aex9/balances/hash/:blockhash/:contract_id", Aex9Controller, :balances_for_hash
-    get "/aex9/balances/:contract_id", Aex9Controller, :balances
-
-    get "/aex9/transfers/from/:sender", Aex9Controller, :transfers_from
-    get "/aex9/transfers/to/:recipient", Aex9Controller, :transfers_to
-    get "/aex9/transfers/from-to/:sender/:recipient", Aex9Controller, :transfers_from_to
-
-    get "/contracts/logs", ContractController, :logs
-    get "/contracts/logs/:direction", ContractController, :logs
-    get "/contracts/logs/:scope_type/:range", ContractController, :logs
-
-    get "/contracts/calls", ContractController, :calls
-    get "/contracts/calls/:direction", ContractController, :calls
-    get "/contracts/calls/:scope_type/:range", ContractController, :calls
-
-    get "/transfers/:scope_type/:range", TransferController, :transfers
-    get "/transfers/:direction", TransferController, :transfers
-    get "/transfers", TransferController, :transfers
-
-    get "/stats/", StatsController, :stats
-    get "/stats/:direction", StatsController, :stats
-    get "/stats/:scope_type/:range", StatsController, :stats
-
-    get "/totalstats/", StatsController, :sum_stats
-    get "/totalstats/:direction", StatsController, :sum_stats
-    get "/totalstats/:scope_type/:range", StatsController, :sum_stats
-
-    get "/status", UtilController, :status
 
     match :*, "/*path", UtilController, :no_route
   end

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -105,7 +105,7 @@ defmodule AeMdwWeb.Router do
 
       # v2-only routes
       get "/blocks/gen/:range", BlockController, :blocks_v2
-      get "/blocks/:range_or_dir", BlockController, :blocks_v2
+      get "/blocks/:direction", BlockController, :blocks_v2
     end
 
     Enum.each(@shared_routes, fn {path, controller, fun} ->

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -85,7 +85,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       assert %{"data" => names} =
                conn
-               |> get("/names/active", by: by, direction: direction, limit: limit)
+               |> get("/v2/names/active", by: by, direction: direction, limit: limit)
                |> json_response(200)
 
       plain_names = Enum.map(names, fn %{"name" => name} -> name end)
@@ -107,7 +107,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       error_msg = "invalid direction: #{direction}"
 
       assert %{"error" => ^error_msg} =
-               conn |> get("/names/active", by: by, direction: direction) |> json_response(400)
+               conn |> get("/v2/names/active", by: by, direction: direction) |> json_response(400)
     end
 
     test "it returns valid names on a given range", %{conn: conn} do
@@ -130,7 +130,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
       assert %{"data" => data, "next" => next} =
                conn
-               |> get("/names/active/gen/#{first}-#{last}")
+               |> get("/v2/names/active/gen/#{first}-#{last}")
                |> json_response(200)
 
       assert Enum.all?(data, fn %{"info" => %{"expire_height" => kbi}} ->

--- a/test/integration/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -28,7 +28,7 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
 
     test "get oracle information for given oracle id with expand parameter", %{conn: conn} do
       id = "ok_2TASQ4QZv584D2ZP7cZxT6sk1L1UyqbWumnWM4g1azGi1qqcR5"
-      conn = get(conn, "/oracle/#{id}?expand")
+      conn = get(conn, "/v2/oracle/#{id}?expand")
 
       assert conn |> json_response(200) |> Jason.encode!() ==
                TestUtil.handle_input(fn ->
@@ -51,7 +51,7 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
     } do
       assert %{"data" => [contract_call]} =
                conn
-               |> get("/contracts/calls/backward", function: "Oracle.register", limit: 1)
+               |> get("/v2/contracts/calls/backward", function: "Oracle.register", limit: 1)
                |> json_response(200)
 
       assert %{
@@ -118,7 +118,7 @@ defmodule Integration.AeMdwWeb.OracleControllerTest do
       limit = 7
 
       %{"data" => oracles, "next" => next} =
-        conn |> get("/oracles", limit: limit, expand: true) |> json_response(200)
+        conn |> get("/v2/oracles", limit: limit, expand: true) |> json_response(200)
 
       assert ^limit = length(oracles)
 


### PR DESCRIPTION
From now on, all new routes should be added only to the latest
version, which will be released at some point in the future.

Older routes will be announced for deprecation and deprecated
accordingly.

Refs #498 