### PR TITLE
fix: fix totalstats first height and v1/v2 stats tests

### DIFF
--- a/lib/ae_mdw/stats.ex
+++ b/lib/ae_mdw/stats.ex
@@ -74,8 +74,8 @@ defmodule AeMdw.Stats do
 
     {range_first, range_last} =
       case range do
-        nil -> {0, last_gen}
-        {:gen, %Range{first: first, last: last}} -> {max(first, 0), min(last, last_gen)}
+        nil -> {1, last_gen}
+        {:gen, %Range{first: first, last: last}} -> {max(first, 1), min(last, last_gen)}
       end
 
     cursor = deserialize_cursor(cursor)

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -141,6 +141,7 @@ defmodule AeMdwWeb.Router do
     get "/aex9/balances/hash/:blockhash/:contract_id", Aex9Controller, :balances_for_hash
     get "/aex9/balances/:contract_id", Aex9Controller, :balance
 
+    get "/stats", StatsController, :stats
     get "/stats/:direction", StatsController, :stats
     get "/stats/:scope_type/:range", StatsController, :stats
     get "/totalstats/:direction", StatsController, :total_stats


### PR DESCRIPTION
- Fix `/totalstats` first height
- Accommodate changes from stats v1 to v2 on test cases. 