### PR TITLE
refactor: migrations with rocksdb

### DIFF
--- a/lib/ae_mdw/database.ex
+++ b/lib/ae_mdw/database.ex
@@ -29,7 +29,8 @@ defmodule AeMdw.Database do
 
   defmacro use_rocksdb?(tab) do
     quote do
-      unquote(tab) == Model.Block or unquote(tab) == Model.Tx or unquote(tab) == Model.Aex9Balance
+      unquote(tab) == Model.Block or unquote(tab) == Model.Tx or unquote(tab) == Model.Aex9Balance or
+        unquote(tab) == Model.Migrations
     end
   end
 

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -484,7 +484,8 @@ defmodule AeMdw.Db.Model do
     [
       AeMdw.Db.Model.Tx,
       AeMdw.Db.Model.Block,
-      AeMdw.Db.Model.Aex9Balance
+      AeMdw.Db.Model.Aex9Balance,
+      AeMdw.Db.Model.Migrations
     ]
   end
 

--- a/priv/migrations/manual/20220304114500_rocksdb_txs_blocks.ex
+++ b/priv/migrations/manual/20220304114500_rocksdb_txs_blocks.ex
@@ -8,8 +8,6 @@ defmodule AeMdw.Migrations.RocksdbTxsBlocks  do
 
   @spec run() :: :ok
   def run do
-    AeMdw.Application.sync(false)
-
     Model.Block
     |> :mnesia.dirty_all_keys()
     |> Enum.each(fn bi ->


### PR DESCRIPTION
## What / Why

Fixes #482 and references #529 

## Validation steps

1. Start the sync in one machine and let it run for 5 minutes.
2. Stop the mdw and copy the databases to other machine:
vps1: `tar zcvf database.tgz ../aeternity/_build/local/rel/aeternity/data/{mnesia/,mdw.db/}`
vps1:`scp database.tgz user@host:~` 
vps2: `rm -rf ${NODEROOT}/_build/local/rel/aeternity/data/{mnesia/,mdw.db/}` 
vps2: `tar xvf ~/database.tgz -C ../${NODEROOT}` 
3. Start the mdw on vps2 and check the log:
`grep "migrations are up to date" log/info.log`