### PR TITLE
feat: /v2/deltastats

### DIFF
--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -213,17 +213,32 @@ defmodule AeMdw.Db.Format do
     }
   end
 
-  def to_raw_map(m_stat, Model.Stat) do
+  def to_raw_map(
+        Model.delta_stat(
+          index: height,
+          auctions_started: auctions_started,
+          names_activated: names_activated,
+          names_expired: names_expired,
+          names_revoked: names_revoked,
+          oracles_registered: oracles_registered,
+          oracles_expired: oracles_expired,
+          contracts_created: contracts_created,
+          block_reward: block_reward,
+          dev_reward: dev_reward
+        ),
+        Model.DeltaStat
+      ) do
     %{
-      height: Model.stat(m_stat, :index),
-      inactive_names: Model.stat(m_stat, :inactive_names),
-      active_names: Model.stat(m_stat, :active_names),
-      active_auctions: Model.stat(m_stat, :active_auctions),
-      inactive_oracles: Model.stat(m_stat, :inactive_oracles),
-      active_oracles: Model.stat(m_stat, :active_oracles),
-      contracts: Model.stat(m_stat, :contracts),
-      block_reward: Model.stat(m_stat, :block_reward),
-      dev_reward: Model.stat(m_stat, :dev_reward)
+      height: height,
+      auctions_started: auctions_started,
+      names_activated: names_activated,
+      names_expired: names_expired,
+      names_revoked: names_revoked,
+      oracles_registered: oracles_registered,
+      oracles_expired: oracles_expired,
+      contracts_created: contracts_created,
+      block_reward: block_reward,
+      dev_reward: dev_reward
     }
   end
 
@@ -437,11 +452,11 @@ defmodule AeMdw.Db.Format do
     |> update_in([:account_id], &Enc.encode(:account_pubkey, &1))
   end
 
-  def to_map(m_stat, Model.Stat),
-    do: to_raw_map(m_stat, Model.Stat)
+  def to_map(m_delta_stat, Model.DeltaStat),
+    do: to_raw_map(m_delta_stat, Model.DeltaStat)
 
-  def to_map(m_stat, Model.TotalStat),
-    do: to_raw_map(m_stat, Model.TotalStat)
+  def to_map(m_delta_stat, Model.TotalStat),
+    do: to_raw_map(m_delta_stat, Model.TotalStat)
 
   def to_map({_, _, _, _} = aex9_data, source)
       when source in [Model.Aex9Contract, Model.Aex9ContractSymbol, Model.RevAex9Contract],

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -403,29 +403,31 @@ defmodule AeMdw.Db.Model do
   defrecord :target_kind_int_transfer_tx, @target_kind_int_transfer_tx_defaults
 
   # statistics
