### PR TITLE
test: fix integration inactive names cases by expiration/deactivation

### DIFF
--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -181,7 +181,10 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
                |> json_response(200)
 
       expirations =
-        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height, "revoke" => revoke}} ->
+          revoke_height = if revoke, do: Util.txi_to_gen(revoke)
+          min(revoke_height, expire_height)
+        end)
 
       assert ^limit = length(names)
       assert ^expirations = Enum.sort(expirations)
@@ -190,8 +193,14 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
                conn |> get(next) |> json_response(200)
 
       next_expirations =
-        Enum.map(next_names, fn %{"info" => %{"expire_height" => expire_height}} ->
-          expire_height
+        Enum.map(next_names, fn %{
+                                  "info" => %{
+                                    "expire_height" => expire_height,
+                                    "revoke" => revoke
+                                  }
+                                } ->
+          revoke_height = if revoke, do: Util.txi_to_gen(revoke)
+          min(revoke_height, expire_height)
         end)
 
       assert ^limit = length(next_names)
@@ -669,7 +678,10 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
                |> json_response(200)
 
       expirations =
-        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height, "revoke" => revoke}} ->
+          revoke_height = if revoke, do: Util.txi_to_gen(revoke)
+          min(revoke_height, expire_height)
+        end)
 
       assert ^limit = length(names)
       assert ^expirations = Enum.sort(expirations)
@@ -678,8 +690,14 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
                conn |> get(next) |> json_response(200)
 
       next_expirations =
-        Enum.map(next_names, fn %{"info" => %{"expire_height" => expire_height}} ->
-          expire_height
+        Enum.map(next_names, fn %{
+                                  "info" => %{
+                                    "expire_height" => expire_height,
+                                    "revoke" => revoke
+                                  }
+                                } ->
+          revoke_height = if revoke, do: Util.txi_to_gen(revoke)
+          min(revoke_height, expire_height)
         end)
 
       assert ^limit = length(next_names)


### PR DESCRIPTION
## What

* Fixes test cases that considers inactive names expiration/deactivation only by expiration height.

## Why

On v1 endpoint, [at least since April 30 2021 (v1.0.8)](https://github.com/aeternity/ae_mdw/issues/396#issuecomment-1087850775), the `InactiveNameExpiration` table/record is also used for revoked height. This is needed to know which names were deactivated lately (or firstly depending on `backward` or `forward` direction) whether the name had expired or had being revoked.

## Notes

On v2 endpoint the purpose of the parameter can be improved/clarified renaming it from `by=expiration` to ~~`by=height`~~ `by=deactivation`