### PR TITLE
fix: fix aex9 balances route for a contract

### DIFF
--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -139,7 +139,7 @@ defmodule AeMdwWeb.Router do
     get "/aex9/balances/account/:account_id", Aex9Controller, :balances
     get "/aex9/balances/gen/:range/:contract_id", Aex9Controller, :balances_range
     get "/aex9/balances/hash/:blockhash/:contract_id", Aex9Controller, :balances_for_hash
-    get "/aex9/balances/:contract_id", Aex9Controller, :balance
+    get "/aex9/balances/:contract_id", Aex9Controller, :balances
 
     get "/stats/:direction", StatsController, :stats
     get "/stats/:scope_type/:range", StatsController, :stats


### PR DESCRIPTION
Fix for v1 -> v2 migration:
```   5) test balances returns an error message when the balance is not available (Integration.AeMdwWeb.Aex9ControllerTest)
     test/integration/ae_mdw_web/controllers/aex9_controller_test.exs:243
     ** (Phoenix.ActionClauseError) no function clause matching in AeMdwWeb.Aex9Controller.balance/2
...
         # 2
         %{"contract_id" => "ct_M9yohHgcLjhpp1Z8SaA1UTmRMQzR4FWjJHajGga8KBoZTEPwC"}
```