### PR TITLE
feat: cached aex9 balances

### DIFF
--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -40,8 +40,14 @@ defmodule AeMdw.Aex9 do
         nil
       )
       |> Stream.map(&Database.fetch!(Model.Aex9Balance, &1))
-      |> Enum.into(%{}, fn Model.aex9_balance(index: {_ct_pk, account_pk}, amount: amount) ->
-        {{:address, account_pk}, amount}
+      |> Enum.into(%{}, fn Model.aex9_balance(index: {_ct_pk, account_pk}, amount: amount) = m_bal ->
+        if amount == nil do
+          {amount, _key_height_hash} = Db.aex9_balance(contract_pk, account_pk)
+          Database.dirty_write(Model.Aex9Balance, Model.aex9_balance(m_bal, amount: amount))
+          {{:address, account_pk}, amount}
+        else
+          {{:address, account_pk}, amount}
+        end
       end)
     end
   end

--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -30,7 +30,7 @@ defmodule AeMdw.Aex9 do
   @spec fetch_balances(pubkey(), boolean()) :: amounts()
   def fetch_balances(contract_pk, top?) do
     if top? do
-      {amounts, _height} = Db.aex9_balances!(contract_pk)
+      {amounts, _height} = Db.aex9_balances!(contract_pk, true)
       amounts
     else
       Model.Aex9Balance

--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -46,8 +46,11 @@ defmodule AeMdw.Aex9 do
         {{:address, account_pk}, amount}
       end)
       |> case do
-        amounts when map_size(amounts) == 0 -> raise ErrInput.Aex9BalanceNotAvailable, value: "contract #{enc_ct(contract_pk)}"
-        amounts -> amounts
+        amounts when map_size(amounts) == 0 ->
+          raise ErrInput.Aex9BalanceNotAvailable, value: "contract #{enc_ct(contract_pk)}"
+
+        amounts ->
+          amounts
       end
     end
   end

--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -40,14 +40,8 @@ defmodule AeMdw.Aex9 do
         nil
       )
       |> Stream.map(&Database.fetch!(Model.Aex9Balance, &1))
-      |> Enum.into(%{}, fn Model.aex9_balance(index: {_ct_pk, account_pk}, amount: amount) = m_bal ->
-        if amount == nil do
-          {amount, _key_height_hash} = Db.aex9_balance(contract_pk, account_pk)
-          Database.dirty_write(Model.Aex9Balance, Model.aex9_balance(m_bal, amount: amount))
-          {{:address, account_pk}, amount}
-        else
-          {{:address, account_pk}, amount}
-        end
+      |> Enum.into(%{}, fn Model.aex9_balance(index: {_ct_pk, account_pk}, amount: amount) ->
+        {{:address, account_pk}, amount}
       end)
     end
   end

--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -10,6 +10,8 @@ defmodule AeMdw.Aex9 do
   alias AeMdw.Node.Db
   alias AeMdw.Util
 
+  import AeMdwWeb.Helpers.Aex9Helper, only: [enc_ct: 1]
+
   require Model
 
   @type account_transfer_key ::
@@ -43,6 +45,10 @@ defmodule AeMdw.Aex9 do
       |> Enum.into(%{}, fn Model.aex9_balance(index: {_ct_pk, account_pk}, amount: amount) ->
         {{:address, account_pk}, amount}
       end)
+      |> case do
+        amounts when map_size(amounts) == 0 -> raise ErrInput.Aex9BalanceNotAvailable, value: "contract #{enc_ct(contract_pk)}"
+        amounts -> amounts
+      end
     end
   end
 

--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -124,11 +124,21 @@ defmodule AeMdw.Contract do
     }
   end
 
-  @spec is_aex9_successful_call?(fun_arg_res_or_error()) :: boolean
-  def is_aex9_successful_call?({:error, _reason}), do: false
-  def is_aex9_successful_call?(%{result: %{error: _error}}), do: false
-  def is_aex9_successful_call?(%{result: %{abort: _error}}), do: false
-  def is_aex9_successful_call?(_result_ok), do: true
+  @spec extract_successful_function(fun_arg_res_or_error()) ::
+          {:ok, method_name(), method_args()} | :not_found
+  def extract_successful_function({:error, _reason}), do: :not_found
+  def extract_successful_function(%{result: %{error: _error}}), do: :not_found
+  def extract_successful_function(%{result: %{abort: _error}}), do: :not_found
+
+  def extract_successful_function(%{function: method_name, arguments: method_args}) do
+    {:ok, method_name, method_args}
+  end
+
+  @spec is_success_ct_call?(fun_arg_res_or_error()) :: boolean
+  def is_success_ct_call?({:error, _reason}), do: false
+  def is_success_ct_call?(%{result: %{error: _error}}), do: false
+  def is_success_ct_call?(%{result: %{abort: _error}}), do: false
+  def is_success_ct_call?(_result_ok), do: true
 
   @spec is_non_stateful_aex9_function?(method_name()) :: boolean()
   def is_non_stateful_aex9_function?(<<method_name::binary>>) do
@@ -150,14 +160,14 @@ defmodule AeMdw.Contract do
       ]),
       do: {from_pk, to_pk, value}
 
