### PR TITLE
chore: remove unused total stat init

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -13,7 +13,6 @@ defmodule AeMdw.Application do
   alias AeMdw.Db.Stream, as: DbStream
   alias AeMdw.EtsCache
   alias AeMdw.Extract
-  alias AeMdw.Database
   alias AeMdw.NodeHelper
   alias AeMdw.Util
 
@@ -33,7 +32,6 @@ defmodule AeMdw.Application do
     init(:node_records)
     init(:meta)
     init_public(:contract_cache)
-    init_public(:db_state)
     # init(:aesophia)
     init(:app_ctrl_server)
     init(:aecore_services)
@@ -247,24 +245,6 @@ defmodule AeMdw.Application do
   def init_public(:contract_cache) do
     cache_exp = Application.fetch_env!(:ae_mdw, :contract_cache_expiration_minutes)
     EtsCache.new(Contract.table(), cache_exp)
-    :ok
-  end
-
-  def init_public(:db_state) do
-    initial_token_supply = AeMdw.Node.token_supply_delta(0)
-
-    :mnesia.transaction(fn ->
-      case Database.read(Model.TotalStat, 0) do
-        [m_total_stat] ->
-          tot_sup = Model.total_stat(m_total_stat, :total_supply)
-          tot_sup == initial_token_supply || raise "initial total supply doesn't match"
-
-        [] ->
-          m_total_stat = Model.total_stat(index: 0, total_supply: initial_token_supply)
-          Database.write(Model.TotalStat, m_total_stat)
-      end
-    end)
-
     :ok
   end
 


### PR DESCRIPTION
## What

Removes initialization of total stat on height 0 during `Application.start`

## Why

Already performed by `AeMdw.Db.Sync.Stats`