### PR TITLE
fix: aex9 creation for child contracts

### DIFF
--- a/lib/ae_mdw/db/mutations/aex9_create_contract_mutation.ex
+++ b/lib/ae_mdw/db/mutations/aex9_create_contract_mutation.ex
@@ -1,0 +1,57 @@
+defmodule AeMdw.Db.Aex9CreateContractMutation do
+  @moduledoc """
+  Maps a contract to its AEX9 token info.
+  """
+
+  alias AeMdw.Contract
+  alias AeMdw.Db.Contract, as: DBContract
+  alias AeMdw.Txs
+
+  defstruct [
+    :contract_pk,
+    :aex9_meta_info,
+    :caller_pk,
+    :create_txi
+  ]
+
+  @typep pubkey() :: AeMdw.Node.Db.pubkey()
+
+  @opaque t() :: %__MODULE__{
+            contract_pk: pubkey(),
+            aex9_meta_info: Contract.aex9_meta_info() | nil,
+            caller_pk: pubkey(),
+            create_txi: Txs.txi()
+          }
+
+  @spec new(
+          pubkey(),
+          Contract.aex9_meta_info() | nil,
+          pubkey(),
+          Txs.txi()
+        ) :: t()
+  def new(contract_pk, aex9_meta_info, caller_pk, create_txi) do
+    %__MODULE__{
+      contract_pk: contract_pk,
+      aex9_meta_info: aex9_meta_info,
+      caller_pk: caller_pk,
+      create_txi: create_txi
+    }
+  end
+
+  @spec mutate(t()) :: :ok
+  def mutate(%__MODULE__{
+        contract_pk: contract_pk,
+        aex9_meta_info: aex9_meta_info,
+        caller_pk: caller_pk,
+        create_txi: create_txi
+      }) do
+    DBContract.aex9_creation_write(aex9_meta_info, contract_pk, caller_pk, create_txi)
+    :ok
+  end
+end
+
+defimpl AeMdw.Db.Mutation, for: AeMdw.Db.Aex9CreateContractMutation do
+  def mutate(mutation) do
+    @for.mutate(mutation)
+  end
+end

--- a/lib/ae_mdw/db/mutations/contract_call_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_call_mutation.ex
@@ -15,8 +15,7 @@ defmodule AeMdw.Db.ContractCallMutation do
     :create_txi,
     :txi,
     :fun_arg_res,
-    :call_rec,
-    :aex9_meta_info
+    :call_rec
   ]
 
   @typep pubkey() :: AeMdw.Node.Db.pubkey()
@@ -28,7 +27,6 @@ defmodule AeMdw.Db.ContractCallMutation do
             create_txi: txi_option(),
             txi: Txs.txi(),
             fun_arg_res: Contract.fun_arg_res_or_error(),
-            aex9_meta_info: Contract.aex9_meta_info() | nil,
             call_rec: Contract.call()
           }
 
@@ -38,17 +36,15 @@ defmodule AeMdw.Db.ContractCallMutation do
           txi_option(),
           Txs.txi(),
           Contract.fun_arg_res_or_error(),
-          Contract.aex9_meta_info() | nil,
           Contract.call()
         ) :: t()
-  def new(contract_pk, caller_pk, create_txi, txi, fun_arg_res, aex9_meta_info, call_rec) do
+  def new(contract_pk, caller_pk, create_txi, txi, fun_arg_res, call_rec) do
     %__MODULE__{
       contract_pk: contract_pk,
       caller_pk: caller_pk,
       create_txi: create_txi,
       txi: txi,
       fun_arg_res: fun_arg_res,
-      aex9_meta_info: aex9_meta_info,
       call_rec: call_rec
     }
   end
@@ -60,7 +56,6 @@ defmodule AeMdw.Db.ContractCallMutation do
         create_txi: create_txi,
         txi: txi,
         fun_arg_res: fun_arg_res,
-        aex9_meta_info: aex9_meta_info,
         call_rec: call_rec
       }) do
     DBContract.call_write(create_txi, txi, fun_arg_res)
@@ -76,10 +71,6 @@ defmodule AeMdw.Db.ContractCallMutation do
         method_name,
         method_args
       )
-    end
-
-    if aex9_meta_info do
-      DBContract.aex9_creation_write(aex9_meta_info, contract_pk, caller_pk, txi)
     end
 
     :ok

--- a/lib/ae_mdw/db/mutations/contract_create_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_create_mutation.ex
@@ -5,51 +5,33 @@ defmodule AeMdw.Db.ContractCreateMutation do
 
   alias AeMdw.Contract
   alias AeMdw.Db.Contract, as: DBContract
-  alias AeMdw.Node.Db
   alias AeMdw.Txs
 
   @derive AeMdw.Db.Mutation
