### PR TITLE
fix: missing InactiveNameOwner record

### DIFF
--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -319,7 +319,7 @@ defmodule AeMdw.Db.Name do
 
   @spec revoke_or_expire_height(Model.name()) :: Blocks.height()
   def revoke_or_expire_height(m_name) do
-    do_revoke_or_expire_height(Model.name(m_name, :revoke), Model.name(m_name, :expire))
+    revoke_or_expire_height(Model.name(m_name, :revoke), Model.name(m_name, :expire))
   end
 
   @spec cache_through_read(table(), cache_key()) :: {:ok, name_record()} | nil
@@ -439,8 +439,8 @@ defmodule AeMdw.Db.Name do
   #
   # Private functions
   #
-  defp do_revoke_or_expire_height(nil = _revoke, expire), do: expire
-  defp do_revoke_or_expire_height({{revoke_height, _}, _}, _expire), do: revoke_height
+  defp revoke_or_expire_height(nil = _revoke, expire), do: expire
+  defp revoke_or_expire_height({{revoke_height, _}, _}, _expire), do: revoke_height
 
   defp cache_through_delete_active(
          txn,

--- a/test/ae_mdw/db/name_claim_mutation_test.exs
+++ b/test/ae_mdw/db/name_claim_mutation_test.exs
@@ -1,0 +1,72 @@
+defmodule AeMdw.Db.NameClaimMutationTest do
+  use ExUnit.Case
+
+  alias AeMdw.Database
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Sync
+
+  require Model
+
+  test "claim an inactive name with timeout 0" do
+    plain_name = "claim.test"
+
+    tx =
+      {:ns_claim_tx,
+       {:id, :account,
+        <<11, 180, 237, 121, 39, 249, 123, 81, 225, 188, 181, 225, 52, 13, 18, 51, 91, 42, 43, 18,
+          200, 188, 82, 33, 214, 60, 75, 203, 57, 212, 30, 97>>}, 11_251, plain_name, 7, :prelima,
+       1_000_000_000_000_000, 0}
+
+    tx_hash =
+      <<159, 240, 103, 205, 63, 165, 186, 153, 226, 186, 128, 241, 61, 192, 66, 89, 156, 217, 200,
+        247, 31, 137, 16, 129, 250, 190, 199, 100, 137, 179, 112, 165>>
+
+    claim_height = 200
+    old_claim_height = 100
+    old_claims = [{{old_claim_height, 1}, 123}]
+    updates = [{{150, 0}, 173}]
+    owner_pk = <<8435::256>>
+    block_index = {claim_height, 0}
+    txi = 223
+
+    inactive_name =
+      Model.name(
+        index: plain_name,
+        active: old_claim_height,
+        expire: 199,
+        claims: old_claims,
+        updates: updates,
+        owner: owner_pk,
+        previous: nil
+      )
+
+    Database.dirty_write(Model.InactiveName, inactive_name)
+
+    Database.dirty_write(
+      Model.InactiveNameExpiration,
+      Model.expiration(index: {199, "a123.test"})
+    )
+
+    Database.dirty_write(
+      Model.InactiveNameOwner,
+      Model.owner(index: {Model.name(inactive_name, :owner), plain_name})
+    )
+
+    tx
+    |> Sync.Name.name_claim_mutations(tx_hash, block_index, txi)
+    |> Database.commit()
+
+    assert {:ok,
+            Model.name(
+              index: ^plain_name,
+              active: ^claim_height,
+              claims: [{block_index, txi} | old_claims],
+              expire: expire,
+              owner: ^owner_pk,
+              updates: ^updates
+            )} = Database.fetch(Model.ActiveName, plain_name)
+
+    assert Database.exists?(Model.ActiveNameExpiration, {expire, plain_name})
+    assert Database.exists?(Model.ActiveNameOwner, {owner_pk, plain_name})
+  end
+end

--- a/test/ae_mdw/db/name_claim_mutation_test.exs
+++ b/test/ae_mdw/db/name_claim_mutation_test.exs
@@ -5,6 +5,8 @@ defmodule AeMdw.Db.NameClaimMutationTest do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Sync
 
+  import Mock
+
   require Model
 
   test "claim an inactive name with timeout 0" do
@@ -52,9 +54,13 @@ defmodule AeMdw.Db.NameClaimMutationTest do
       Model.owner(index: {Model.name(inactive_name, :owner), plain_name})
     )
 
