### PR TITLE
fix: resume contract created stats setting min value to 0

### DIFF
--- a/lib/ae_mdw/db/sync/stats.ex
+++ b/lib/ae_mdw/db/sync/stats.ex
@@ -86,7 +86,7 @@ defmodule AeMdw.Db.Sync.Stats do
       names_revoked: length(height_revoked_names),
       oracles_registered: max(0, current_active_oracles - prev_active_oracles),
       oracles_expired: oracles_expired_count,
-      contracts_created: all_contracts_count - prev_contracts,
+      contracts_created: max(0, all_contracts_count - prev_contracts),
       block_reward: current_block_reward,
       dev_reward: current_dev_reward
     )


### PR DESCRIPTION
Avoids negative values for contracts_created delta stats when resuming sync from not the first microblock. 

Current error: `{:delta_stat, 162895, 0, 0, 0, 0, 0, 0, -2, 231660358983900000000,
 28340043916100000000}`