-  defstruct [:contract_pk, :txi, :owner_pk, :aex9_meta_info, :call_rec]
+  defstruct [:txi, :call_rec]
 
   @opaque t() :: %__MODULE__{
-            contract_pk: Db.pubkey(),
             txi: Txs.txi(),
-            owner_pk: Db.pubkey(),
-            aex9_meta_info: Contract.aex9_meta_info() | nil,
             call_rec: Contract.call()
           }
 
   @spec new(
-          Db.pubkey(),
           Txs.txi(),
-          Db.pubkey(),
-          Contract.aex9_meta_info() | nil,
           Contract.call()
         ) :: t()
-  def new(contract_pk, txi, owner_pk, aex9_meta_info, call_rec) do
+  def new(txi, call_rec) do
     %__MODULE__{
-      contract_pk: contract_pk,
       txi: txi,
-      owner_pk: owner_pk,
-      aex9_meta_info: aex9_meta_info,
       call_rec: call_rec
     }
   end
 
   @spec mutate(t()) :: :ok
   def mutate(%__MODULE__{
-        contract_pk: contract_pk,
         txi: txi,
-        owner_pk: owner_pk,
-        aex9_meta_info: aex9_meta_info,
         call_rec: call_rec
       }) do
-    if aex9_meta_info do
-      DBContract.aex9_creation_write(aex9_meta_info, contract_pk, owner_pk, txi)
-    end
-
     AeMdw.Ets.inc(:stat_sync_cache, :contracts_created)
-
     DBContract.logs_write(txi, txi, call_rec)
   end
 end

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -10,6 +10,7 @@ defmodule AeMdw.Db.Sync.Transaction do
   alias AeMdw.Db.Sync
   alias AeMdw.Db.Aex9AccountPresenceMutation
   alias AeMdw.Db.Aex9AccountBalanceMutation
+  alias AeMdw.Db.Aex9CreateContractMutation
   alias AeMdw.Db.ContractCallMutation
   alias AeMdw.Db.ContractCreateMutation
   alias AeMdw.Db.IntTransfer
@@ -290,11 +291,11 @@ defmodule AeMdw.Db.Sync.Transaction do
       {:ok, {type_info, _compiler_vsn, _source_hash}} ->
         call_rec = Contract.get_init_call_rec(tx, block_hash)
 
-        aex9_meta_info =
+        aex9_create_contract_mutation =
           with :ok <- :aect_call.return_type(call_rec),
                true <- Contract.is_aex9?(type_info),
-               {:ok, meta_info} <- Contract.aex9_meta_info(contract_pk) do
-            meta_info
+               {:ok, aex9_meta_info} <- Contract.aex9_meta_info(contract_pk) do
+            Aex9CreateContractMutation.new(contract_pk, aex9_meta_info, owner_pk, txi)
           else
             _failed -> nil
           end
@@ -302,7 +303,8 @@ defmodule AeMdw.Db.Sync.Transaction do
         mutations ++
           Sync.Contract.events_mutations(tx_events, block_index, block_hash, txi, tx_hash, txi) ++
           [
-            ContractCreateMutation.new(contract_pk, txi, owner_pk, aex9_meta_info, call_rec)
+            aex9_create_contract_mutation,
+            ContractCreateMutation.new(txi, call_rec)
           ]
 
       {:error, _reason} ->
@@ -326,24 +328,40 @@ defmodule AeMdw.Db.Sync.Transaction do
     {fun_arg_res, call_rec} =
       Contract.call_tx_info(tx, contract_pk, block_hash, &Contract.to_map/1)
 
