### PR TITLE
fix: fix usage of Collection.stream for getting int calls

### DIFF
--- a/lib/ae_mdw/contracts.ex
+++ b/lib/ae_mdw/contracts.ex
@@ -100,7 +100,8 @@ defmodule AeMdw.Contracts do
   @spec fetch_int_contract_calls(Txs.txi(), Contract.fname()) :: Enumerable.t()
   def fetch_int_contract_calls(txi, fname) do
     @int_contract_call_table
-    |> Collection.stream(:backward, {{txi + 1, @min_int}, {txi, @min_int}}, nil)
+    |> Collection.stream({txi, @min_int})
+    |> Stream.take_while(&match?({^txi, _local_txi}, &1))
     |> Stream.map(&Database.fetch!(@int_contract_call_table, &1))
     |> Stream.filter(&match?(Model.int_contract_call(fname: ^fname), &1))
   end


### PR DESCRIPTION
Problem was the Collection.stream/4 exepcts the scope to always be
{first, last}, regardless of the direction.

Refs #604