-  @stat_defaults [
+  @delta_stat_defaults [
     # height
     index: 0,
-    inactive_names: 0,
-    active_names: 0,
-    active_auctions: 0,
-    inactive_oracles: 0,
-    active_oracles: 0,
-    contracts: 0,
+    auctions_started: 0,
+    names_activated: 0,
+    names_expired: 0,
+    names_revoked: 0,
+    oracles_registered: 0,
+    oracles_expired: 0,
+    contracts_created: 0,
     block_reward: 0,
     dev_reward: 0
   ]
-  defrecord :stat, @stat_defaults
+  defrecord :delta_stat, @delta_stat_defaults
 
-  @type stat ::
-          record(:stat,
+  @type delta_stat ::
+          record(:delta_stat,
             index: Blocks.height(),
-            inactive_names: integer(),
-            active_names: integer(),
-            active_auctions: integer(),
-            inactive_oracles: integer(),
-            active_oracles: integer(),
-            contracts: integer(),
+            auctions_started: integer(),
+            names_activated: integer(),
+            names_expired: integer(),
+            names_revoked: integer(),
+            oracles_registered: integer(),
+            oracles_expired: integer(),
+            contracts_created: integer(),
             block_reward: integer(),
             dev_reward: integer()
           )
@@ -555,7 +557,7 @@ defmodule AeMdw.Db.Model do
 
   defp stat_tables() do
     [
-      AeMdw.Db.Model.Stat,
+      AeMdw.Db.Model.DeltaStat,
       AeMdw.Db.Model.TotalStat
     ]
   end
@@ -611,7 +613,7 @@ defmodule AeMdw.Db.Model do
       :int_transfer_tx,
       :kind_int_transfer_tx,
       :target_kind_int_transfer_tx,
-      :stat,
+      :delta_stat,
       :total_stat,
       :migrations,
       :async_tasks
@@ -674,7 +676,7 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.KindIntTransferTx), do: :kind_int_transfer_tx
   def record(AeMdw.Db.Model.TargetKindIntTransferTx), do: :target_kind_int_transfer_tx
 
-  def record(AeMdw.Db.Model.Stat), do: :stat
+  def record(AeMdw.Db.Model.DeltaStat), do: :delta_stat
   def record(AeMdw.Db.Model.TotalStat), do: :total_stat
 
   @spec table(atom()) :: atom()
@@ -715,7 +717,7 @@ defmodule AeMdw.Db.Model do
   def table(:kind_int_transfer_tx), do: AeMdw.Db.Model.KindIntTransferTx
   def table(:target_int_transfer_tx), do: AeMdw.Db.Model.TargetIntTransferTx
   def table(:target_kind_int_transfer_tx), do: AeMdw.Db.Model.TargetKindIntTransferTx
-  def table(:stat), do: AeMdw.Db.Model.Stat
+  def table(:delta_stat), do: AeMdw.Db.Model.DeltaStat
   def table(:total_stat), do: AeMdw.Db.Model.TotalStat
 
   @spec defaults(atom()) :: list()
@@ -762,7 +764,7 @@ defmodule AeMdw.Db.Model do
   def defaults(:int_transfer_tx), do: @int_transfer_tx_defaults
   def defaults(:kind_int_transfer_tx), do: @kind_int_transfer_tx_defaults
   def defaults(:target_kind_int_transfer_tx), do: @target_kind_int_transfer_tx_defaults
-  def defaults(:stat), do: @stat_defaults
+  def defaults(:delta_stat), do: @delta_stat_defaults
   def defaults(:total_stat), do: @total_stat_defaults
 
   @spec write_count(tuple(), integer()) :: :ok

--- a/lib/ae_mdw/db/mutations/contract_create_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_create_mutation.ex
@@ -48,6 +48,8 @@ defmodule AeMdw.Db.ContractCreateMutation do
       DBContract.aex9_creation_write(aex9_meta_info, contract_pk, owner_pk, txi)
     end
 
+    AeMdw.Ets.inc(:stat_sync_cache, :contracts_created)
+
     DBContract.logs_write(txi, txi, call_rec)
   end
 end

--- a/lib/ae_mdw/db/mutations/contract_create_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_create_mutation.ex
@@ -48,7 +48,6 @@ defmodule AeMdw.Db.ContractCreateMutation do
       DBContract.aex9_creation_write(aex9_meta_info, contract_pk, owner_pk, txi)
     end
 
-    AeMdw.Ets.inc(:stat_sync_cache, :contracts)
     DBContract.logs_write(txi, txi, call_rec)
   end
 end

--- a/lib/ae_mdw/db/mutations/name_claim_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_claim_mutation.ex
@@ -105,8 +105,7 @@ defmodule AeMdw.Db.NameClaimMutation do
 
         lock_amount = (is_lima? && name_fee) || :aec_governance.name_claim_locked_fee()
         IntTransfer.fee({height, txi}, :lock_name, owner_pk, txi, lock_amount)
-        Ets.inc(:stat_sync_cache, :active_names)
-        previous && Ets.dec(:stat_sync_cache, :inactive_names)
+        Ets.inc(:stat_sync_cache, :names_activated)
 
         log_name_change(height, plain_name, "activate")
 
@@ -122,7 +121,6 @@ defmodule AeMdw.Db.NameClaimMutation do
         m_bid =
           case DBName.cache_through_prev(Model.AuctionBid, DBName.bid_top_key(plain_name)) do
             :not_found ->
-              Ets.inc(:stat_sync_cache, :active_auctions)
               make_m_bid.([{block_index, txi}])
 
             {:ok,
@@ -153,6 +151,8 @@ defmodule AeMdw.Db.NameClaimMutation do
         DBName.cache_through_write(Model.AuctionBid, m_bid)
         DBName.cache_through_write(Model.AuctionOwner, m_owner)
         DBName.cache_through_write(Model.AuctionExpiration, m_auction_exp)
+
+        Ets.inc(:stat_sync_cache, :auctions_started)
 
         log_auction_change(height, plain_name, "activate auction expiring in #{auction_end}")
     end

--- a/lib/ae_mdw/db/mutations/oracle_register_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracle_register_mutation.ex
@@ -68,8 +68,7 @@ defmodule AeMdw.Db.OracleRegisterMutation do
     m_exp_new = Model.expiration(index: {expire, oracle_pk})
     Oracle.cache_through_write(Model.ActiveOracleExpiration, m_exp_new)
 
-    AeMdw.Ets.inc(:stat_sync_cache, :active_oracles)
-    previous && AeMdw.Ets.dec(:stat_sync_cache, :inactive_oracles)
+    AeMdw.Ets.inc(:stat_sync_cache, :oracles_registered)
 
     :ok
   end

--- a/lib/ae_mdw/db/mutations/stats_mutation.ex
+++ b/lib/ae_mdw/db/mutations/stats_mutation.ex
@@ -1,6 +1,6 @@
 defmodule AeMdw.Db.StatsMutation do
   @moduledoc """
-  Inserts statistics about this generation into Model.Stat table.
+  Inserts statistics about this generation into Model.DeltaStat table.
   """
 
   alias AeMdw.Db.Model
@@ -9,27 +9,27 @@ defmodule AeMdw.Db.StatsMutation do
   require Model
 
   @derive AeMdw.Db.Mutation
-  defstruct [:stat, :total_stat]
+  defstruct [:delta_stat, :total_stat]
 
   @type t() :: %__MODULE__{
-          stat: Model.stat(),
+          delta_stat: Model.delta_stat(),
           total_stat: Model.total_stat()
         }
 
-  @spec new(Model.stat(), Model.total_stat()) :: t()
-  def new(m_stat, m_total_stat) do
+  @spec new(Model.delta_stat(), Model.total_stat()) :: t()
+  def new(m_delta_stat, m_total_stat) do
     %__MODULE__{
-      stat: m_stat,
+      delta_stat: m_delta_stat,
       total_stat: m_total_stat
     }
   end
 
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{
-        stat: stat,
+        delta_stat: delta_stat,
         total_stat: total_stat
       }) do
-    Database.write(Model.Stat, stat)
+    Database.write(Model.DeltaStat, delta_stat)
     Database.write(Model.TotalStat, total_stat)
   end
 end

--- a/lib/ae_mdw/db/origin.ex
+++ b/lib/ae_mdw/db/origin.ex
@@ -20,7 +20,6 @@ defmodule AeMdw.Db.Origin do
   def block_index({:contract, id}),
     do: map_some(tx_index({:contract, id}), &Model.tx(read_tx!(&1), :block_index))
 
-  @spec tx_index(creation_txi_locator()) :: {:ok, Txs.txi() | -1} | :not_found
   @doc """
   Tries to find the transaction that created a contract by finding it from 3
   sources:
@@ -35,6 +34,7 @@ defmodule AeMdw.Db.Origin do
     and created through core hard-forks. These contracts will have a negative
     txi where the number is the index of the preloaded contracts.
   """
+  @spec tx_index(creation_txi_locator()) :: {:ok, Txs.txi() | -1} | :not_found
   def tx_index({:contract, pk}) do
     with :error <- field_txi(:contract_create_tx, nil, pk),
          :error <- field_txi(:contract_call_tx, nil, pk) do
@@ -42,14 +42,6 @@ defmodule AeMdw.Db.Origin do
         nil -> :not_found
         index -> {:ok, -index - 1}
       end
-    end
-  end
-
-  defp field_txi(tx_type, pos, pk) do
-    case next(Model.Field, {tx_type, pos, pk, -1}) do
-      :"$end_of_table" -> :error
-      {^tx_type, ^pos, ^pk, txi} -> {:ok, txi}
-      {_tx_type, _pos, _pk, _txi} -> :error
     end
   end
 
@@ -94,6 +86,32 @@ defmodule AeMdw.Db.Origin do
       |> :aeser_id.specialize()
 
     contract_id
+  end
+
+  @spec count_contracts() :: non_neg_integer()
+  def count_contracts do
+    ct_list1 = do_list_by_tx_type([], {:contract_create_tx, <<>>, -1})
+    ct_list2 = do_list_by_tx_type([], {:contract_call_tx, <<>>, -1})
+
+    length(ct_list1) + length(ct_list2)
+  end
+
+  #
+  # Private functions
+  #
+  defp field_txi(tx_type, pos, pk) do
+    case next(Model.Field, {tx_type, pos, pk, -1}) do
+      :"$end_of_table" -> :error
+      {^tx_type, ^pos, ^pk, txi} -> {:ok, txi}
+      {_tx_type, _pos, _pk, _txi} -> :error
+    end
+  end
+
+  defp do_list_by_tx_type(origin_pks, {type, _pk, _txi} = key) do
+    case next(Model.Origin, key) do
+      {^type, pubkey, _txi} = next_key -> do_list_by_tx_type([pubkey | origin_pks], next_key)
+      _not_the_type -> origin_pks
+    end
   end
 
   defp preset_contracts do

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -70,7 +70,7 @@ defmodule AeMdw.Db.Sync.Contract do
         end
 
       :ets.insert(:ct_create_sync_cache, {contract_pk, txi})
-      AeMdw.Ets.inc(:stat_sync_cache, :contracts)
+      AeMdw.Ets.inc(:stat_sync_cache, :contracts_created)
 
       {
         SyncOrigin.origin_mutations(:contract_call_tx, nil, contract_pk, txi, tx_hash),
@@ -122,7 +122,7 @@ defmodule AeMdw.Db.Sync.Contract do
           recipient_id = :aec_spend_tx.recipient_id(tx)
           {:account, contract_pk} = :aeser_id.specialize(recipient_id)
 
-          AeMdw.Ets.inc(:stat_sync_cache, :contracts)
+          AeMdw.Ets.inc(:stat_sync_cache, :contracts_created)
           :ets.insert(:ct_create_sync_cache, {contract_pk, call_txi})
 
           SyncOrigin.origin_mutations(:contract_call_tx, nil, contract_pk, call_txi, call_tx_hash)

--- a/lib/ae_mdw/db/sync/invalidate.ex
+++ b/lib/ae_mdw/db/sync/invalidate.ex
@@ -88,7 +88,7 @@ defmodule AeMdw.Db.Sync.Invalidate do
 
   def stat_key_dels(from_kbi) do
     keys = from_kbi..last_gen()
-    %{Model.Stat => keys, Model.TotalStat => keys}
+    %{Model.DeltaStat => keys, Model.TotalStat => keys}
   end
 
   def tx_keys_range(from_txi) do

--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -87,8 +87,7 @@ defmodule AeMdw.Db.Sync.Name do
         cache_through_write(Model.InactiveName, new_m_name)
         cache_through_write(Model.InactiveNameExpiration, new_m_name_exp)
 
-        inc(:stat_sync_cache, :inactive_names)
-        dec(:stat_sync_cache, :active_names)
+        inc(:stat_sync_cache, :names_expired)
 
         log_name_change(height, plain_name, "expire")
 
@@ -134,8 +133,7 @@ defmodule AeMdw.Db.Sync.Name do
     cache_through_write(Model.InactiveName, m_name)
     cache_through_write(Model.InactiveNameExpiration, m_exp)
 
-    inc(:stat_sync_cache, :inactive_names)
-    dec(:stat_sync_cache, :active_names)
+    inc(:stat_sync_cache, :names_revoked)
 
     log_name_change(height, plain_name, "revoke")
   end

--- a/lib/ae_mdw/db/sync/stats.ex
+++ b/lib/ae_mdw/db/sync/stats.ex
@@ -126,10 +126,10 @@ defmodule AeMdw.Db.Sync.Stats do
       block_reward: prev_block_reward + inc_block_reward,
       dev_reward: prev_dev_reward + inc_dev_reward,
       total_supply: prev_total_supply + token_supply_delta + inc_block_reward + inc_dev_reward,
-      active_auctions: prev_active_auctions + auctions_started - auctions_expired,
-      active_names: prev_active_names + names_activated - (names_expired + names_revoked),
+      active_auctions: max(0, prev_active_auctions + auctions_started - auctions_expired),
+      active_names: max(0, prev_active_names + names_activated - (names_expired + names_revoked)),
       inactive_names: prev_inactive_names + names_expired + names_revoked,
-      active_oracles: prev_active_oracles + oracles_registered - oracles_expired,
+      active_oracles: max(0, prev_active_oracles + oracles_registered - oracles_expired),
       inactive_oracles: prev_inactive_oracles + oracles_expired,
       contracts: prev_contracts + contracts_created
     )

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -282,7 +282,6 @@ defmodule AeMdw.Db.Sync.Transaction do
     owner_pk = :aect_create_tx.owner_pubkey(tx)
 
     :ets.insert(:ct_create_sync_cache, {contract_pk, txi})
-    AeMdw.Ets.inc(:stat_sync_cache, :contracts_created)
 
     mutations = Origin.origin_mutations(:contract_create_tx, nil, contract_pk, txi, tx_hash)
 

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -282,6 +282,7 @@ defmodule AeMdw.Db.Sync.Transaction do
     owner_pk = :aect_create_tx.owner_pubkey(tx)
 
     :ets.insert(:ct_create_sync_cache, {contract_pk, txi})
+    AeMdw.Ets.inc(:stat_sync_cache, :contracts_created)
 
     mutations = Origin.origin_mutations(:contract_create_tx, nil, contract_pk, txi, tx_hash)
 
@@ -362,7 +363,7 @@ defmodule AeMdw.Db.Sync.Transaction do
   defp tx_mutations(%TxContext{type: :ga_attach_tx, tx: tx, txi: txi, tx_hash: tx_hash}) do
     contract_pk = :aega_attach_tx.contract_pubkey(tx)
     :ets.insert(:ct_create_sync_cache, {contract_pk, txi})
-    AeMdw.Ets.inc(:stat_sync_cache, :contracts)
+    AeMdw.Ets.inc(:stat_sync_cache, :contracts_created)
 
     Origin.origin_mutations(:ga_attach_tx, nil, contract_pk, txi, tx_hash)
   end

--- a/lib/ae_mdw/stats.ex
+++ b/lib/ae_mdw/stats.ex
@@ -11,7 +11,7 @@ defmodule AeMdw.Stats do
 
   require Model
 
-  @type stat() :: map()
+  @type delta_stat() :: map()
   @type total_stat() :: map()
   @type cursor() :: binary() | nil
 
@@ -20,12 +20,13 @@ defmodule AeMdw.Stats do
   @typep limit() :: Database.limit()
   @typep range() :: {:gen, Range.t()} | nil
 
-  @table Model.Stat
+  @delta_table Model.DeltaStat
   @totals_table Model.TotalStat
 
-  @spec fetch_stats(direction(), range(), cursor(), limit()) :: {cursor(), [stat()], cursor()}
-  def fetch_stats(direction, range, cursor, limit) do
-    {:ok, last_gen} = Database.last_key(AeMdw.Db.Model.Stat)
+  @spec fetch_delta_stats(direction(), range(), cursor(), limit()) ::
+          {cursor(), [delta_stat()], cursor()}
+  def fetch_delta_stats(direction, range, cursor, limit) do
+    {:ok, last_gen} = Database.last_key(AeMdw.Db.Model.DeltaStat)
 
     {range_first, range_last} =
       case range do
@@ -66,8 +67,8 @@ defmodule AeMdw.Stats do
     end
   end
 
-  @spec fetch_stat!(height()) :: stat()
-  def fetch_stat!(height), do: render_stat(Database.fetch!(@table, height))
+  @spec fetch_stat!(height()) :: delta_stat()
+  def fetch_stat!(height), do: render_stat(Database.fetch!(@delta_table, height))
 
   @spec fetch_total_stat!(height()) :: total_stat()
   def fetch_total_stat!(height), do: render_total_stat(Database.fetch!(@totals_table, height))
@@ -76,7 +77,7 @@ defmodule AeMdw.Stats do
 
   defp render_total_stats(gens), do: Enum.map(gens, &fetch_total_stat!/1)
 
-  defp render_stat(stat), do: Format.to_map(stat, @table)
+  defp render_stat(stat), do: Format.to_map(stat, @delta_table)
 
   defp render_total_stat(total_stat), do: Format.to_map(total_stat, @totals_table)
 

--- a/lib/ae_mdw_web/controllers/stats_controller.ex
+++ b/lib/ae_mdw_web/controllers/stats_controller.ex
@@ -13,7 +13,17 @@ defmodule AeMdwWeb.StatsController do
     %{pagination: {direction, _is_reversed?, limit, _has_cursor?}, cursor: cursor, scope: scope} =
       assigns
 
-    {prev_cursor, stats, next_cursor} = Stats.fetch_stats(direction, scope, cursor, limit)
+    {prev_cursor, stats, next_cursor} = Stats.fetch_delta_stats(direction, scope, cursor, limit)
+
+    Util.paginate(conn, prev_cursor, stats, next_cursor)
+  end
+
+  @spec delta_stats(Conn.t(), map()) :: Conn.t()
+  def delta_stats(%Conn{assigns: assigns} = conn, _params) do
+    %{pagination: {direction, _is_reversed?, limit, _has_cursor?}, cursor: cursor, scope: scope} =
+      assigns
+
+    {prev_cursor, stats, next_cursor} = Stats.fetch_delta_stats(direction, scope, cursor, limit)
 
     Util.paginate(conn, prev_cursor, stats, next_cursor)
   end

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -5,7 +5,6 @@ defmodule AeMdwWeb.Router do
     {"/txs/count", AeMdwWeb.TxController, :count},
     {"/txs/count/:id", AeMdwWeb.TxController, :count_id},
     {"/transfers", AeMdwWeb.TransferController, :transfers},
-    {"/stats/", AeMdwWeb.StatsController, :stats},
     {"/totalstats/", AeMdwWeb.StatsController, :total_stats},
     {"/status", AeMdwWeb.UtilController, :status}
   ]