-    {child_mutations, aex9_meta_info} =
-      Sync.Contract.child_contract_mutations(
-        :aect_call.return_type(call_rec) == :ok,
-        fun_arg_res,
+    child_mutations =
+      if :aect_call.return_type(call_rec) == :ok do
+        Sync.Contract.child_contract_mutations(
+          fun_arg_res,
+          caller_pk,
+          txi,
+          tx_hash
+        )
+      else
+        []
+      end
+
+    events_mutations =
+      Sync.Contract.events_mutations(
+        tx_events,
+        block_index,
+        block_hash,
         txi,
-        tx_hash
+        tx_hash,
+        create_txi
       )
 
     aex9_balance_mutation =
-      with true <- aex9_meta_info != nil,
+      with :ok <- :aect_call.return_type(call_rec),
+           true <- Contract.is_aex9?(contract_pk),
            {:ok, method_name, method_args} <- Contract.extract_successful_function(fun_arg_res) do
         Aex9AccountBalanceMutation.new(method_name, method_args, contract_pk, caller_pk)
       else
-        _false_not_found -> nil
+        _error_or_false -> nil
       end
 
-    child_mutations ++
-      Sync.Contract.events_mutations(tx_events, block_index, block_hash, txi, tx_hash, create_txi) ++
+    Enum.concat([
+      child_mutations,
+      events_mutations,
       [
         aex9_balance_mutation,
         ContractCallMutation.new(
@@ -352,10 +370,10 @@ defmodule AeMdw.Db.Sync.Transaction do
           create_txi,
           txi,
           fun_arg_res,
-          aex9_meta_info,
           call_rec
         )
       ]
+    ])
   end
 
   defp tx_mutations(%TxContext{

--- a/test/ae_mdw/db/aex9_balance_mutation_test.exs
+++ b/test/ae_mdw/db/aex9_balance_mutation_test.exs
@@ -1,5 +1,5 @@
 defmodule AeMdw.Db.Aex9AccountBalanceMutationTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   alias AeMdw.Database
   alias AeMdw.Db.Aex9AccountBalanceMutation

--- a/test/integration/ae_mdw/sync/aex9_create_contract_mutation_test.exs
+++ b/test/integration/ae_mdw/sync/aex9_create_contract_mutation_test.exs
@@ -1,0 +1,91 @@
+defmodule Integration.AeMdw.Db.Aex9CreateContractMutationTest do
+  use ExUnit.Case
+
+  @moduletag :integration
+
+  alias AeMdw.Node.Db, as: NodeDb
+  alias AeMdw.Contract
+  alias AeMdw.Database
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Sync
+  alias AeMdw.Validate
+
+  import Support.TestMnesiaSandbox
+
+  require Ex2ms
+  require Model
+
+  # aex9 created by contract call
+  @aex9_ct_pk Validate.id!("ct_6MFUZmk8wE76qnQqEqitQztabxZrp8AhEiSSMuyQYeSWUU467")
+
+  # credo:disable-for-next-line
+  @tag (Application.get_env(:aecore, :network_id) != "ae_uat" && :skip) || :integration
+  test "aex9 contract creation by a contract call" do
+    fn ->
+      txi = 25_729_031
+      contract_pk = @aex9_ct_pk
+      tx_hash = Validate.id!("th_2c6Nipg2ijrpyS4UXWsE1Fd7t5cNtYJqYT3ecj3EAFgdtB1Gw9")
+      {block_hash, :contract_call_tx, _signed_tx, tx} = NodeDb.get_tx_data(tx_hash)
+
+      <<caller_pk::binary-32>> = :aect_call_tx.caller_pubkey(tx)
+      ^contract_pk = :aect_call_tx.contract_pubkey(tx)
+
+      {fun_arg_res, _call_rec} =
+        Contract.call_tx_info(tx, contract_pk, block_hash, &Contract.to_map/1)
+
+      child_mutations =
+        Sync.Contract.child_contract_mutations(
+          fun_arg_res,
+          caller_pk,
+          txi,
+          tx_hash
+        )
+
+      assert [aex9_child_contract_mutation | origin_mutations] = child_mutations
+      assert child_contract_pk = aex9_child_contract_mutation.contract_pk
+      assert child_contract_pk != contract_pk
+      assert aex9_meta_info = aex9_child_contract_mutation.aex9_meta_info
+
+      name = "TestAEX9-B vs TestAEX9-A"
+      symbol = "TAEX9-B/TAEX9-A"
+      decimals = 18
+      assert {^name, ^symbol, ^decimals} = aex9_meta_info
+
+      assert ^origin_mutations =
+               Sync.Origin.origin_mutations(
+                 :contract_call_tx,
+                 nil,
+                 child_contract_pk,
+                 txi,
+                 tx_hash
+               )
+
+      # delete if already synced
+      :mnesia.delete(Model.Aex9Contract, {name, symbol, txi, decimals}, :write)
+      :mnesia.delete(Model.Aex9ContractSymbol, {symbol, name, txi, decimals}, :write)
+      :mnesia.delete(Model.RevAex9Contract, {txi, name, symbol, decimals}, :write)
+      :mnesia.delete(Model.Aex9ContractPubkey, child_contract_pk, :write)
+
+      Database.transaction(child_mutations)
+
+      m_contract = Model.aex9_contract(index: {name, symbol, txi, decimals})
+      m_contract_sym = Model.aex9_contract_symbol(index: {symbol, name, txi, decimals})
+      m_rev_contract = Model.rev_aex9_contract(index: {txi, name, symbol, decimals})
+      m_contract_pk = Model.aex9_contract_pubkey(index: child_contract_pk, txi: txi)
+
+      assert [^m_contract] =
+               :mnesia.read(Model.Aex9Contract, {name, symbol, txi, decimals}, :write)
+
+      assert [^m_contract_sym] =
+               :mnesia.read(Model.Aex9ContractSymbol, {symbol, name, txi, decimals}, :write)
+
+      assert [^m_rev_contract] =
+               :mnesia.read(Model.RevAex9Contract, {txi, name, symbol, decimals}, :write)
+
+      assert [^m_contract_pk] = :mnesia.read(Model.Aex9ContractPubkey, child_contract_pk, :write)
+
+      :mnesia.abort(:rollback)
+    end
+    |> mnesia_sandbox()
+  end
+end


### PR DESCRIPTION
## What/Why

Fixes #591 

## Validation steps
`NETWORK_ID=ae_uat INTEGRATION_TEST=1 elixir --sname aeternity@localhost -S mix test.integration test/integration/ae_mdw/sync/aex9_create_contract_mutation_test.exs`