### PR TITLE
refactor: mutations derive to default impl

### DIFF
--- a/lib/ae_mdw/db/mutation.ex
+++ b/lib/ae_mdw/db/mutation.ex
@@ -15,3 +15,9 @@ defprotocol AeMdw.Db.Mutation do
   @spec mutate(t()) :: :ok
   def mutate(mutation)
 end
+
+defimpl AeMdw.Db.Mutation, for: Any do
+  def mutate(%mod{} = mutation) do
+    mod.mutate(mutation)
+  end
+end

--- a/lib/ae_mdw/db/mutations/aex9_account_presence_mutation.ex
+++ b/lib/ae_mdw/db/mutations/aex9_account_presence_mutation.ex
@@ -6,6 +6,7 @@ defmodule AeMdw.Db.Aex9AccountPresenceMutation do
   alias AeMdw.Db.Sync
   alias AeMdw.Blocks
 
+  @derive AeMdw.Db.Mutation
   defstruct [:height, :mbi]
 
   @opaque t() :: %__MODULE__{
@@ -21,11 +22,5 @@ defmodule AeMdw.Db.Aex9AccountPresenceMutation do
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{height: height, mbi: mbi}) do
     Sync.Contract.aex9_derive_account_presence!({height, mbi})
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.Aex9AccountPresenceMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/block_rewards_mutation.ex
+++ b/lib/ae_mdw/db/mutations/block_rewards_mutation.ex
@@ -7,6 +7,7 @@ defmodule AeMdw.Db.BlockRewardsMutation do
   alias AeMdw.Db.IntTransfer
   alias AeMdw.Ets
 
+  @derive AeMdw.Db.Mutation
   defstruct [:height, :block_rewards]
 
   @type block_reward() :: {IntTransfer.kind(), IntTransfer.target(), IntTransfer.amount()}
@@ -32,11 +33,5 @@ defmodule AeMdw.Db.BlockRewardsMutation do
       IntTransfer.write(gen_txi_pos, kind, target_pk, @ref_txi, amount)
       Ets.inc(:stat_sync_cache, (kind == "reward_dev" && :dev_reward) || :block_reward, amount)
     end)
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.BlockRewardsMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/contract_call_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_call_mutation.ex
@@ -8,6 +8,7 @@ defmodule AeMdw.Db.ContractCallMutation do
   alias AeMdw.Sync.AsyncTasks
   alias AeMdw.Txs
 
