### PR TITLE
chore: use in-memory database when dealing with latest changes

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -43,6 +43,7 @@ defmodule AeMdw.Application do
     :ok = AeMdw.Db.RocksDb.open()
 
     children = [
+      AeMdw.Db.State,
       AeMdw.Sync.Watcher,
       AeMdw.Sync.AsyncTasks.Supervisor,
       AeMdwWeb.Supervisor,

--- a/lib/ae_mdw/database.ex
+++ b/lib/ae_mdw/database.ex
@@ -13,7 +13,6 @@ defmodule AeMdw.Database do
 
   alias AeMdw.Db.Model
   alias AeMdw.Db.Mutation
-  alias AeMdw.Db.TxnMutation
   alias AeMdw.Db.RocksDb
   alias AeMdw.Db.RocksDbCF
 
@@ -236,20 +235,20 @@ defmodule AeMdw.Database do
     :mnesia.delete(table, key, :write)
   end
 
-  @doc """
-  Creates a transaction and commits the changes of a mutation list.
-  """
-  @spec commit([TxnMutation.t()]) :: :ok
-  def commit(txn_mutations) do
-    {:ok, txn} = RocksDb.transaction_new()
+  # @doc """
+  # Creates a transaction and commits the changes of a mutation list.
+  # """
+  # @spec commit([TxnMutation.t()]) :: :ok
+  # def commit(txn_mutations) do
+  #   txn = RocksDb.transaction_new()
 
-    txn_mutations
-    |> List.flatten()
-    |> Enum.reject(&is_nil/1)
-    |> Enum.each(&TxnMutation.execute(&1, txn))
+  #   txn_mutations
+  #   |> List.flatten()
+  #   |> Enum.reject(&is_nil/1)
+  #   |> Enum.each(&TxnMutation.execute(&1, txn))
 
-    :ok = RocksDb.transaction_commit(txn)
-  end
+  #   :ok = RocksDb.transaction_commit(txn)
+  # end
 
   @spec transaction([Mutation.t()]) :: :ok
   def transaction(mutations) do

--- a/lib/ae_mdw/db/mutations/write_txn_mutation.ex
+++ b/lib/ae_mdw/db/mutations/write_txn_mutation.ex
@@ -5,6 +5,7 @@ defmodule AeMdw.Db.WriteTxnMutation do
   """
 
   alias AeMdw.Database
+  alias AeMdw.Db.State
 
   @derive AeMdw.Db.TxnMutation
   defstruct [:table, :record]
@@ -19,8 +20,8 @@ defmodule AeMdw.Db.WriteTxnMutation do
     %__MODULE__{table: table, record: record}
   end
 
-  @spec execute(t(), Database.transaction()) :: :ok
-  def execute(%__MODULE__{table: table, record: record}, txn) do
-    Database.write(txn, table, record)
+  @spec execute(t(), State.t()) :: State.t()
+  def execute(%__MODULE__{table: table, record: record}, state) do
+    State.put(state, table, record)
   end
 end

--- a/lib/ae_mdw/db/rocksdb.ex
+++ b/lib/ae_mdw/db/rocksdb.ex
@@ -97,9 +97,11 @@ defmodule AeMdw.Db.RocksDb do
   @doc """
   Starts a new empty transaction with fsync option.
   """
-  @spec transaction_new() :: {:ok, transaction()}
+  @spec transaction_new() :: transaction()
   def transaction_new do
-    {:ok, _t_ref} = :rocksdb.transaction(db_ref(), sync: true)
+    {:ok, t_ref} = :rocksdb.transaction(db_ref(), sync: true)
+
+    t_ref
   end
 
   @doc """

--- a/lib/ae_mdw/db/state.ex
+++ b/lib/ae_mdw/db/state.ex
@@ -1,0 +1,118 @@
+defmodule AeMdw.Db.State do
+  @moduledoc """
+  Represents the overall state of the database, regardless of where it is being
+  stored.
+  """
+  alias AeMdw.Database
+  alias AeMdw.Db.RocksDb
+  alias AeMdw.Db.TxnMutation
+
+  defstruct [:tables, :queued_changes]
+
+  use GenServer
+
+  @typep key() :: Database.key()
+  @typep record() :: Database.record()
+  # @typep row() :: {:active, record()} | :deleted
+  @typep table() :: Database.table()
+  @typep records() :: :gb_trees.tree()
+  @typep tables() :: %{Database.table() => records()}
+  @opaque t() :: %__MODULE__{tables: tables()}
+
+  @spec commit(t(), [TxnMutation.t()]) :: t()
+  def commit(state, mutations) do
+    state = Enum.reduce(mutations, state, &TxnMutation.execute/2)
+
+    queue_changes(state)
+
+    state
+  end
+
+  @spec get(t(), table(), key()) :: {:ok, record()} | :not_found
+  def get(%__MODULE__{tables: tables}, table, key) do
+    records = Map.get(tables, table, [])
+
+    case :gb_trees.lookup(key, records) do
+      {:value, {:active, record}} ->
+        {:ok, record}
+
+      {:value, :deleted} ->
+        :not_found
+
+      :none ->
+        case Database.read(table, key) do
+          [record] -> {:ok, record}
+          [] -> :not_found
+        end
+    end
+  end
+
+  @spec put(t(), table(), record()) :: t()
+  def put(%__MODULE__{tables: tables} = state, table, record) do
+    key = elem(record, 1)
+
+    new_tables =
+      Map.update(tables, table, :gb_trees.empty(), fn
+        records -> :gb_trees.insert(key, {:active, record}, records)
+      end)
+
+    %__MODULE__{state | tables: new_tables}
+  end
+
+  @spec delete(t(), table(), key()) :: t()
+  def delete(%__MODULE__{tables: tables} = state, table, key) do
+    new_tables =
+      Map.update(tables, table, :gb_trees.empty(), fn
+        records -> :gb_trees.delete(records, key)
+      end)
+
+    %__MODULE__{state | tables: new_tables}
+  end
+
+  ## Gen Server calls
+  @spec start_link(GenServer.options()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec current_state :: t()
+  def current_state do
+    GenServer.call(__MODULE__, :current_state)
+  end
+
+  defp queue_changes(%__MODULE__{tables: tables}) do
+    GenServer.cast(__MODULE__, {:queue_changes, tables})
+  end
+
+  ## Gen Server Callbacks
+
+  @impl true
+  def init(:ok) do
+    {:ok, %__MODULE__{queued_changes: :queue.new()}}
+  end
+
+  @impl true
+  def handle_call(:current_state, _from, state) do
+    {:reply, state, state}
+  end
+
+  @impl true
+  def handle_cast({:queue_changes, tables}, state) do
+    # this call would queue the changes to be performed once a certain condition is
+    # reached (e.g. once another queue for changes is added)
+
+    # committing the changes would be something along these lines:
+    transaction = RocksDb.transaction_new()
+
+    Enum.each(tables, fn {table, records} ->
+      Enum.each(records, fn
+        {_key, {:active, record}} -> Database.write(transaction, table, record)
+        {_key, :deleted} -> :ok
+      end)
+    end)
+
+    RocksDb.transaction_commit(transaction)
+
+    {:noreply, state}
+  end
+end

--- a/lib/ae_mdw/db/sync/block_index.ex
+++ b/lib/ae_mdw/db/sync/block_index.ex
@@ -7,7 +7,7 @@ defmodule AeMdw.Db.Sync.BlockIndex do
   alias AeMdw.Db.Sync
   alias AeMdw.Db.Model
   alias AeMdw.Database
-  alias AeMdw.Db.WriteTxnMutation
+  # alias AeMdw.Db.WriteTxnMutation
   alias AeMdw.Log
 
   import AeMdw.Util
@@ -24,7 +24,7 @@ defmodule AeMdw.Db.Sync.BlockIndex do
       header = :aec_chain.get_key_header_by_height(max_height) |> ok!
       initial_hash = :aec_headers.hash_header(header) |> ok!
 
-      {m_block_list, _} =
+      {_m_block_list, _} =
         Enum.reduce(max_height..min_height, {[], initial_hash}, fn height, {m_block_list, hash} ->
           if rem(height, @log_freq) == 0, do: Log.info("syncing block index at #{height}")
 
@@ -33,9 +33,9 @@ defmodule AeMdw.Db.Sync.BlockIndex do
           {[m_key_block | m_block_list], prev_hash}
         end)
 
-      m_block_list
-      |> Enum.map(&WriteTxnMutation.new(Model.Block, &1))
-      |> Database.commit()
+      # m_block_list
+      # |> Enum.map(&WriteTxnMutation.new(Model.Block, &1))
+      # |> Database.commit()
     end
 
     max_kbi()

--- a/lib/ae_mdw/db/txn_mutation.ex
+++ b/lib/ae_mdw/db/txn_mutation.ex
@@ -3,15 +3,17 @@ defprotocol AeMdw.Db.TxnMutation do
   Same as AeMdw.Db.Mutation but using a known database transaction.
   """
 
+  alias AeMdw.Db.State
+
   @doc """
   Abstracted function that performs the actual change into database.
   """
-  @spec execute(t(), AeMdw.Database.transaction()) :: :ok
-  def execute(mutation, transaction)
+  @spec execute(t(), State.t()) :: State.t()
+  def execute(mutation, state)
 end
 
 defimpl AeMdw.Db.TxnMutation, for: Any do
-  def execute(%mod{} = mutation, txn) do
-    mod.execute(mutation, txn)
+  def execute(%mod{} = mutation, state) do
+    mod.execute(mutation, state)
   end
 end


### PR DESCRIPTION
This is a draft which can be improved in many ways, but ultimately
this is the intended goal:

* Keep changes from the last X generations or microblocks
  in-memory (could be 1 microblock, or more)
* Easily revert these changes which weren't yet committed
* To be able to asynchronously write these in-memory changes to the
  database without having to wait for these changes to be done to
  continue syncing
* Transform the Mutation.execute/2 function into a 100% stateless
  function, which would only return the new state which contains the
  new changes to be migrated. Leaving only the State.commit/1 function
  to actually perform these changes (asynchronously)

Pending improvements:
* Instead of keeping the state of the un-committed changes in the
  State genserver state, use :persistent_term to allow other
  processes (e.g. webserver/controller processes) to inspect these
  changes
* Read these un-committed changes from the context modules and from
  the Collection module

Attached there's a diagram of the communication between the layers of the system:

![image](https://user-images.githubusercontent.com/750314/157540791-3465cb8e-0c2b-402f-83a0-6f0405744c2a.png)