-    tx
-    |> Sync.Name.name_claim_mutations(tx_hash, block_index, txi)
-    |> Database.commit()
+    with_mocks [
+      {AeMdw.Db.Util, [], [proto_vsn: fn _height -> 3 end]}
+    ] do
+      tx
+      |> Sync.Name.name_claim_mutations(tx_hash, block_index, txi)
+      |> Database.commit()
+    end
 
     assert {:ok,
             Model.name(

--- a/test/ae_mdw/db/name_revoke_mutation_test.exs
+++ b/test/ae_mdw/db/name_revoke_mutation_test.exs
@@ -3,6 +3,7 @@ defmodule AeMdw.Db.NameRevokeMutationTest do
 
   alias AeMdw.Database
   alias AeMdw.Db.Model
+  alias AeMdw.Db.NameRevokeMutation
 
   require Model
 
@@ -45,7 +46,7 @@ defmodule AeMdw.Db.NameRevokeMutationTest do
 
     Database.dirty_write(Model.ActiveNameOwner, Model.owner(index: {owner_pk, plain_name}))
 
-    Database.commit([AeMdw.Db.NameRevokeMutation.new(name_hash, revoke_txi, revoke_block_index)])
+    Database.commit([NameRevokeMutation.new(name_hash, revoke_txi, revoke_block_index)])
 
     assert {:ok,
             Model.name(

--- a/test/ae_mdw/db/name_revoke_mutation_test.exs
+++ b/test/ae_mdw/db/name_revoke_mutation_test.exs
@@ -1,0 +1,64 @@
+defmodule AeMdw.Db.NameRevokeMutationTest do
+  use ExUnit.Case
+
+  alias AeMdw.Database
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Sync
+
+  require Model
+
+  test "revoke a active name" do
+    plain_name = "revoke.test"
+
+    name_hash =
+      case :aens.get_name_hash(plain_name) do
+        {:ok, name_id_bin} -> Enc.encode(:name, name_id_bin)
+        _error -> nil
+      end
+
+    revoke_height = 3
+    revoke_block_index = {revoke_height, 0}
+    revoke_txi = 124
+
+    expire = 100
+    owner_pk = <<538_053::256>>
+
+    active_name =
+      Model.name(
+        index: plain_name,
+        active: 1,
+        expire: expire,
+        claims: [{{1, 0}, 123}],
+        updates: [],
+        transfers: [],
+        revoke: nil,
+        auction: 0,
+        owner: owner_pk,
+        previous: nil
+      )
+
+    cache_through_read(Model.PlainName, name_hash)
+    Database.dirty_write(Model.PlainName, Model.plain_name(index: name_hash, value: plain_name))
+    Database.dirty_write(Model.ActiveName, active_name)
+
+    Database.dirty_write(
+      Model.ActiveNameExpiration,
+      Model.expiration(index: {expire, plain_name})
+    )
+
+    Database.dirty_write(Model.ActiveNameOwner, Model.owner(index: {owner_pk, plain_name}))
+
+    Database.commit([AeMdw.Db.NameRevokeMutation.new(name_hash, revoke_txi, revoke_block_index)])
+
+    assert {:ok,
+            Model.name(
+              index: ^plain_name,
+              expire: ^expire,
+              owner: ^owner_pk,
+              revoke: {^revoke_block_index, ^revoke_txi}
+            )} = Database.fetch(Model.InactiveName, plain_name)
+
+    assert Database.exists?(Model.InactiveNameExpiration, {revoke_height, plain_name})
+    assert Database.exists?(Model.InactiveNameOwner, {owner_pk, plain_name})
+  end
+end

--- a/test/ae_mdw/db/name_revoke_mutation_test.exs
+++ b/test/ae_mdw/db/name_revoke_mutation_test.exs
@@ -3,7 +3,6 @@ defmodule AeMdw.Db.NameRevokeMutationTest do
 
   alias AeMdw.Database
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Sync
 
   require Model
 
@@ -12,7 +11,7 @@ defmodule AeMdw.Db.NameRevokeMutationTest do
 
     name_hash =
       case :aens.get_name_hash(plain_name) do
-        {:ok, name_id_bin} -> Enc.encode(:name, name_id_bin)
+        {:ok, name_id_bin} -> :aeser_api_encoder.encode(:name, name_id_bin)
         _error -> nil
       end
 

--- a/test/ae_mdw/db/name_revoke_mutation_test.exs
+++ b/test/ae_mdw/db/name_revoke_mutation_test.exs
@@ -32,12 +32,10 @@ defmodule AeMdw.Db.NameRevokeMutationTest do
         updates: [],
         transfers: [],
         revoke: nil,
-        auction: 0,
         owner: owner_pk,
         previous: nil
       )
 
-    cache_through_read(Model.PlainName, name_hash)
     Database.dirty_write(Model.PlainName, Model.plain_name(index: name_hash, value: plain_name))
     Database.dirty_write(Model.ActiveName, active_name)
 


### PR DESCRIPTION
## What

Single function to deactivate names so that `InactiveNameOwner` (along with `InactiveName` and `InactiveNameExpiration`) is always written on every name deactivation (expiration, update or revoke)

## Why

Missing record when revoked or updated.

## Validation steps

Sync until 80114 on testnet