### PR TITLE
fix: deactivate name on update with ttl 0

### DIFF
--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -118,14 +118,11 @@ defmodule AeMdw.Db.Name do
 
   @spec expire_name(transaction(), Blocks.height(), Names.plain_name()) :: :ok
   def expire_name(txn, height, plain_name) do
-    m_name = cache_through_read!(txn, Model.ActiveName, plain_name)
+    Model.name(expire: expiration) =
+      m_name = cache_through_read!(txn, Model.ActiveName, plain_name)
 
-    if Model.name(m_name, :expire) == height do
-      deactivate_name(txn, height, m_name)
-      Ets.inc(:stat_sync_cache, :names_expired)
-    else
-      cache_through_delete(txn, Model.ActiveNameExpiration, {height, plain_name})
-    end
+    deactivate_name(txn, height, expiration, m_name)
+    Ets.inc(:stat_sync_cache, :names_expired)
   end
 
   @spec expire_auction(
@@ -158,6 +155,7 @@ defmodule AeMdw.Db.Name do
     cache_through_write(txn, Model.ActiveName, m_name)
     cache_through_write(txn, Model.ActiveNameOwner, m_owner)
     cache_through_write(txn, Model.ActiveNameExpiration, m_name_exp)
+
     cache_through_delete(txn, Model.AuctionExpiration, {height, plain_name})
     cache_through_delete(txn, Model.AuctionOwner, {owner, plain_name})
     cache_through_delete(txn, Model.AuctionBid, bid_key)
@@ -413,6 +411,7 @@ defmodule AeMdw.Db.Name do
 
   def cache_through_delete_inactive(txn, Model.name(index: plain_name, owner: owner_pk) = m_name) do
     expire = revoke_or_expire_height(m_name)
+
     cache_through_delete(txn, Model.InactiveName, plain_name)
     cache_through_delete(txn, Model.InactiveNameOwner, {owner_pk, plain_name})
     cache_through_delete(txn, Model.InactiveNameExpiration, {expire, plain_name})
@@ -420,13 +419,14 @@ defmodule AeMdw.Db.Name do
     :ok
   end
 
-  @spec deactivate_name(transaction(), Blocks.height(), Model.name()) :: :ok
+  @spec deactivate_name(transaction(), Blocks.height(), Blocks.height(), Model.name()) :: :ok
   def deactivate_name(
         txn,
         deactivate_height,
+        expiration,
         Model.name(index: plain_name, owner: owner_pk) = m_name
       ) do
-    cache_through_delete_active(txn, m_name)
+    cache_through_delete_active(txn, expiration, m_name)
 
     m_exp = Model.expiration(index: {deactivate_height, plain_name})
     m_owner = Model.owner(index: {owner_pk, plain_name})
@@ -444,11 +444,12 @@ defmodule AeMdw.Db.Name do
 
   defp cache_through_delete_active(
          txn,
-         Model.name(index: plain_name, expire: expire, owner: owner_pk)
+         expiration,
+         Model.name(index: plain_name, owner: owner_pk)
        ) do
     cache_through_delete(txn, Model.ActiveName, plain_name)
     cache_through_delete(txn, Model.ActiveNameOwner, {owner_pk, plain_name})
-    cache_through_delete(txn, Model.ActiveNameExpiration, {expire, plain_name})
+    cache_through_delete(txn, Model.ActiveNameExpiration, {expiration, plain_name})
   end
 
   defp pointer_kv_raw(ptr),

--- a/test/ae_mdw/db/name_update_mutation_test.exs
+++ b/test/ae_mdw/db/name_update_mutation_test.exs
@@ -52,7 +52,7 @@ defmodule AeMdw.Db.NameUpdateMutationTest do
       assert {:ok,
               Model.name(
                 index: ^plain_name,
-                expire: ^expire,
+                expire: ^update_height,
                 owner: ^owner_pk,
                 updates: [{^block_index, ^txi}],
                 revoke: nil

--- a/test/ae_mdw/db/name_update_mutation_test.exs
+++ b/test/ae_mdw/db/name_update_mutation_test.exs
@@ -1,0 +1,65 @@
+defmodule AeMdw.Db.NameUpdateMutationTest do
+  use ExUnit.Case
+
+  alias AeMdw.Database
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.NameUpdateMutation
+
+  require Model
+
+  import AeMdw.Node.AeTxFixtures
+
+  describe "update" do
+    test "deactives a name by ttl 0" do
+      owner_pk = <<123_456::256>>
+      plain_name = "update-tll-0.test"
+      tx = new_aens_update_tx(owner_pk, plain_name, 0)
+
+      update_height = 10
+      expire = update_height + 100
+
+      active_name =
+        Model.name(
+          index: plain_name,
+          active: 1,
+          expire: expire,
+          claims: [{{1, 0}, 123}],
+          updates: [],
+          transfers: [],
+          revoke: nil,
+          owner: owner_pk,
+          previous: nil
+        )
+
+      Database.dirty_write(
+        Model.PlainName,
+        Model.plain_name(index: :aens_update_tx.name_hash(tx), value: plain_name)
+      )
+
+      Database.dirty_write(Model.ActiveName, active_name)
+
+      Database.dirty_write(
+        Model.ActiveNameExpiration,
+        Model.expiration(index: {expire, plain_name})
+      )
+
+      Database.dirty_write(Model.ActiveNameOwner, Model.owner(index: {owner_pk, plain_name}))
+
+      block_index = {update_height, 0}
+      txi = 124
+      Database.commit([NameUpdateMutation.new(tx, txi, block_index)])
+
+      assert {:ok,
+              Model.name(
+                index: ^plain_name,
+                expire: ^expire,
+                owner: ^owner_pk,
+                updates: [{^block_index, ^txi}],
+                revoke: nil
+              )} = Database.fetch(Model.InactiveName, plain_name)
+
+      assert Database.exists?(Model.InactiveNameExpiration, {update_height, plain_name})
+      assert Database.exists?(Model.InactiveNameOwner, {owner_pk, plain_name})
+    end
+  end
+end

--- a/test/support/ae_mdw/node/aetx_fixtures.ex
+++ b/test/support/ae_mdw/node/aetx_fixtures.ex
@@ -1,0 +1,26 @@
+defmodule AeMdw.Node.AeTxFixtures do
+  @moduledoc false
+
+  alias AeMdw.Node.Db
+  alias AeMdw.Names
+
+  @spec new_aens_update_tx(Db.pubkey(), Names.plain_name(), non_neg_integer()) :: tuple()
+  def new_aens_update_tx(owner_pk, plain_name, name_ttl) do
+    account_id = :aeser_id.create(:account, owner_pk)
+    {:ok, name_hash} = :aens.get_name_hash(plain_name)
+
+    {:ok, aetx} =
+      :aens_update_tx.new(%{
+        account_id: account_id,
+        nonce: 1,
+        name_id: :aeser_id.create(:name, name_hash),
+        name_ttl: name_ttl,
+        pointers: [:aens_pointer.new("account_pubkey", account_id)],
+        client_ttl: 0,
+        fee: 17_780_000_000_000
+      })
+
+    {_mod, tx} = :aetx.specialize_type(aetx)
+    tx
+  end
+end


### PR DESCRIPTION
## What

- Fixes the delete of `ActiveNameExpiration` during a name update with ttl 0
- Expires without any validation (assures that previous state transitions were correct)

## Why

Fixes sync on height [162223](https://github.com/aeternity/ae_mdw/pull/594#issuecomment-1075625216)

## Validation steps

Sync from scratch (delete the `mdw.db` dir) until the height 164809 with:
```
$ git checkout rocksdb-contracts
$ git merge --no-commit fix-update-ttl-0
$ make shell # or docker-compose up
```