@@ -30,7 +29,8 @@ defmodule AeMdwWeb.Router do
     {"/contracts/logs/:scope_type/:range", AeMdwWeb.ContractController, :logs},
     {"/contracts/calls", AeMdwWeb.ContractController, :calls},
     {"/contracts/calls/:direction", AeMdwWeb.ContractController, :calls},
-    {"/contracts/calls/:scope_type/:range", AeMdwWeb.ContractController, :calls}
+    {"/contracts/calls/:scope_type/:range", AeMdwWeb.ContractController, :calls},
+    {"/stats", AeMdwWeb.StatsController, :stats}
   ]
 
   pipeline :api do
@@ -82,6 +82,8 @@ defmodule AeMdwWeb.Router do
 
       get "/oracles/:id", OracleController, :oracle
       get "/oracles", OracleController, :oracles
+
+      get "/deltastats", StatsController, :delta_stats
     end
 
     Enum.each(@shared_routes ++ @non_migrated_routes, fn {path, controller, fun} ->

--- a/priv/migrations/20211220163202_index_ga_attach_txs.ex
+++ b/priv/migrations/20211220163202_index_ga_attach_txs.ex
@@ -112,9 +112,13 @@ defmodule AeMdw.Migrations.IndexGaAttachTxs do
 
     {:atomic, :ok} =
       :mnesia.transaction(fn ->
-        [Model.stat(contracts: contracts) = m_stat] = Database.read(Model.Stat, height + 1)
-        new_m_stat = Model.stat(m_stat, contracts: contracts + new_contracts_count)
-        Database.write(Model.Stat, new_m_stat)
+        [Model.delta_stat(contracts_created: contracts) = m_delta_stat] =
+          Database.read(Model.DeltaStat, height + 1)
+
+        new_m_delta_stat =
+          Model.delta_stat(m_delta_stat, contracts_created: contracts + new_contracts_count)
+
+        Database.write(Model.DeltaStat, new_m_delta_stat)
       end)
 
     new_contracts_count

--- a/test/ae_mdw/db/rocksdbcf_test.exs
+++ b/test/ae_mdw/db/rocksdbcf_test.exs
@@ -128,8 +128,7 @@ defmodule AeMdw.Db.RocksDbCFTest do
     end
 
     test "returns the previous key for tuple" do
-      assert :ok = RocksDbCF.dirty_put(Model.Block, Model.block(index: {new_kbi(), -1}))
-      assert :ok = RocksDbCF.dirty_put(Model.Block, Model.block(index: {new_kbi(), -1}))
+      assert :ok = RocksDbCF.dirty_put(Model.Block, Model.block(index: {0, -1}))
       assert {:ok, {0, -1}} = RocksDbCF.prev_key(Model.Block, {0, nil})
     end
   end

--- a/test/integration/ae_mdw/sync/stats_test.exs
+++ b/test/integration/ae_mdw/sync/stats_test.exs
@@ -12,8 +12,13 @@ defmodule Integration.AeMdw.Db.Sync.StatsTest do
   require Model
 
   @initial_token_offer AeMdw.Node.token_supply_delta(0)
+
   @first_block_reward_height 181
   @first_block_reward 1_000_000_000_000_000_000
+
+  # block_height from /txs/forward?type=
+  @first_name_height 194
+  @first_oracle_height 4165
   @first_contract_height 4187
 
   describe "new_mutation/2" do
@@ -80,6 +85,94 @@ defmodule Integration.AeMdw.Db.Sync.StatsTest do
     assert Model.delta_stat(m_delta_stat, :names_expired) == 0
     assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
     assert Model.delta_stat(m_delta_stat, :oracles_registered) == 0
+    assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
+    assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
+  end
+
+  test "with all_cached? = true and 1st name" do
+    on_exit(fn ->
+      AeMdw.Ets.clear(:stat_sync_cache)
+    end)
+
+    AeMdw.Ets.inc(:stat_sync_cache, :names_activated)
+    %StatsMutation{delta_stat: m_delta_stat} = Stats.new_mutation(@first_name_height, true)
+    # delta/transitions are only reflected at height + 1
+    AeMdw.Ets.clear(:stat_sync_cache)
+
+    %StatsMutation{total_stat: m_total_stat} =
+      Stats.new_mutation(@first_name_height + 1, true)
+
+    total_block_reward =
+      1..@first_name_height |> Enum.map(&IntTransfer.read_block_reward/1) |> Enum.sum()
+
+    total_dev_reward =
+      1..@first_name_height |> Enum.map(&IntTransfer.read_dev_reward/1) |> Enum.sum()
+
+    assert Model.total_stat(m_total_stat, :block_reward) == total_block_reward
+    assert Model.total_stat(m_total_stat, :dev_reward) == total_dev_reward
+
+    total_supply =
+      0..(@first_name_height + 1) |> Enum.map(&AeMdw.Node.token_supply_delta/1) |> Enum.sum()
+
+    assert Model.total_stat(m_total_stat, :total_supply) ==
+             total_supply + total_block_reward + total_dev_reward
+
+    assert Model.total_stat(m_total_stat, :inactive_names) == 0
+    assert Model.total_stat(m_total_stat, :active_names) == 1
+    assert Model.total_stat(m_total_stat, :active_auctions) == 0
+    assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
+    assert Model.total_stat(m_total_stat, :active_oracles) == 0
+    assert Model.total_stat(m_total_stat, :contracts) == 0
+
+    assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
+    assert Model.delta_stat(m_delta_stat, :names_activated) == 1
+    assert Model.delta_stat(m_delta_stat, :names_expired) == 0
+    assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
+    assert Model.delta_stat(m_delta_stat, :oracles_registered) == 0
+    assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
+    assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
+  end
+
+  test "with all_cached? = true and 1st oracle" do
+    on_exit(fn ->
+      AeMdw.Ets.clear(:stat_sync_cache)
+    end)
+
+    AeMdw.Ets.inc(:stat_sync_cache, :oracles_registered)
+    %StatsMutation{delta_stat: m_delta_stat} = Stats.new_mutation(@first_oracle_height, true)
+    # delta/transitions are only reflected at height + 1
+    AeMdw.Ets.clear(:stat_sync_cache)
+
+    %StatsMutation{total_stat: m_total_stat} =
+      Stats.new_mutation(@first_oracle_height + 1, true)
+
+    total_block_reward =
+      1..@first_oracle_height |> Enum.map(&IntTransfer.read_block_reward/1) |> Enum.sum()
+
+    total_dev_reward =
+      1..@first_oracle_height |> Enum.map(&IntTransfer.read_dev_reward/1) |> Enum.sum()
+
+    assert Model.total_stat(m_total_stat, :block_reward) == total_block_reward
+    assert Model.total_stat(m_total_stat, :dev_reward) == total_dev_reward
+
+    total_supply =
+      0..(@first_oracle_height + 1) |> Enum.map(&AeMdw.Node.token_supply_delta/1) |> Enum.sum()
+
+    assert Model.total_stat(m_total_stat, :total_supply) ==
+             total_supply + total_block_reward + total_dev_reward
+
+    assert Model.total_stat(m_total_stat, :inactive_names) == 0
+    assert Model.total_stat(m_total_stat, :active_names) == 3
+    assert Model.total_stat(m_total_stat, :active_auctions) == 0
+    assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
+    assert Model.total_stat(m_total_stat, :active_oracles) == 1
+    assert Model.total_stat(m_total_stat, :contracts) == 0
+
+    assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
+    assert Model.delta_stat(m_delta_stat, :names_activated) == 0
+    assert Model.delta_stat(m_delta_stat, :names_expired) == 0
+    assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
+    assert Model.delta_stat(m_delta_stat, :oracles_registered) == 1
     assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
     assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
   end

--- a/test/integration/ae_mdw/sync/stats_test.exs
+++ b/test/integration/ae_mdw/sync/stats_test.exs
@@ -8,6 +8,8 @@ defmodule Integration.AeMdw.Db.Sync.StatsTest do
   alias AeMdw.Db.Sync.Stats
   alias AeMdw.Db.StatsMutation
   alias AeMdw.Db.IntTransfer
+  alias AeMdw.Db.Origin
+  alias AeMdw.Db.Util
 
   require Model
 
@@ -16,13 +18,14 @@ defmodule Integration.AeMdw.Db.Sync.StatsTest do
   @first_block_reward_height 181
   @first_block_reward 1_000_000_000_000_000_000
 
-  # block_height from /txs/forward?type=
-  @first_name_height 194
-  @first_oracle_height 4165
-  @first_contract_height 4187
+  # block_height from /txs/forward?type={tx_type} for respective tx_type below
+  @first_name_claim_height 194
+  @first_oracle_register_height 4165
+  @first_contract_create_height 4187
+  @first_name_revoked_height 34_923
 
-  describe "new_mutation/2" do
-    test "with all_cached? = false and 1st block reward" do
+  describe "new_mutation/2 with all_cached? = false" do
+    test "on 1st block reward" do
       %StatsMutation{delta_stat: m_delta_stat, total_stat: m_total_stat} =
         Stats.new_mutation(@first_block_reward_height, false)
 
@@ -56,168 +59,241 @@ defmodule Integration.AeMdw.Db.Sync.StatsTest do
     end
   end
 
-  test "with all_cached? = true and 1st block reward" do
-    on_exit(fn ->
+  describe "new_mutation/2 with all_cached? = true" do
+    test "on 1st block reward" do
+      on_exit(fn ->
+        AeMdw.Ets.clear(:stat_sync_cache)
+      end)
+
+      AeMdw.Ets.inc(:stat_sync_cache, :block_reward, @first_block_reward)
+
+      %StatsMutation{delta_stat: m_delta_stat, total_stat: m_total_stat} =
+        Stats.new_mutation(@first_block_reward_height, true)
+
+      assert Model.total_stat(m_total_stat, :block_reward) == @first_block_reward
+      assert Model.total_stat(m_total_stat, :dev_reward) == 0
+
+      assert Model.total_stat(m_total_stat, :total_supply) ==
+               @initial_token_offer + @first_block_reward
+
+      assert Model.total_stat(m_total_stat, :inactive_names) == 0
+      assert Model.total_stat(m_total_stat, :active_names) == 0
+      assert Model.total_stat(m_total_stat, :active_auctions) == 0
+      assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
+      assert Model.total_stat(m_total_stat, :active_oracles) == 0
+      assert Model.total_stat(m_total_stat, :contracts) == 0
+
+      assert Model.delta_stat(m_delta_stat, :block_reward) == @first_block_reward
+      assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
+      assert Model.delta_stat(m_delta_stat, :names_activated) == 0
+      assert Model.delta_stat(m_delta_stat, :names_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
+      assert Model.delta_stat(m_delta_stat, :oracles_registered) == 0
+      assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
+    end
+
+    test "on 1st name_claim_tx" do
+      on_exit(fn ->
+        AeMdw.Ets.clear(:stat_sync_cache)
+      end)
+
+      AeMdw.Ets.inc(:stat_sync_cache, :names_activated)
+
+      %StatsMutation{delta_stat: m_delta_stat} =
+        Stats.new_mutation(@first_name_claim_height, true)
+
+      # delta/transitions are only reflected at height + 1
       AeMdw.Ets.clear(:stat_sync_cache)
-    end)
 
-    AeMdw.Ets.inc(:stat_sync_cache, :block_reward, @first_block_reward)
+      %StatsMutation{total_stat: m_total_stat} =
+        Stats.new_mutation(@first_name_claim_height + 1, true)
 
-    %StatsMutation{delta_stat: m_delta_stat, total_stat: m_total_stat} =
-      Stats.new_mutation(@first_block_reward_height, true)
+      total_block_reward =
+        1..@first_name_claim_height |> Enum.map(&IntTransfer.read_block_reward/1) |> Enum.sum()
 
-    assert Model.total_stat(m_total_stat, :block_reward) == @first_block_reward
-    assert Model.total_stat(m_total_stat, :dev_reward) == 0
+      total_dev_reward =
+        1..@first_name_claim_height |> Enum.map(&IntTransfer.read_dev_reward/1) |> Enum.sum()
 
-    assert Model.total_stat(m_total_stat, :total_supply) ==
-             @initial_token_offer + @first_block_reward
+      assert Model.total_stat(m_total_stat, :block_reward) == total_block_reward
+      assert Model.total_stat(m_total_stat, :dev_reward) == total_dev_reward
 
-    assert Model.total_stat(m_total_stat, :inactive_names) == 0
-    assert Model.total_stat(m_total_stat, :active_names) == 0
-    assert Model.total_stat(m_total_stat, :active_auctions) == 0
-    assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
-    assert Model.total_stat(m_total_stat, :active_oracles) == 0
-    assert Model.total_stat(m_total_stat, :contracts) == 0
+      total_supply =
+        0..(@first_name_claim_height + 1)
+        |> Enum.map(&AeMdw.Node.token_supply_delta/1)
+        |> Enum.sum()
 
-    assert Model.delta_stat(m_delta_stat, :block_reward) == @first_block_reward
-    assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
-    assert Model.delta_stat(m_delta_stat, :names_activated) == 0
-    assert Model.delta_stat(m_delta_stat, :names_expired) == 0
-    assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
-    assert Model.delta_stat(m_delta_stat, :oracles_registered) == 0
-    assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
-    assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
-  end
+      assert Model.total_stat(m_total_stat, :total_supply) ==
+               total_supply + total_block_reward + total_dev_reward
 
-  test "with all_cached? = true and 1st name" do
-    on_exit(fn ->
+      assert Model.total_stat(m_total_stat, :inactive_names) == 0
+      assert Model.total_stat(m_total_stat, :active_names) == 1
+      assert Model.total_stat(m_total_stat, :active_auctions) == 0
+      assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
+      assert Model.total_stat(m_total_stat, :active_oracles) == 0
+      assert Model.total_stat(m_total_stat, :contracts) == 0
+
+      assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
+      assert Model.delta_stat(m_delta_stat, :names_activated) == 1
+      assert Model.delta_stat(m_delta_stat, :names_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
+      assert Model.delta_stat(m_delta_stat, :oracles_registered) == 0
+      assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
+    end
+
+    test "on 1st name_revoke_tx" do
+      on_exit(fn ->
+        AeMdw.Ets.clear(:stat_sync_cache)
+      end)
+
+      AeMdw.Ets.inc(:stat_sync_cache, :names_revoked)
+
+      %StatsMutation{delta_stat: m_delta_stat} =
+        Stats.new_mutation(@first_name_revoked_height, true)
+
+      # delta/transitions are only reflected at height + 1
       AeMdw.Ets.clear(:stat_sync_cache)
-    end)
 
-    AeMdw.Ets.inc(:stat_sync_cache, :names_activated)
-    %StatsMutation{delta_stat: m_delta_stat} = Stats.new_mutation(@first_name_height, true)
-    # delta/transitions are only reflected at height + 1
-    AeMdw.Ets.clear(:stat_sync_cache)
+      %StatsMutation{total_stat: m_total_stat} =
+        Stats.new_mutation(@first_name_revoked_height + 1, true)
 
-    %StatsMutation{total_stat: m_total_stat} =
-      Stats.new_mutation(@first_name_height + 1, true)
+      total_block_reward =
+        1..@first_name_revoked_height |> Enum.map(&IntTransfer.read_block_reward/1) |> Enum.sum()
 
-    total_block_reward =
-      1..@first_name_height |> Enum.map(&IntTransfer.read_block_reward/1) |> Enum.sum()
+      total_dev_reward =
+        1..@first_name_revoked_height |> Enum.map(&IntTransfer.read_dev_reward/1) |> Enum.sum()
 
-    total_dev_reward =
-      1..@first_name_height |> Enum.map(&IntTransfer.read_dev_reward/1) |> Enum.sum()
+      assert Model.total_stat(m_total_stat, :block_reward) == total_block_reward
+      assert Model.total_stat(m_total_stat, :dev_reward) == total_dev_reward
 
-    assert Model.total_stat(m_total_stat, :block_reward) == total_block_reward
-    assert Model.total_stat(m_total_stat, :dev_reward) == total_dev_reward
+      total_supply =
+        0..(@first_name_revoked_height + 1)
+        |> Enum.map(&AeMdw.Node.token_supply_delta/1)
+        |> Enum.sum()
 
-    total_supply =
-      0..(@first_name_height + 1) |> Enum.map(&AeMdw.Node.token_supply_delta/1) |> Enum.sum()
+      assert Model.total_stat(m_total_stat, :total_supply) ==
+               total_supply + total_block_reward + total_dev_reward
 
-    assert Model.total_stat(m_total_stat, :total_supply) ==
-             total_supply + total_block_reward + total_dev_reward
+      assert Model.total_stat(m_total_stat, :inactive_names) == Util.count(Model.InactiveName)
+      assert Model.total_stat(m_total_stat, :active_names) == Util.count(Model.ActiveName)
 
-    assert Model.total_stat(m_total_stat, :inactive_names) == 0
-    assert Model.total_stat(m_total_stat, :active_names) == 1
-    assert Model.total_stat(m_total_stat, :active_auctions) == 0
-    assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
-    assert Model.total_stat(m_total_stat, :active_oracles) == 0
-    assert Model.total_stat(m_total_stat, :contracts) == 0
+      assert Model.total_stat(m_total_stat, :active_auctions) ==
+               Util.count(Model.AuctionExpiration)
 
-    assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
-    assert Model.delta_stat(m_delta_stat, :names_activated) == 1
-    assert Model.delta_stat(m_delta_stat, :names_expired) == 0
-    assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
-    assert Model.delta_stat(m_delta_stat, :oracles_registered) == 0
-    assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
-    assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
-  end
+      assert Model.total_stat(m_total_stat, :inactive_oracles) == Util.count(Model.InactiveOracle)
+      assert Model.total_stat(m_total_stat, :active_oracles) == Util.count(Model.ActiveOracle)
+      assert Model.total_stat(m_total_stat, :contracts) == Origin.count_contracts()
 
-  test "with all_cached? = true and 1st oracle" do
-    on_exit(fn ->
+      assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
+      assert Model.delta_stat(m_delta_stat, :names_activated) == 0
+      assert Model.delta_stat(m_delta_stat, :names_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :names_revoked) == 1
+      assert Model.delta_stat(m_delta_stat, :oracles_registered) == 0
+      assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
+    end
+
+    test "on 1st oracle_register_tx" do
+      on_exit(fn ->
+        AeMdw.Ets.clear(:stat_sync_cache)
+      end)
+
+      AeMdw.Ets.inc(:stat_sync_cache, :oracles_registered)
+
+      %StatsMutation{delta_stat: m_delta_stat} =
+        Stats.new_mutation(@first_oracle_register_height, true)
+
+      # delta/transitions are only reflected at height + 1
       AeMdw.Ets.clear(:stat_sync_cache)
-    end)
 
-    AeMdw.Ets.inc(:stat_sync_cache, :oracles_registered)
-    %StatsMutation{delta_stat: m_delta_stat} = Stats.new_mutation(@first_oracle_height, true)
-    # delta/transitions are only reflected at height + 1
-    AeMdw.Ets.clear(:stat_sync_cache)
+      %StatsMutation{total_stat: m_total_stat} =
+        Stats.new_mutation(@first_oracle_register_height + 1, true)
 
-    %StatsMutation{total_stat: m_total_stat} =
-      Stats.new_mutation(@first_oracle_height + 1, true)
+      total_block_reward =
+        1..@first_oracle_register_height
+        |> Enum.map(&IntTransfer.read_block_reward/1)
+        |> Enum.sum()
 
-    total_block_reward =
-      1..@first_oracle_height |> Enum.map(&IntTransfer.read_block_reward/1) |> Enum.sum()
+      total_dev_reward =
+        1..@first_oracle_register_height |> Enum.map(&IntTransfer.read_dev_reward/1) |> Enum.sum()
 
-    total_dev_reward =
-      1..@first_oracle_height |> Enum.map(&IntTransfer.read_dev_reward/1) |> Enum.sum()
+      assert Model.total_stat(m_total_stat, :block_reward) == total_block_reward
+      assert Model.total_stat(m_total_stat, :dev_reward) == total_dev_reward
 
-    assert Model.total_stat(m_total_stat, :block_reward) == total_block_reward
-    assert Model.total_stat(m_total_stat, :dev_reward) == total_dev_reward
+      total_supply =
+        0..(@first_oracle_register_height + 1)
+        |> Enum.map(&AeMdw.Node.token_supply_delta/1)
+        |> Enum.sum()
 
-    total_supply =
-      0..(@first_oracle_height + 1) |> Enum.map(&AeMdw.Node.token_supply_delta/1) |> Enum.sum()
+      assert Model.total_stat(m_total_stat, :total_supply) ==
+               total_supply + total_block_reward + total_dev_reward
 
-    assert Model.total_stat(m_total_stat, :total_supply) ==
-             total_supply + total_block_reward + total_dev_reward
+      assert Model.total_stat(m_total_stat, :inactive_names) == 0
+      assert Model.total_stat(m_total_stat, :active_names) == 3
+      assert Model.total_stat(m_total_stat, :active_auctions) == 0
+      assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
+      assert Model.total_stat(m_total_stat, :active_oracles) == 1
+      assert Model.total_stat(m_total_stat, :contracts) == 0
 
-    assert Model.total_stat(m_total_stat, :inactive_names) == 0
-    assert Model.total_stat(m_total_stat, :active_names) == 3
-    assert Model.total_stat(m_total_stat, :active_auctions) == 0
-    assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
-    assert Model.total_stat(m_total_stat, :active_oracles) == 1
-    assert Model.total_stat(m_total_stat, :contracts) == 0
+      assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
+      assert Model.delta_stat(m_delta_stat, :names_activated) == 0
+      assert Model.delta_stat(m_delta_stat, :names_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
+      assert Model.delta_stat(m_delta_stat, :oracles_registered) == 1
+      assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
+    end
 
-    assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
-    assert Model.delta_stat(m_delta_stat, :names_activated) == 0
-    assert Model.delta_stat(m_delta_stat, :names_expired) == 0
-    assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
-    assert Model.delta_stat(m_delta_stat, :oracles_registered) == 1
-    assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
-    assert Model.delta_stat(m_delta_stat, :contracts_created) == 0
-  end
+    test "on 1st contract creation" do
+      on_exit(fn ->
+        AeMdw.Ets.clear(:stat_sync_cache)
+      end)
 
-  test "with all_cached? = true and 1st contract" do
-    on_exit(fn ->
+      AeMdw.Ets.inc(:stat_sync_cache, :contracts_created)
+
+      %StatsMutation{delta_stat: m_delta_stat} =
+        Stats.new_mutation(@first_contract_create_height, true)
+
+      # delta/transitions are only reflected at height + 1
       AeMdw.Ets.clear(:stat_sync_cache)
-    end)
 
-    AeMdw.Ets.inc(:stat_sync_cache, :contracts_created)
-    %StatsMutation{delta_stat: m_delta_stat} = Stats.new_mutation(@first_contract_height, true)
-    # delta/transitions are only reflected at height + 1
-    AeMdw.Ets.clear(:stat_sync_cache)
+      %StatsMutation{total_stat: m_total_stat} =
+        Stats.new_mutation(@first_contract_create_height + 1, true)
 
-    %StatsMutation{total_stat: m_total_stat} =
-      Stats.new_mutation(@first_contract_height + 1, true)
+      total_block_reward =
+        1..@first_contract_create_height
+        |> Enum.map(&IntTransfer.read_block_reward/1)
+        |> Enum.sum()
 
-    total_block_reward =
-      1..@first_contract_height |> Enum.map(&IntTransfer.read_block_reward/1) |> Enum.sum()
+      total_dev_reward =
+        1..@first_contract_create_height |> Enum.map(&IntTransfer.read_dev_reward/1) |> Enum.sum()
 
-    total_dev_reward =
-      1..@first_contract_height |> Enum.map(&IntTransfer.read_dev_reward/1) |> Enum.sum()
+      assert Model.total_stat(m_total_stat, :block_reward) == total_block_reward
+      assert Model.total_stat(m_total_stat, :dev_reward) == total_dev_reward
 
-    assert Model.total_stat(m_total_stat, :block_reward) == total_block_reward
-    assert Model.total_stat(m_total_stat, :dev_reward) == total_dev_reward
+      total_supply =
+        0..(@first_contract_create_height + 1)
+        |> Enum.map(&AeMdw.Node.token_supply_delta/1)
+        |> Enum.sum()
 
-    total_supply =
-      0..(@first_contract_height + 1) |> Enum.map(&AeMdw.Node.token_supply_delta/1) |> Enum.sum()
+      assert Model.total_stat(m_total_stat, :total_supply) ==
+               total_supply + total_block_reward + total_dev_reward
 
-    assert Model.total_stat(m_total_stat, :total_supply) ==
-             total_supply + total_block_reward + total_dev_reward
+      assert Model.total_stat(m_total_stat, :inactive_names) == 0
+      assert Model.total_stat(m_total_stat, :active_names) == 3
+      assert Model.total_stat(m_total_stat, :active_auctions) == 0
+      assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
+      assert Model.total_stat(m_total_stat, :active_oracles) == 1
+      assert Model.total_stat(m_total_stat, :contracts) == 1
 
-    assert Model.total_stat(m_total_stat, :inactive_names) == 0
-    assert Model.total_stat(m_total_stat, :active_names) == 3
-    assert Model.total_stat(m_total_stat, :active_auctions) == 0
-    assert Model.total_stat(m_total_stat, :inactive_oracles) == 0
-    assert Model.total_stat(m_total_stat, :active_oracles) == 1
-    assert Model.total_stat(m_total_stat, :contracts) == 1
-
-    assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
-    assert Model.delta_stat(m_delta_stat, :names_activated) == 0
-    assert Model.delta_stat(m_delta_stat, :names_expired) == 0
-    assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
-    assert Model.delta_stat(m_delta_stat, :oracles_registered) == 0
-    assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
-    assert Model.delta_stat(m_delta_stat, :contracts_created) == 1
+      assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
+      assert Model.delta_stat(m_delta_stat, :names_activated) == 0
+      assert Model.delta_stat(m_delta_stat, :names_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :names_revoked) == 0
+      assert Model.delta_stat(m_delta_stat, :oracles_registered) == 0
+      assert Model.delta_stat(m_delta_stat, :oracles_expired) == 0
+      assert Model.delta_stat(m_delta_stat, :contracts_created) == 1
+    end
   end
 end

--- a/test/integration/ae_mdw/sync/stats_test.exs
+++ b/test/integration/ae_mdw/sync/stats_test.exs
@@ -3,13 +3,12 @@ defmodule Integration.AeMdw.Db.Sync.StatsTest do
 
   @moduletag :integration
 
+  alias AeMdw.Collection
   alias AeMdw.Database
   alias AeMdw.Db.Model
   alias AeMdw.Db.Sync.Stats
   alias AeMdw.Db.StatsMutation
   alias AeMdw.Db.IntTransfer
-  alias AeMdw.Db.Origin
-  alias AeMdw.Db.Util
 
   require Model
 
@@ -175,16 +174,12 @@ defmodule Integration.AeMdw.Db.Sync.StatsTest do
       assert Model.total_stat(m_total_stat, :total_supply) ==
                total_supply + total_block_reward + total_dev_reward
 
-      assert Model.total_stat(m_total_stat, :inactive_names) == Util.count(Model.InactiveName)
-      assert Model.total_stat(m_total_stat, :active_names) == Util.count(Model.ActiveName)
+      inactive_names =
+        Model.InactiveNameExpiration
+        |> Collection.stream(:forward, {{0, <<>>}, {@first_name_revoked_height + 1, <<>>}}, nil)
+        |> Enum.count()
 
-      assert Model.total_stat(m_total_stat, :active_auctions) ==
-               Util.count(Model.AuctionExpiration)
-
-      assert Model.total_stat(m_total_stat, :inactive_oracles) == Util.count(Model.InactiveOracle)
-      assert Model.total_stat(m_total_stat, :active_oracles) == Util.count(Model.ActiveOracle)
-      assert Model.total_stat(m_total_stat, :contracts) == Origin.count_contracts()
-
+      assert Model.total_stat(m_total_stat, :inactive_names) == inactive_names
       assert Model.delta_stat(m_delta_stat, :auctions_started) == 0
       assert Model.delta_stat(m_delta_stat, :names_activated) == 0
       assert Model.delta_stat(m_delta_stat, :names_expired) == 0

--- a/test/integration/ae_mdw_web/controllers/stats_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/stats_controller_test.exs
@@ -7,12 +7,12 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
 
   @default_limit 10
 
-  describe "stats" do
+  describe "delta stats" do
     test "when no subpath it gets stats in backwards direction", %{conn: conn} do
       limit = 3
       last_gen = Util.last_gen()
 
-      conn = get(conn, "/v2/stats", limit: limit)
+      conn = get(conn, "/v2/deltastats", limit: limit)
       response = json_response(conn, 200)
 
       assert ^limit = Enum.count(response["data"])
@@ -32,7 +32,7 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
     end
 
     test "when direction=forward it gets stats starting from 1", %{conn: conn} do
-      conn = get(conn, "/v2/stats", direction: "forward")
+      conn = get(conn, "/v2/deltastats", direction: "forward")
       response = json_response(conn, 200)
 
       assert @default_limit = Enum.count(response["data"])
@@ -52,9 +52,9 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
     end
 
     test "it gets generations with numeric range and default limit", %{conn: conn} do
-      first = 305_000
-      last = 305_100
-      conn = get(conn, "/v2/stats", scope: "gen:#{first}-#{last}")
+      first = 55_000
+      last = 55_200
+      conn = get(conn, "/v2/deltastats", scope: "gen:#{first}-#{last}")
       response = json_response(conn, 200)
 
       assert @default_limit = Enum.count(response["data"])
@@ -74,10 +74,10 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
     end
 
     test "it gets generations backwards with numeric range and limit=1", %{conn: conn} do
-      first = 305_100
-      last = 305_000
+      first = 56_300
+      last = 56_000
       limit = 1
-      conn = get(conn, "/v2/stats", scope: "gen:#{first}-#{last}", limit: limit)
+      conn = get(conn, "/v2/deltastats", scope: "gen:#{first}-#{last}", limit: limit)
       response = json_response(conn, 200)
 
       assert ^limit = Enum.count(response["data"])
@@ -98,7 +98,7 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
 
     test "renders error when the range is invalid", %{conn: conn} do
       range = "invalid"
-      conn = get(conn, "/v2/stats", scope: "gen:#{range}")
+      conn = get(conn, "/v2/deltastats", scope: "gen:#{range}")
       error_msg = "invalid range: #{range}"
 
       assert %{"error" => ^error_msg} = json_response(conn, 400)

--- a/test/integration/ae_mdw_web/controllers/stats_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/stats_controller_test.exs
@@ -52,8 +52,8 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
     end
 
     test "it gets generations with numeric range and default limit", %{conn: conn} do
-      first = 55_000
-      last = 55_200
+      first = 47_800
+      last = 48_000
       conn = get(conn, "/v2/deltastats", scope: "gen:#{first}-#{last}")
       response = json_response(conn, 200)
 
@@ -74,8 +74,8 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
     end
 
     test "it gets generations backwards with numeric range and limit=1", %{conn: conn} do
-      first = 56_300
-      last = 56_000
+      first = 49_300
+      last = 49_000
       limit = 1
       conn = get(conn, "/v2/deltastats", scope: "gen:#{first}-#{last}", limit: limit)
       response = json_response(conn, 200)
@@ -159,8 +159,8 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
     end
 
     test "it gets generations with numeric range and default limit", %{conn: conn} do
-      first = 305_000
-      last = 305_100
+      first = 50_000
+      last = 50_500
       conn = get(conn, "/v2/totalstats", scope: "gen:#{first}-#{last}")
       response = json_response(conn, 200)
 
@@ -181,8 +181,8 @@ defmodule Integration.AeMdwWeb.StatsControllerTest do
     end
 
     test "it gets generations backwards with numeric range and limit=1", %{conn: conn} do
-      first = 305_100
-      last = 305_000
+      first = 50_400
+      last = 50_000
       limit = 1
       conn = get(conn, "/v2/totalstats", scope: "gen:#{first}-#{last}", limit: limit)
       response = json_response(conn, 200)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,8 +5,8 @@ if :integration not in Keyword.fetch!(config, :include) do
   Application.stop(:aecore)
 
   :ets.new(:counters, [:named_table, :set, :public])
-  :ets.insert(:counters, {:txi, -1})
-  :ets.insert(:counters, {:kbi, -1})
+  :ets.insert(:counters, {:txi, 0})
+  :ets.insert(:counters, {:kbi, 0})
 
   # reset database
   alias AeMdw.Db.RocksDb


### PR DESCRIPTION
## What

Adds `/v2/deltastats` which contains object state transition counters (as per request `names_revoked` was added to give a reason for inactivation). 

## Why

refs #557 

## Validation steps

```
INTEGRATION_TEST=1 elixir --sname aeternity@localhost -S mix test.integration  test/integration/ae_mdw/sync/stats_test.exs
INTEGRATION_TEST=1 elixir --sname aeternity@localhost -S mix test.integration  test/integration/ae_mdw_web/controllers/stats_controller_test.exs 
```

## Additional notes
Optionally #562 can be merged to this branch to review altogether.