+  @derive AeMdw.Db.Mutation
   defstruct [
     :contract_pk,
     :caller_pk,
@@ -100,11 +101,5 @@ defmodule AeMdw.Db.ContractCallMutation do
     else
       AsyncTasks.Producer.enqueue(:update_aex9_presence, [contract_pk])
     end
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.ContractCallMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/contract_create_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_create_mutation.ex
@@ -8,6 +8,7 @@ defmodule AeMdw.Db.ContractCreateMutation do
   alias AeMdw.Node.Db
   alias AeMdw.Txs
 
+  @derive AeMdw.Db.Mutation
   defstruct [:contract_pk, :txi, :owner_pk, :aex9_meta_info, :call_rec]
 
   @opaque t() :: %__MODULE__{
@@ -49,11 +50,5 @@ defmodule AeMdw.Db.ContractCreateMutation do
 
     AeMdw.Ets.inc(:stat_sync_cache, :contracts)
     DBContract.logs_write(txi, txi, call_rec)
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.ContractCreateMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/key_blocks_mutation.ex
+++ b/lib/ae_mdw/db/mutations/key_blocks_mutation.ex
@@ -8,6 +8,7 @@ defmodule AeMdw.Db.KeyBlocksMutation do
 
   require Model
 
+  @derive AeMdw.Db.TxnMutation
   defstruct [:key_block, :next_txi]
 
   @opaque t() :: %__MODULE__{
@@ -27,11 +28,5 @@ defmodule AeMdw.Db.KeyBlocksMutation do
 
     Database.write(txn, Model.Block, m_block)
     Database.write(txn, Model.Block, Model.block(next_kb, tx_index: next_txi))
-  end
-end
-
-defimpl AeMdw.Db.TxnMutation, for: AeMdw.Db.KeyBlocksMutation do
-  def execute(mutation, txn) do
-    @for.execute(mutation, txn)
   end
 end

--- a/lib/ae_mdw/db/mutations/name_claim_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_claim_mutation.ex
@@ -19,6 +19,7 @@ defmodule AeMdw.Db.NameClaimMutation do
   require Logger
   require Model
 
+  @derive AeMdw.Db.Mutation
   defstruct [
     :plain_name,
     :name_hash,
@@ -171,11 +172,5 @@ defmodule AeMdw.Db.NameClaimMutation do
       [{^txi, m_tx}] -> Format.to_raw_map(m_tx)
       [] -> read_raw_tx!(txi)
     end
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.NameClaimMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/name_revoke_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_revoke_mutation.ex
@@ -8,6 +8,7 @@ defmodule AeMdw.Db.NameRevokeMutation do
   alias AeMdw.Names
   alias AeMdw.Txs
 
+  @derive AeMdw.Db.Mutation
   defstruct [:name_hash, :txi, :block_index]
 
   @opaque t() :: %__MODULE__{
@@ -28,11 +29,5 @@ defmodule AeMdw.Db.NameRevokeMutation do
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{name_hash: name_hash, txi: txi, block_index: block_index}) do
     Name.revoke(name_hash, txi, block_index)
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.NameRevokeMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_transfer_mutation.ex
@@ -10,6 +10,7 @@ defmodule AeMdw.Db.NameTransferMutation do
   alias AeMdw.Node.Db
   alias AeMdw.Txs
 
+  @derive AeMdw.Db.Mutation
   defstruct [:name_hash, :new_owner, :txi, :block_index]
 
   @opaque t() :: %__MODULE__{
@@ -40,11 +41,5 @@ defmodule AeMdw.Db.NameTransferMutation do
         block_index: block_index
       }) do
     Name.transfer(name_hash, new_owner, txi, block_index)
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.NameTransferMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/name_update_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_update_mutation.ex
@@ -9,6 +9,7 @@ defmodule AeMdw.Db.NameUpdateMutation do
   alias AeMdw.Node
   alias AeMdw.Txs
 
+  @derive AeMdw.Db.Mutation
   defstruct [:name_hash, :name_ttl, :pointers, :txi, :block_index, :internal?]
 
   @opaque t() :: %__MODULE__{
@@ -46,11 +47,5 @@ defmodule AeMdw.Db.NameUpdateMutation do
         internal?: internal?
       }) do
     Name.update(name_hash, name_ttl, pointers, txi, block_index, internal?)
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.NameUpdateMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/names_expiration_mutation.ex
+++ b/lib/ae_mdw/db/mutations/names_expiration_mutation.ex
@@ -7,6 +7,7 @@ defmodule AeMdw.Db.NamesExpirationMutation do
   alias AeMdw.Db.Name
   alias AeMdw.Names
 
+  @derive AeMdw.Db.Mutation
   defstruct [:height, :expired_names, :expired_auctions]
 
   @typep auction_key() :: {Names.plain_name(), Names.auction_timeout()}
@@ -33,11 +34,5 @@ defmodule AeMdw.Db.NamesExpirationMutation do
     Enum.each(expired_auctions, fn {plain_name, auction_timeout} ->
       Name.expire_auction(height, plain_name, auction_timeout)
     end)
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.NamesExpirationMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/oracle_extend_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracle_extend_mutation.ex
@@ -14,6 +14,7 @@ defmodule AeMdw.Db.OracleExtendMutation do
   require Model
   require Logger
 
+  @derive AeMdw.Db.Mutation
   defstruct [:block_index, :txi, :oracle_pk, :delta_ttl]
 
   @opaque t() :: %__MODULE__{
@@ -53,11 +54,5 @@ defmodule AeMdw.Db.OracleExtendMutation do
       nil ->
         Log.warn("[#{height}] invalid extend for oracle #{Enc.encode(:oracle_pubkey, oracle_pk)}")
     end
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.OracleExtendMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/oracle_register_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracle_register_mutation.ex
@@ -11,6 +11,7 @@ defmodule AeMdw.Db.OracleRegisterMutation do
 
   require Model
 
+  @derive AeMdw.Db.Mutation
   defstruct [:oracle_pk, :block_index, :expire, :txi]
 
   @typep expiration() :: Blocks.height()
@@ -71,11 +72,5 @@ defmodule AeMdw.Db.OracleRegisterMutation do
     previous && AeMdw.Ets.dec(:stat_sync_cache, :inactive_oracles)
 
     :ok
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.OracleRegisterMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/oracle_response_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracle_response_mutation.ex
@@ -8,6 +8,7 @@ defmodule AeMdw.Db.OracleResponseMutation do
   alias AeMdw.Node.Db
   alias AeMdw.Txs
 
+  @derive AeMdw.Db.Mutation
   defstruct [:block_index, :txi, :oracle_pk, :fee]
 
   @opaque t() :: %__MODULE__{
@@ -35,11 +36,5 @@ defmodule AeMdw.Db.OracleResponseMutation do
         fee: fee
       }) do
     IntTransfer.write({height, txi}, "reward_oracle", oracle_pk, txi, fee)
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.OracleResponseMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/oracles_expiration_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracles_expiration_mutation.ex
@@ -10,6 +10,7 @@ defmodule AeMdw.Db.OraclesExpirationMutation do
   alias AeMdw.Db.Oracle
   alias AeMdw.Node.Db
 
+  @derive AeMdw.Db.Mutation
   defstruct [:height, :expired_pubkeys]
 
   @opaque t() :: %__MODULE__{
@@ -25,11 +26,5 @@ defmodule AeMdw.Db.OraclesExpirationMutation do
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{height: height, expired_pubkeys: expired_pubkeys}) do
     Enum.each(expired_pubkeys, &Oracle.expire_oracle(height, &1))
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.OraclesExpirationMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/stats_mutation.ex
+++ b/lib/ae_mdw/db/mutations/stats_mutation.ex
@@ -8,6 +8,7 @@ defmodule AeMdw.Db.StatsMutation do
 
   require Model
 
+  @derive AeMdw.Db.Mutation
   defstruct [:stat, :total_stat]
 
   @type t() :: %__MODULE__{
@@ -30,11 +31,5 @@ defmodule AeMdw.Db.StatsMutation do
       }) do
     Database.write(Model.Stat, stat)
     Database.write(Model.TotalStat, total_stat)
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.StatsMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/write_field_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_field_mutation.ex
@@ -11,6 +11,7 @@ defmodule AeMdw.Db.WriteFieldMutation do
 
   require Model
 
+  @derive AeMdw.Db.Mutation
   defstruct [:tx_type, :pos, :pubkey, :txi]
 
   @type pos() :: non_neg_integer() | nil
@@ -33,11 +34,5 @@ defmodule AeMdw.Db.WriteFieldMutation do
     m_field = Model.field(index: {tx_type, pos, pubkey, txi})
     Database.write(Model.Field, m_field)
     Model.incr_count({tx_type, pos, pubkey})
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.WriteFieldMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/write_fields_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_fields_mutation.ex
@@ -11,6 +11,7 @@ defmodule AeMdw.Db.WriteFieldsMutation do
 
   require Model
 
+  @derive AeMdw.Db.Mutation
   defstruct [:type, :tx, :block_index, :txi]
 
   @opaque t() :: %__MODULE__{
@@ -59,11 +60,5 @@ defmodule AeMdw.Db.WriteFieldsMutation do
   defp resolve_pubkey(id, _type, _field, _block_index) do
     {_tag, pk} = :aeser_id.specialize(id)
     pk
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.WriteFieldsMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/write_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_mutation.ex
@@ -6,6 +6,7 @@ defmodule AeMdw.Db.WriteMutation do
 
   alias AeMdw.Database
 
+  @derive AeMdw.Db.Mutation
   defstruct [:table, :record]
 
   @opaque t() :: %__MODULE__{
@@ -21,11 +22,5 @@ defmodule AeMdw.Db.WriteMutation do
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{table: table, record: record}) do
     Database.write(table, record)
-  end
-end
-
-defimpl AeMdw.Db.Mutation, for: AeMdw.Db.WriteMutation do
-  def mutate(mutation) do
-    @for.mutate(mutation)
   end
 end

--- a/lib/ae_mdw/db/mutations/write_txn_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_txn_mutation.ex
@@ -6,6 +6,7 @@ defmodule AeMdw.Db.WriteTxnMutation do
 
   alias AeMdw.Database
 
+  @derive AeMdw.Db.TxnMutation
   defstruct [:table, :record]
 
   @opaque t() :: %__MODULE__{
@@ -21,11 +22,5 @@ defmodule AeMdw.Db.WriteTxnMutation do
   @spec execute(t(), Database.transaction()) :: :ok
   def execute(%__MODULE__{table: table, record: record}, txn) do
     Database.write(txn, table, record)
-  end
-end
-
-defimpl AeMdw.Db.TxnMutation, for: AeMdw.Db.WriteTxnMutation do
-  def execute(mutation, txn) do
-    @for.execute(mutation, txn)
   end
 end

--- a/lib/ae_mdw/db/txn_mutation.ex
+++ b/lib/ae_mdw/db/txn_mutation.ex
@@ -7,5 +7,11 @@ defprotocol AeMdw.Db.TxnMutation do
   Abstracted function that performs the actual change into database.
   """
   @spec execute(t(), AeMdw.Database.transaction()) :: :ok
-  def execute(transaction, mutation)
+  def execute(mutation, transaction)
+end
+
+defimpl AeMdw.Db.TxnMutation, for: Any do
+  def execute(%mod{} = mutation, txn) do
+    mod.execute(mutation, txn)
+  end
 end


### PR DESCRIPTION
## What/Why

Make declarative implementations for the `Mutation` and `TxnMutation` protocols to simplify the transition to transaction mutations when it's resumed.

## Validation steps

Resync and see that these endpoints work for height 10k:
http://localhost:4000/blocks/forward
http://localhost:4000/txs/forward
http://localhost:4000/names