### PR TITLE
chore: rename name endpoints swagger operation ids

### DIFF
--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -801,7 +801,7 @@ defmodule AeMdwWeb.NameController do
     description("Get name information for given acount/owner")
     produces(["application/json"])
     deprecated(false)
-    operation_id("get_owned_by")
+    operation_id("get_names_owned_by")
     tag("Middleware")
 
     parameters do
@@ -880,7 +880,7 @@ defmodule AeMdwWeb.NameController do
     description("Get pointers for given name.")
     produces(["application/json"])
     deprecated(false)
-    operation_id("get_pointers_by_id")
+    operation_id("get_name_pointers")
     tag("Middleware")
 
     parameters do
@@ -899,7 +899,7 @@ defmodule AeMdwWeb.NameController do
     description("Get names pointing to a particular pubkey.")
     produces(["application/json"])
     deprecated(false)
-    operation_id("get_pointees_by_id")
+    operation_id("get_name_pointees")
     tag("Middleware")
 
     parameters do


### PR DESCRIPTION
All operations naming should be consistent with each other and should
include the name of the resource being returned by the endpoint.

Refs #179