-  def get_aex9_transfer("transfer_allowance", [
+  def get_aex9_transfer(_caller_pk, "transfer_allowance", [
         %{type: :address, value: from_pk},
         %{type: :address, value: to_pk},
         %{type: :int, value: value}
       ]),
       do: {from_pk, to_pk, value}
 
-  def get_aex9_transfer(_other_function, _other_args), do: nil
+  def get_aex9_transfer(_caller_pk, _other_function, _other_args), do: nil
 
   @spec is_aex9?(DBN.pubkey() | type_info()) :: boolean()
   def is_aex9?(pubkey) when is_binary(pubkey) do

--- a/lib/ae_mdw/database.ex
+++ b/lib/ae_mdw/database.ex
@@ -38,12 +38,11 @@ defmodule AeMdw.Database do
     :mnesia.dirty_all_keys(table)
   end
 
-  @spec dirty_delete(transaction(), table(), key()) :: :ok
-  def dirty_delete(txn, table, key) when use_rocksdb?(table) do
-    :ok = RocksDbCF.dirty_delete(txn, table, key)
+  @spec dirty_delete(table(), key()) :: :ok
+  def dirty_delete(tab, key) when use_rocksdb?(tab) do
+    :ok = RocksDbCF.dirty_delete(tab, key)
   end
 
-  @spec dirty_delete(table(), key()) :: :ok
   def dirty_delete(tab, key), do: :mnesia.dirty_delete(tab, key)
 
   @spec dirty_fetch(transaction(), table(), record()) :: {:ok, record()} | :not_found
@@ -199,15 +198,6 @@ defmodule AeMdw.Database do
     match?({:ok, _record}, fetch(tab, key))
   end
 
-  @spec delete(table(), key()) :: :ok
-  def delete(tab, key) when use_rocksdb?(tab) do
-    :ok = RocksDbCF.delete(tab, key)
-  end
-
-  def delete(table, key) do
-    :mnesia.delete(table, key, :write)
-  end
-
   @spec read(table(), key()) :: [record()]
   def read(tab, key) when use_rocksdb?(tab) do
     case RocksDbCF.fetch(tab, key) do
@@ -233,6 +223,16 @@ defmodule AeMdw.Database do
   @spec write(table(), record()) :: :ok
   def write(table, record) do
     :mnesia.write(table, record, :write)
+  end
+
+  @spec delete(transaction(), table(), key()) :: :ok
+  def delete(txn, table, key) when use_rocksdb?(table) do
+    :ok = RocksDbCF.delete(txn, table, key)
+  end
+
+  @spec delete(table(), key()) :: :ok
+  def delete(table, key) do
+    :mnesia.delete(table, key, :write)
   end
 
   @doc """

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -4,6 +4,7 @@ defmodule AeMdw.Db.Contract do
   """
   alias AeMdw.Node, as: AE
 
+  alias AeMdw.Collection
   alias AeMdw.Contract
   alias AeMdw.Database
   alias AeMdw.Db.WriteMutation
@@ -22,7 +23,7 @@ defmodule AeMdw.Db.Contract do
   require Model
   require Record
 
-  import AeMdw.Util, only: [compose: 2, max_256bit_int: 0]
+  import AeMdw.Util, only: [compose: 2, min_bin: 0, max_256bit_bin: 0, max_256bit_int: 0]
   import AeMdw.Db.Util
 
   @type rev_aex9_contract_key :: {pos_integer(), String.t(), String.t(), pos_integer()}
@@ -66,7 +67,74 @@ defmodule AeMdw.Db.Contract do
   def aex9_delete_presence(contract_pk, txi, pubkey) do
     Database.delete(Model.Aex9AccountPresence, {pubkey, txi, contract_pk})
     Database.delete(Model.IdxAex9AccountPresence, {txi, pubkey, contract_pk})
-    :ok
+  end
+
+  @spec aex9_burn_balance(transaction(), pubkey(), pubkey(), non_neg_integer()) :: :ok | :error
+  def aex9_burn_balance(txn, contract_pk, account_pk, burned_value) do
+    case Database.dirty_fetch(txn, Model.Aex9Balance, {contract_pk, account_pk}) do
+      {:ok, m_aex9_balance} ->
+        amount = Model.aex9_balance(m_aex9_balance, :amount)
+        m_aex9_balance = Model.aex9_balance(m_aex9_balance, amount: amount - burned_value)
+        Database.write(txn, Model.Aex9Balance, m_aex9_balance)
+
+      :not_found ->
+        :error
+    end
+  end
+
+  @spec aex9_mint_balance(transaction(), pubkey(), pubkey(), non_neg_integer()) :: :ok | :error
+  def aex9_mint_balance(txn, contract_pk, to_pk, minted_value) do
+    with {:ok, m_aex9_balance_to} <-
+           Database.dirty_fetch(txn, Model.Aex9Balance, {contract_pk, to_pk}) do
+      to_amount = Model.aex9_balance(m_aex9_balance_to, :amount)
+      m_aex9_balance_to = Model.aex9_balance(m_aex9_balance_to, amount: to_amount + minted_value)
+      Database.write(txn, Model.Aex9Balance, m_aex9_balance_to)
+    else
+      :not_found ->
+        :error
+    end
+  end
+
+  @spec aex9_transfer_balance(transaction(), pubkey(), pubkey(), pubkey(), non_neg_integer()) ::
+          :ok | :error
+  def aex9_transfer_balance(txn, contract_pk, from_pk, to_pk, transfered_value) do
+    with {:ok, m_aex9_balance_from} <-
+           Database.dirty_fetch(txn, Model.Aex9Balance, {contract_pk, from_pk}),
+         {:ok, m_aex9_balance_to} <-
+           Database.dirty_fetch(txn, Model.Aex9Balance, {contract_pk, to_pk}) do
+      from_amount = Model.aex9_balance(m_aex9_balance_from, :amount)
+      to_amount = Model.aex9_balance(m_aex9_balance_to, :amount)
+
+      m_aex9_balance_from =
+        Model.aex9_balance(m_aex9_balance_from, amount: from_amount - transfered_value)
+
+      m_aex9_balance_to =
+        Model.aex9_balance(m_aex9_balance_to, amount: to_amount + transfered_value)
+
+      Database.write(txn, Model.Aex9Balance, m_aex9_balance_from)
+      Database.write(txn, Model.Aex9Balance, m_aex9_balance_to)
+    else
+      :not_found ->
+        :error
+    end
+  end
+
+  @spec aex9_delete_balance(pubkey(), pubkey()) :: :ok
+  def aex9_delete_balance(contract_pk, account_pk) do
+    Database.delete(Model.Aex9Balance, {contract_pk, account_pk})
+  end
+
+  @spec aex9_invalidate_balances(pubkey()) :: :ok
+  def aex9_invalidate_balances(contract_pk) do
+    Model.Aex9Balance
+    |> Collection.stream(
+      :forward,
+      {{contract_pk, min_bin()}, {contract_pk, max_256bit_bin()}},
+      nil
+    )
+    |> Enum.each(fn account_pk ->
+      Database.delete(Model.Aex9Balance, {contract_pk, account_pk})
+    end)
   end
 
   @spec aex9_presence_exists?(pubkey(), pubkey(), integer()) :: boolean()

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -28,6 +28,7 @@ defmodule AeMdw.Db.Contract do
 
   @type rev_aex9_contract_key :: {pos_integer(), String.t(), String.t(), pos_integer()}
   @typep pubkey :: Db.pubkey()
+  @typep transaction :: Database.transaction()
 
   @spec aex9_creation_write(tuple(), pubkey(), pubkey(), integer()) :: :ok
   def aex9_creation_write({name, symbol, decimals}, contract_pk, owner_pk, txi) do
@@ -119,9 +120,9 @@ defmodule AeMdw.Db.Contract do
     end
   end
 
-  @spec aex9_delete_balance(pubkey(), pubkey()) :: :ok
-  def aex9_delete_balance(contract_pk, account_pk) do
-    Database.delete(Model.Aex9Balance, {contract_pk, account_pk})
+  @spec aex9_delete_balance(transaction(), pubkey(), pubkey()) :: :ok
+  def aex9_delete_balance(txn, contract_pk, account_pk) do
+    Database.dirty_delete(txn, Model.Aex9Balance, {contract_pk, account_pk})
   end
 
   @spec aex9_invalidate_balances(pubkey()) :: :ok

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -123,7 +123,7 @@ defmodule AeMdw.Db.Contract do
   def aex9_invalidate_balance(txn, contract_pk, account_pk) do
     with {:ok, m_aex9_balance} <-
            Database.dirty_fetch(txn, Model.Aex9Balance, {contract_pk, account_pk}) do
-      m_aex9_balance = Model.aex9_balance(m_aex9_balance, amount: -1)
+      m_aex9_balance = Model.aex9_balance(m_aex9_balance, amount: nil)
       Database.write(txn, Model.Aex9Balance, m_aex9_balance)
     else
       :not_found ->

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -84,12 +84,15 @@ defmodule AeMdw.Db.Contract do
 
   @spec aex9_mint_balance(transaction(), pubkey(), pubkey(), non_neg_integer()) :: :ok | :error
   def aex9_mint_balance(txn, contract_pk, to_pk, minted_value) do
-    with {:ok, m_aex9_balance_to} <-
-           Database.dirty_fetch(txn, Model.Aex9Balance, {contract_pk, to_pk}) do
-      to_amount = Model.aex9_balance(m_aex9_balance_to, :amount)
-      m_aex9_balance_to = Model.aex9_balance(m_aex9_balance_to, amount: to_amount + minted_value)
-      Database.write(txn, Model.Aex9Balance, m_aex9_balance_to)
-    else
+    case Database.dirty_fetch(txn, Model.Aex9Balance, {contract_pk, to_pk}) do
+      {:ok, m_aex9_balance_to} ->
+        to_amount = Model.aex9_balance(m_aex9_balance_to, :amount)
+
+        m_aex9_balance_to =
+          Model.aex9_balance(m_aex9_balance_to, amount: to_amount + minted_value)
+
+        Database.write(txn, Model.Aex9Balance, m_aex9_balance_to)
+
       :not_found ->
         :error
     end
@@ -121,11 +124,11 @@ defmodule AeMdw.Db.Contract do
 
   @spec aex9_invalidate_balance(transaction(), pubkey(), pubkey()) :: :ok
   def aex9_invalidate_balance(txn, contract_pk, account_pk) do
-    with {:ok, m_aex9_balance} <-
-           Database.dirty_fetch(txn, Model.Aex9Balance, {contract_pk, account_pk}) do
-      m_aex9_balance = Model.aex9_balance(m_aex9_balance, amount: nil)
-      Database.write(txn, Model.Aex9Balance, m_aex9_balance)
-    else
+    case Database.dirty_fetch(txn, Model.Aex9Balance, {contract_pk, account_pk}) do
+      {:ok, m_aex9_balance} ->
+        m_aex9_balance = Model.aex9_balance(m_aex9_balance, amount: nil)
+        Database.write(txn, Model.Aex9Balance, m_aex9_balance)
+
       :not_found ->
         :error
     end

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -172,6 +172,19 @@ defmodule AeMdw.Db.Model do
             previous: oracle() | nil
           )
 
+  # AEX9 balance:
+  #     index = {contract_pk, account_pk}
+  #     block_index = {kbi, mbi}
+  #     amounts: float
+  @type aex9_balance ::
+          record(:aex9_balance,
+            index: {Db.pubkey(), Db.pubkey()},
+            block_index: Blocks.block_index(),
+            amount: float()
+          )
+  @aex9_balance_defaults [index: {<<>>, <<>>}, block_index: {-1, -1}, amount: nil]
+  defrecord :aex9_balance, @aex9_balance_defaults
+
   # AEX9 contract:
   #     index: {name, symbol, txi, decimals}
   @aex9_contract_defaults [
@@ -470,7 +483,8 @@ defmodule AeMdw.Db.Model do
     # next candidate chain_tables()
     [
       AeMdw.Db.Model.Tx,
-      AeMdw.Db.Model.Block
+      AeMdw.Db.Model.Block,
+      AeMdw.Db.Model.Aex9Balance
     ]
   end
 
@@ -580,6 +594,7 @@ defmodule AeMdw.Db.Model do
       :id_count,
       :origin,
       :rev_origin,
+      :aex9_balance,
       :aex9_contract,
       :aex9_contract_symbol,
       :rev_aex9_contract,
@@ -634,6 +649,7 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.IdCount), do: :id_count
   def record(AeMdw.Db.Model.Origin), do: :origin
   def record(AeMdw.Db.Model.RevOrigin), do: :rev_origin
+  def record(AeMdw.Db.Model.Aex9Balance), do: :aex9_balance
   def record(AeMdw.Db.Model.Aex9Contract), do: :aex9_contract
   def record(AeMdw.Db.Model.Aex9ContractSymbol), do: :aex9_contract_symbol
   def record(AeMdw.Db.Model.RevAex9Contract), do: :rev_aex9_contract
@@ -690,6 +706,7 @@ defmodule AeMdw.Db.Model do
   def table(:id_count), do: AeMdw.Db.Model.IdCount
   def table(:origin), do: AeMdw.Db.Model.Origin
   def table(:rev_origin), do: AeMdw.Db.Model.RevOrigin
+  def table(:aex9_balance), do: AeMdw.Db.Model.Aex9Balance
   def table(:aex9_contract), do: AeMdw.Db.Model.Aex9Contract
   def table(:aex9_contract_symbol), do: AeMdw.Db.Model.Aex9ContractSymbol
   def table(:rev_aex9_contract), do: AeMdw.Db.Model.RevAex9Contract
@@ -731,6 +748,7 @@ defmodule AeMdw.Db.Model do
   def defaults(:id_count), do: @id_count_defaults
   def defaults(:origin), do: @origin_defaults
   def defaults(:rev_origin), do: @rev_origin_defaults
+  def defaults(:aex9_balance), do: @aex9_balance_defaults
   def defaults(:aex9_contract), do: @aex9_contract_defaults
   def defaults(:aex9_contract_symbol), do: @aex9_contract_symbol_defaults
   def defaults(:rev_aex9_contract), do: @rev_aex9_contract_defaults

--- a/lib/ae_mdw/db/mutations/aex9_account_balance_mutation.ex
+++ b/lib/ae_mdw/db/mutations/aex9_account_balance_mutation.ex
@@ -69,10 +69,10 @@ defmodule AeMdw.Db.Aex9AccountBalanceMutation do
   end
 
   defp update_aex9_balance(txn, method_name, method_args, contract_pk, caller_pk) do
-    with {from_pk, to_pk, value} <-
-           Contract.get_aex9_transfer(caller_pk, method_name, method_args) do
-      DbContract.aex9_transfer_balance(txn, contract_pk, from_pk, to_pk, value)
-    else
+    case Contract.get_aex9_transfer(caller_pk, method_name, method_args) do
+      {from_pk, to_pk, value} ->
+        DbContract.aex9_transfer_balance(txn, contract_pk, from_pk, to_pk, value)
+
       nil ->
         DbContract.aex9_delete_balances(txn, contract_pk)
     end

--- a/lib/ae_mdw/db/mutations/aex9_account_balance_mutation.ex
+++ b/lib/ae_mdw/db/mutations/aex9_account_balance_mutation.ex
@@ -1,0 +1,79 @@
+defmodule AeMdw.Db.Aex9AccountBalanceMutation do
+  @moduledoc """
+  Computes and derives Aex9 tokens, and stores it into the appropriate indexes.
+  """
+
+  alias AeMdw.Database
+  alias AeMdw.Contract
+  alias AeMdw.Db.Contract, as: DbContract
+  alias AeMdw.Db.Model
+  alias AeMdw.Node.Db
+
+  @derive AeMdw.Db.TxnMutation
+  defstruct [:method_name, :method_args, :contract_pk, :caller_pk]
+
+  @opaque t() :: %__MODULE__{
+            method_name: Contract.method_name(),
+            method_args: Contract.method_args(),
+            contract_pk: Db.pubkey(),
+            caller_pk: Db.pubkey()
+          }
+
+  @spec new(Contract.method_name(), Contract.method_args(), Db.pubkey(), Db.pubkey()) :: t()
+  def new(method_name, method_args, contract_pk, caller_pk) do
+    %__MODULE__{
+      method_name: method_name,
+      method_args: method_args,
+      contract_pk: contract_pk,
+      caller_pk: caller_pk
+    }
+  end
+
+  @spec execute(t(), Database.transaction()) :: :ok
+  def execute(
+        %__MODULE__{
+          method_name: method_name,
+          method_args: method_args,
+          contract_pk: contract_pk,
+          caller_pk: caller_pk
+        },
+        txn
+      ) do
+    update_aex9_balance(txn, method_name, method_args, contract_pk, caller_pk)
+    :ok
+  end
+
+  defp update_aex9_balance(
+         txn,
+         "burn",
+         [%{type: :int, value: value}],
+         contract_pk,
+         account_pk
+       ) do
+    DbContract.aex9_burn_balance(txn, contract_pk, account_pk, value)
+  end
+
+  defp update_aex9_balance(txn, "swap", [], contract_pk, caller_pk) do
+    Database.dirty_delete(txn, Model.Aex9Balance, {contract_pk, caller_pk})
+  end
+
+  defp update_aex9_balance(
+         txn,
+         "mint",
+         [
+           %{type: :address, value: to_pk},
+           %{type: :int, value: value}
+         ],
+         contract_pk,
+         _caller_pk
+       ) do
+    DbContract.aex9_mint_balance(txn, contract_pk, to_pk, value)
+  end
+
+  defp update_aex9_balance(txn, method_name, method_args, contract_pk, caller_pk) do
+    with {from_pk, to_pk, value} <-
+           Contract.get_aex9_transfer(caller_pk, method_name, method_args) do
+      DbContract.aex9_transfer_balance(txn, contract_pk, from_pk, to_pk, value)
+    end
+  end
+end

--- a/lib/ae_mdw/db/mutations/aex9_account_balance_mutation.ex
+++ b/lib/ae_mdw/db/mutations/aex9_account_balance_mutation.ex
@@ -52,7 +52,7 @@ defmodule AeMdw.Db.Aex9AccountBalanceMutation do
   end
 
   defp update_aex9_balance(txn, "swap", [], contract_pk, caller_pk) do
-    DbContract.aex9_invalidate_balance(txn, contract_pk, caller_pk)
+    DbContract.aex9_swap_balance(txn, contract_pk, caller_pk)
   end
 
   defp update_aex9_balance(

--- a/lib/ae_mdw/db/mutations/contract_call_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_call_mutation.ex
@@ -66,10 +66,9 @@ defmodule AeMdw.Db.ContractCallMutation do
     DBContract.call_write(create_txi, txi, fun_arg_res)
     DBContract.logs_write(create_txi, txi, call_rec)
 
-    if Contract.is_aex9?(contract_pk) and Contract.is_aex9_successful_call?(fun_arg_res) do
-      %{function: method_name, arguments: method_args} = fun_arg_res
-
-      if not Contract.is_non_stateful_aex9_function?(method_name) do
+    with true <- Contract.is_aex9?(contract_pk),
+      {:ok, method_name, method_args} <- Contract.extract_successful_function(fun_arg_res),
+      false <- Contract.is_non_stateful_aex9_function?(method_name) do
         update_aex9_presence(
           contract_pk,
           caller_pk,
@@ -77,7 +76,6 @@ defmodule AeMdw.Db.ContractCallMutation do
           method_name,
           method_args
         )
-      end
     end
 
     if aex9_meta_info do

--- a/lib/ae_mdw/db/mutations/contract_call_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_call_mutation.ex
@@ -67,15 +67,15 @@ defmodule AeMdw.Db.ContractCallMutation do
     DBContract.logs_write(create_txi, txi, call_rec)
 
     with true <- Contract.is_aex9?(contract_pk),
-      {:ok, method_name, method_args} <- Contract.extract_successful_function(fun_arg_res),
-      false <- Contract.is_non_stateful_aex9_function?(method_name) do
-        update_aex9_presence(
-          contract_pk,
-          caller_pk,
-          txi,
-          method_name,
-          method_args
-        )
+         {:ok, method_name, method_args} <- Contract.extract_successful_function(fun_arg_res),
+         false <- Contract.is_non_stateful_aex9_function?(method_name) do
+      update_aex9_presence(
+        contract_pk,
+        caller_pk,
+        txi,
+        method_name,
+        method_args
+      )
     end
 
     if aex9_meta_info do

--- a/lib/ae_mdw/db/rocksdb.ex
+++ b/lib/ae_mdw/db/rocksdb.ex
@@ -95,16 +95,6 @@ defmodule AeMdw.Db.RocksDb do
   end
 
   @doc """
-  Delete a key-value from a column family.
-  """
-  @spec delete(table(), binary()) :: :ok | {:error, any()}
-  def delete(table, key) do
-    {db_ref, cf_ref} = cf_refs(table)
-
-    :rocksdb.delete(db_ref, cf_ref, key, [])
-  end
-
-  @doc """
   Starts a new empty transaction with fsync option.
   """
   @spec transaction_new() :: {:ok, transaction()}
@@ -135,7 +125,17 @@ defmodule AeMdw.Db.RocksDb do
   defdelegate iterator_close(it), to: :rocksdb
 
   @doc """
-  Write directly without transaction for single writes.
+  Delete a key without a transaction.
+  """
+  @spec dirty_delete(table(), binary()) :: :ok | {:error, any()}
+  def dirty_delete(table, key) do
+    {db_ref, cf_ref} = cf_refs(table)
+
+    :rocksdb.delete(db_ref, cf_ref, key, [])
+  end
+
+  @doc """
+  Write a key-value directly without a transaction.
   """
   @spec dirty_put(table(), binary(), binary()) :: :ok
   def dirty_put(table, key, value) do
@@ -162,8 +162,8 @@ defmodule AeMdw.Db.RocksDb do
   @doc """
   Delete a key-value from a column family.
   """
-  @spec dirty_delete(transaction(), table(), binary()) :: :ok | {:error, any()}
-  def dirty_delete(t_ref, table, key) do
+  @spec delete(transaction(), table(), binary()) :: :ok | {:error, any()}
+  def delete(t_ref, table, key) do
     {db_ref, cf_ref} = cf_refs(table)
 
     case :rocksdb.transaction_get(t_ref, cf_ref, key, []) do

--- a/lib/ae_mdw/db/rocksdb_cf.ex
+++ b/lib/ae_mdw/db/rocksdb_cf.ex
@@ -45,11 +45,11 @@ defmodule AeMdw.Db.RocksDbCF do
     :ok = RocksDb.put(txn, table, key, value)
   end
 
-  @spec delete(table(), key()) :: :ok | {:error, any}
-  def delete(table, index) do
+  @spec delete(transaction(), table(), key()) :: :ok
+  def delete(txn, table, index) do
     key = :sext.encode(index)
 
-    :ok = RocksDb.delete(table, key)
+    :ok = RocksDb.delete(txn, table, key)
   end
 
   @spec exists?(table(), key()) :: boolean()
@@ -131,11 +131,11 @@ defmodule AeMdw.Db.RocksDbCF do
     :ok = RocksDb.dirty_put(table, key, value)
   end
 
-  @spec dirty_delete(transaction(), table(), key()) :: :ok | {:error, any}
-  def dirty_delete(txn, table, index) do
+  @spec dirty_delete(table(), key()) :: :ok | {:error, any}
+  def dirty_delete(table, index) do
     key = :sext.encode(index)
 
-    :ok = RocksDb.dirty_delete(txn, table, key)
+    :ok = RocksDb.dirty_delete(table, key)
   end
 
   @spec dirty_fetch(transaction(), table(), key()) :: {:ok, record()} | :not_found

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -345,16 +345,16 @@ defmodule AeMdw.Db.Sync.Transaction do
     child_mutations ++
       Sync.Contract.events_mutations(tx_events, block_index, block_hash, txi, tx_hash, create_txi) ++
       [
-        aex9_balance_mutation
-        | ContractCallMutation.new(
-            contract_pk,
-            caller_pk,
-            create_txi,
-            txi,
-            fun_arg_res,
-            aex9_meta_info,
-            call_rec
-          )
+        aex9_balance_mutation,
+        ContractCallMutation.new(
+          contract_pk,
+          caller_pk,
+          create_txi,
+          txi,
+          fun_arg_res,
+          aex9_meta_info,
+          call_rec
+        )
       ]
   end
 

--- a/lib/ae_mdw/error.ex
+++ b/lib/ae_mdw/error.ex
@@ -23,6 +23,7 @@ defmodule AeMdw.Error do
   def to_string(Input.NotFound, x), do: concat("not found", x)
   def to_string(Input.Expired, x), do: concat("expired", x)
   def to_string(Input.NotAex9, x), do: concat("not AEX9 contract", x)
+  def to_string(Input.Aex9BalanceNotAvailable, x), do: concat("balance is not yet available", x)
   def to_string(Input.Base64, x), do: concat("invalid base64 encoding", x)
   def to_string(Input.Hex32, x), do: concat("invalid hex32 encoding", x)
   def to_string(Input.RangeTooBig, x), do: concat("invalid range", x)
@@ -45,6 +46,7 @@ defmodule AeMdw.Error do
             | __MODULE__.NotFound
             | __MODULE__.Expired
             | __MODULE__.NotAex9
+            | __MODULE__.Aex9BalanceNotAvailable
             | __MODULE__.Base64
             | __MODULE__.Hex32
             | __MODULE__.RangeTooBig
@@ -66,6 +68,7 @@ defmodule AeMdw.Error do
     defexception!(NotFound)
     defexception!(Expired)
     defexception!(NotAex9)
+    defexception!(Aex9BalanceNotAvailable)
     defexception!(Base64)
     defexception!(Hex32)
     defexception!(RangeTooBig)

--- a/lib/ae_mdw/sync/async_tasks/update_aex9_presence.ex
+++ b/lib/ae_mdw/sync/async_tasks/update_aex9_presence.ex
@@ -6,6 +6,7 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9Presence do
 
   alias AeMdw.Node.Db, as: DBN
 
+  alias AeMdw.Database
   alias AeMdw.Db.Contract
   alias AeMdw.Db.Model
   alias AeMdw.Db.Origin
@@ -20,16 +21,26 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9Presence do
   def process([contract_pk]) do
     Log.info("[update_aex9_presence] #{inspect(contract_pk)} ...")
 
-    {time_delta, {amounts, _last_block_tuple}} =
+    {time_delta, {balances, _last_block_tuple}} =
       :timer.tc(fn -> DBN.aex9_balances(contract_pk) end)
 
     Log.info("[update_aex9_presence] #{inspect(contract_pk)} after #{time_delta / @microsecs}s")
 
+    {:key, height, _hash} = DBN.top_height_hash(false)
     create_txi = Origin.tx_index!({:contract, contract_pk})
 
     :mnesia.sync_dirty(fn ->
-      Enum.each(amounts, fn {{:address, account_pk}, _amount} ->
+      Enum.each(balances, fn {{:address, account_pk}, amount} ->
         Contract.aex9_write_new_presence(contract_pk, create_txi, account_pk)
+
+        m_balance =
+          Model.aex9_balance(
+            index: {contract_pk, account_pk},
+            block_index: {height, -1},
+            amount: amount
+          )
+
+        Database.dirty_write(Model.Aex9Balance, m_balance)
       end)
     end)
 

--- a/lib/ae_mdw_web/controllers/aex9_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex9_controller.ex
@@ -331,8 +331,9 @@ defmodule AeMdwWeb.Aex9Controller do
   end
 
   defp balances_reply(conn, contract_pk) do
-    {amounts, {type, height, hash}} = DBN.aex9_balances!(contract_pk, top?(conn))
-    json(conn, balances_to_map({amounts, {type, height, hash}}, contract_pk))
+    amounts = Aex9.fetch_balances(contract_pk, top?(conn))
+    hash_tuple = DBN.top_height_hash(top?(conn))
+    json(conn, balances_to_map({amounts, hash_tuple}, contract_pk))
   end
 
   defp balances_range_reply(conn, contract_pk, range) do

--- a/priv/migrations/manual/20220304114500_rocksdb_txs_blocks.ex
+++ b/priv/migrations/manual/20220304114500_rocksdb_txs_blocks.ex
@@ -1,0 +1,34 @@
+defmodule AeMdw.Migrations.RocksdbTxsBlocks  do
+  @moduledoc """
+  Copies all records from mnesia Model.Tx and Model.Block to mdw RocksDB.
+  """
+  alias AeMdw.Database
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.RocksDbCF
+
+  @spec run() :: :ok
+  def run do
+    AeMdw.Application.sync(false)
+
+    Model.Block
+    |> :mnesia.dirty_all_keys()
+    |> Enum.map(fn bi ->
+      [m_block] = :mnesia.dirty_read(Model.Block, bi)
+      RocksDbCF.dirty_put(Model.Block, m_block)
+    end)
+
+    first_txi = case Database.last_key(Model.Tx) do
+      :none -> :mnesia.dirty_first(Model.Tx)
+      {:ok, txi} -> txi
+    end |> IO.inspect()
+
+    last_txi = :mnesia.dirty_last(Model.Tx)
+
+    Enum.each(first_txi..last_txi, fn txi ->
+      [m_tx] = :mnesia.dirty_read(Model.Tx, txi)
+      RocksDbCF.dirty_put(Model.Tx, m_tx)
+    end)
+
+    :ok
+  end
+end

--- a/priv/migrations/manual/20220304114500_rocksdb_txs_blocks.ex
+++ b/priv/migrations/manual/20220304114500_rocksdb_txs_blocks.ex
@@ -12,7 +12,7 @@ defmodule AeMdw.Migrations.RocksdbTxsBlocks  do
 
     Model.Block
     |> :mnesia.dirty_all_keys()
-    |> Enum.map(fn bi ->
+    |> Enum.each(fn bi ->
       [m_block] = :mnesia.dirty_read(Model.Block, bi)
       RocksDbCF.dirty_put(Model.Block, m_block)
     end)
@@ -20,7 +20,7 @@ defmodule AeMdw.Migrations.RocksdbTxsBlocks  do
     first_txi = case Database.last_key(Model.Tx) do
       :none -> :mnesia.dirty_first(Model.Tx)
       {:ok, txi} -> txi
-    end |> IO.inspect()
+    end
 
     last_txi = :mnesia.dirty_last(Model.Tx)
 

--- a/test/ae_mdw/db/aex9_balance_mutation_text.exs
+++ b/test/ae_mdw/db/aex9_balance_mutation_text.exs
@@ -9,9 +9,6 @@ defmodule AeMdw.Db.Aex9AccountBalanceMutationTest do
 
   @ct_pk1 <<1::256>>
   @ct_pk2 <<2::256>>
-  # @ct_pk3 <<3::256>>
-  # @ct_pk4 <<4::256>>
-  # @ct_pk5 <<5::256>>
 
   @initial_amount 1_000_000
 
@@ -101,7 +98,7 @@ defmodule AeMdw.Db.Aex9AccountBalanceMutationTest do
     Database.commit([mutation])
 
     expected_balance =
-      Model.aex9_balance(index: {@ct_pk1, @swap_pk}, block_index: @block_index1, amount: nil)
+      Model.aex9_balance(index: {@ct_pk1, @swap_pk}, block_index: @block_index1, amount: 0)
 
     assert ^expected_balance = Database.fetch!(Model.Aex9Balance, {@ct_pk1, @swap_pk})
   end

--- a/test/ae_mdw/db/aex9_balance_mutation_text.exs
+++ b/test/ae_mdw/db/aex9_balance_mutation_text.exs
@@ -1,0 +1,226 @@
+defmodule AeMdw.Db.Aex9AccountBalanceMutationTest do
+  use ExUnit.Case
+
+  alias AeMdw.Database
+  alias AeMdw.Db.Aex9AccountBalanceMutation
+  alias AeMdw.Db.Model
+
+  require Model
+
+  @ct_pk1 <<1::256>>
+  @ct_pk2 <<2::256>>
+  # @ct_pk3 <<3::256>>
+  # @ct_pk4 <<4::256>>
+  # @ct_pk5 <<5::256>>
+
+  @initial_amount 1_000_000
+
+  @some_caller_pk <<10::256>>
+
+  @burn_pk <<11::256>>
+  @swap_pk <<12::256>>
+  @mint_pk <<13::256>>
+  @transfer_pk1 <<141::256>>
+  @transfer_pk2 <<142::256>>
+  @transfer_allowance_pk1 <<151::256>>
+  @transfer_allowance_pk2 <<152::256>>
+  @other_call_pk1 <<161::256>>
+  @other_call_pk2 <<162::256>>
+
+  @block_index1 {1234, 0}
+
+  setup_all _ctx do
+    Enum.each(
+      [
+        @burn_pk,
+        @swap_pk,
+        @mint_pk,
+        @transfer_pk1,
+        @transfer_pk2,
+        @transfer_allowance_pk1,
+        @transfer_allowance_pk2,
+      ],
+      fn account_pk ->
+        Database.dirty_write(
+          Model.Aex9Balance,
+          Model.aex9_balance(
+            index: {@ct_pk1, account_pk},
+            block_index: @block_index1,
+            amount: @initial_amount
+          )
+        )
+      end
+    )
+
+    Enum.each(
+      [
+        @other_call_pk1,
+        @other_call_pk2
+      ],
+      fn account_pk ->
+        Database.dirty_write(
+          Model.Aex9Balance,
+          Model.aex9_balance(
+            index: {@ct_pk2, account_pk},
+            block_index: @block_index1,
+            amount: @initial_amount
+          )
+        )
+      end
+    )
+
+    :ok
+  end
+
+  test "update aex9 balance after a burn" do
+    burn_value = 1000
+
+    mutation =
+      Aex9AccountBalanceMutation.new(
+        "burn",
+        [%{type: :int, value: burn_value}],
+        @ct_pk1,
+        @burn_pk
+      )
+
+    Database.commit([mutation])
+
+    expected_balance =
+      Model.aex9_balance(
+        index: {@ct_pk1, @burn_pk},
+        block_index: @block_index1,
+        amount: @initial_amount - burn_value
+      )
+
+    assert ^expected_balance = Database.fetch!(Model.Aex9Balance, {@ct_pk1, @burn_pk})
+  end
+
+  test "update aex9 balance after a swap" do
+    mutation = Aex9AccountBalanceMutation.new("swap", [], @ct_pk1, @swap_pk)
+
+    Database.commit([mutation])
+
+    expected_balance =
+      Model.aex9_balance(index: {@ct_pk1, @swap_pk}, block_index: @block_index1, amount: nil)
+
+    assert ^expected_balance = Database.fetch!(Model.Aex9Balance, {@ct_pk1, @swap_pk})
+  end
+
+  test "update aex9 balance after a mint" do
+    minted_value = 2_000_000
+
+    mutation =
+      Aex9AccountBalanceMutation.new(
+        "mint",
+        [
+          %{type: :address, value: @mint_pk},
+          %{type: :int, value: minted_value}
+        ],
+        @ct_pk1,
+        @some_caller_pk
+      )
+
+    Database.commit([mutation])
+
+    expected_balance =
+      Model.aex9_balance(
+        index: {@ct_pk1, @mint_pk},
+        block_index: @block_index1,
+        amount: @initial_amount + minted_value
+      )
+
+    assert ^expected_balance = Database.fetch!(Model.Aex9Balance, {@ct_pk1, @mint_pk})
+  end
+
+  test "update aex9 balance after a transer" do
+    transfer_value = 234_567_890
+
+    mutation =
+      Aex9AccountBalanceMutation.new(
+        "transfer",
+        [
+          %{type: :address, value: @transfer_pk2},
+          %{type: :int, value: transfer_value}
+        ],
+        @ct_pk1,
+        @transfer_pk1
+      )
+
+    Database.commit([mutation])
+
+    expected_balance1 =
+      Model.aex9_balance(
+        index: {@ct_pk1, @transfer_pk1},
+        block_index: @block_index1,
+        amount: @initial_amount - transfer_value
+      )
+
+    expected_balance2 =
+      Model.aex9_balance(
+        index: {@ct_pk1, @transfer_pk2},
+        block_index: @block_index1,
+        amount: @initial_amount + transfer_value
+      )
+
+    assert ^expected_balance1 =
+             Database.fetch!(Model.Aex9Balance, {@ct_pk1, @transfer_pk1})
+
+    assert ^expected_balance2 =
+             Database.fetch!(Model.Aex9Balance, {@ct_pk1, @transfer_pk2})
+  end
+
+  test "update aex9 balance after a transer allowance" do
+    transfer_value = 234_567_891
+
+    mutation =
+      Aex9AccountBalanceMutation.new(
+        "transfer_allowance",
+        [
+          %{type: :address, value: @transfer_allowance_pk1},
+          %{type: :address, value: @transfer_allowance_pk2},
+          %{type: :int, value: transfer_value}
+        ],
+        @ct_pk1,
+        @some_caller_pk
+      )
+
+    Database.commit([mutation])
+
+    expected_balance1 =
+      Model.aex9_balance(
+        index: {@ct_pk1, @transfer_allowance_pk1},
+        block_index: @block_index1,
+        amount: @initial_amount - transfer_value
+      )
+
+    expected_balance2 =
+      Model.aex9_balance(
+        index: {@ct_pk1, @transfer_allowance_pk2},
+        block_index: @block_index1,
+        amount: @initial_amount + transfer_value
+      )
+
+    assert ^expected_balance1 =
+             Database.fetch!(Model.Aex9Balance, {@ct_pk1, @transfer_allowance_pk1})
+
+    assert ^expected_balance2 =
+             Database.fetch!(Model.Aex9Balance, {@ct_pk1, @transfer_allowance_pk2})
+  end
+
+  test "invalidate aex9 balance on untrackable call" do
+    some_value = 1000
+
+    mutation =
+      Aex9AccountBalanceMutation.new(
+        "burn_and_something",
+        [%{type: :int, value: some_value}],
+        @ct_pk2,
+        @other_call_pk1
+      )
+
+    Database.commit([mutation])
+
+    assert :not_found = Database.fetch(Model.Aex9Balance, {@ct_pk2, @other_call_pk1})
+    assert :not_found = Database.fetch(Model.Aex9Balance, {@ct_pk2, @other_call_pk2})
+  end
+end

--- a/test/ae_mdw/db/aex9_balance_mutation_text.exs
+++ b/test/ae_mdw/db/aex9_balance_mutation_text.exs
@@ -38,7 +38,7 @@ defmodule AeMdw.Db.Aex9AccountBalanceMutationTest do
         @transfer_pk1,
         @transfer_pk2,
         @transfer_allowance_pk1,
-        @transfer_allowance_pk2,
+        @transfer_allowance_pk2
       ],
       fn account_pk ->
         Database.dirty_write(
@@ -162,11 +162,9 @@ defmodule AeMdw.Db.Aex9AccountBalanceMutationTest do
         amount: @initial_amount + transfer_value
       )
 
-    assert ^expected_balance1 =
-             Database.fetch!(Model.Aex9Balance, {@ct_pk1, @transfer_pk1})
+    assert ^expected_balance1 = Database.fetch!(Model.Aex9Balance, {@ct_pk1, @transfer_pk1})
 
-    assert ^expected_balance2 =
-             Database.fetch!(Model.Aex9Balance, {@ct_pk1, @transfer_pk2})
+    assert ^expected_balance2 = Database.fetch!(Model.Aex9Balance, {@ct_pk1, @transfer_pk2})
   end
 
   test "update aex9 balance after a transer allowance" do

--- a/test/ae_mdw/db/rocksdb_test.exs
+++ b/test/ae_mdw/db/rocksdb_test.exs
@@ -31,7 +31,7 @@ defmodule AeMdw.Db.RocksDbTest do
       value = new_block() |> :erlang.term_to_binary()
 
       assert :ok = RocksDb.put(txn, Model.Block, key, value)
-      assert :ok = RocksDb.dirty_delete(txn, Model.Block, key)
+      assert :ok = RocksDb.delete(txn, Model.Block, key)
       assert :not_found = RocksDb.dirty_get(txn, Model.Block, key)
     end
   end

--- a/test/ae_mdw/db/rocksdbcf_test.exs
+++ b/test/ae_mdw/db/rocksdbcf_test.exs
@@ -71,13 +71,13 @@ defmodule AeMdw.Db.RocksDbCFTest do
     end
   end
 
-  describe "delete/2" do
-    test "deletes a committed record" do
+  describe "dirty_delete/2" do
+    test "dirty_delete directly a committed record" do
       key = {654_321, -1}
       m_block = Model.block(index: key)
       assert :ok = RocksDbCF.dirty_put(Model.Block, m_block)
       assert {:ok, ^m_block} = RocksDbCF.fetch(Model.Block, key)
-      assert :ok = RocksDbCF.delete(Model.Block, key)
+      assert :ok = RocksDbCF.dirty_delete(Model.Block, key)
       assert :not_found = RocksDbCF.fetch(Model.Block, key)
     end
   end

--- a/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
@@ -10,7 +10,7 @@ defmodule Integration.AeMdwWeb.Aex9ControllerTest do
 
   @moduletag :integration
 
-  @big_balance_contract_id "ct_2M4mVQCDVxu6mvUrEue1xMafLsoA1bgsfC3uT95F3r1xysaCvE"
+  @big_balance_contract_id "ct_BwJcRRa7jTAvkpzc2D16tJzHMGCJurtJMUBtyyfGi2QjPuMVv"
   @default_limit 10
 
   describe "by_contract" do

--- a/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
@@ -1,16 +1,21 @@
 defmodule Integration.AeMdwWeb.Aex9ControllerTest do
   use AeMdwWeb.ConnCase, async: false
 
+  alias AeMdw.Collection
+  alias AeMdw.Database
   alias AeMdw.Db.Origin
   alias AeMdw.Db.Model
   alias AeMdw.Db.Util
   alias AeMdw.Validate
+
+  import AeMdw.Util
 
   require Model
 
   @moduletag :integration
 
   @big_balance_contract_id "ct_BwJcRRa7jTAvkpzc2D16tJzHMGCJurtJMUBtyyfGi2QjPuMVv"
+  @another_big_balance_contract_id "ct_M9yohHgcLjhpp1Z8SaA1UTmRMQzR4FWjJHajGga8KBoZTEPwC"
   @default_limit 10
 
   describe "by_contract" do
@@ -233,6 +238,28 @@ defmodule Integration.AeMdwWeb.Aex9ControllerTest do
         assert String.starts_with?(account, "ak_")
         assert is_integer(balance) and balance >= 0
       end)
+    end
+
+    test "returns an error message when the balance is not available", %{conn: conn} do
+      contract_id = @another_big_balance_contract_id
+      contract_pk = Validate.id!(contract_id)
+
+      Model.Aex9Balance
+      |> Collection.stream(
+        :forward,
+        {{contract_pk, min_bin()}, {contract_pk, max_256bit_bin()}},
+        nil
+      )
+      |> Enum.each(fn account_pk ->
+        Database.dirty_delete(Model.Aex9Balance, {contract_pk, account_pk})
+      end)
+
+      conn = get(conn, "/aex9/balances/#{contract_id}")
+
+      assert %{"error" => msg} = json_response(conn, 400)
+
+      assert msg ==
+               "balance is not yet available: contract ct_M9yohHgcLjhpp1Z8SaA1UTmRMQzR4FWjJHajGga8KBoZTEPwC"
     end
   end
 


### PR DESCRIPTION
## What

Persists aex9 balances to improve `/aex9/balances/:contract_id` availability (and consequently general mdw availability).

## Why

Solves #295 

## Validation steps

### Manual
1. Run an async task for a big contract:
```
alias AeMdw.Sync.AsyncTasks.Producer
Producer.enqueue(:update_aex9_presence, [AeMdw.Validate.id!("ct_BwJcRRa7jTAvkpzc2D16tJzHMGCJurtJMUBtyyfGi2QjPuMVv")])
Producer.commit_enqueued()
```
2. Wait for long async task to finish (following the clear logs) and make the request to the endpoint:
http://localhost:4000/aex9/balances/ct_BwJcRRa7jTAvkpzc2D16tJzHMGCJurtJMUBtyyfGi2QjPuMVv

### Automated
```
INTEGRATION_TEST=1 elixir --sname aeternity@localhost -S mix test.integration  test/integration/ae_mdw_web/controllers/aex9_controller_test.exs:222
Finished in 7.5 seconds
24 tests, 0 failures, 23 excluded

elixir --sname aeternity@localhost -S mix test test/ae_mdw/db/aex9_balance_mutation_text.exs
Finished in 0.1 seconds
6 tests, 0 failure
```