### PR TITLE
refactor: rename /v2/names/* by=expiration to by=deactivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2162,9 +2162,12 @@ There are 4 paginable endpoints for listing names:
 - /names/active - for listing `active` names
 - /names/auctions - for listing `auctions`
 
-They support ordering via parameters `by` (with options `expiration` and `name`), and `direction` (with options `forward` and `backward`).
+They support ordering via parameters `by` (with options `deactivation` and `name`), and `direction` (with options `forward` and `backward`).
 
-Without these parameters, the endpoints return results ordered as if `by=expiration` and `direction=backward` were provided.
+Using the `by=deactivation` means for inactive names that they are sorted by the height of deactivation, whether the name had expired or had been revoked. 
+For active names it means they are sorted by expiration height.
+
+Without these parameters, the endpoints return results ordered as if `by=deactivation` and `direction=backward` were provided.
 
 The parameter `limit` (by default = 10) is optional, and limits the number of elements in the response.
 
@@ -2314,18 +2317,18 @@ $ curl -s "https://mainnet.aeternity.io/mdw/v2/names?limit=2" | jq '.'
       "status": "name"
     }
   ],
-  "next": "/v2/names?by=expiration&cursor=703645-jiangjiajia.chain&direction=backward&expand=false&limit=2",
+  "next": "/v2/names?by=deactivation&cursor=703645-jiangjiajia.chain&direction=backward&expand=false&limit=2",
   "prev": null
 }
 ```
 
 #### Inactive names
 
-For demonstration, they are ordered by `expiration` with direction `forward`.
+For demonstration, they are ordered by `deactivation` with direction `forward`.
 This means, we list from oldest to newest expired names.
 
 ```
-$ curl -s "https://mainnet.aeternity.io/mdw/names/inactive?by=expiration&direction=forward&limit=2" | jq '.'
+$ curl -s "https://mainnet.aeternity.io/mdw/names/inactive?by=deactivation&direction=forward&limit=2" | jq '.'
 {
   "data": [
     {
@@ -4594,7 +4597,7 @@ The example output would look like:
           ......................................................................
 
 
-          Path: "/names/inactive?by=expiration&direction=forward&limit=1"
+          Path: "/names/inactive?by=deactivation&direction=forward&limit=1"
           Number of requests: 7
           Successful requests: 7
           Failed requests: 0

--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -50,7 +50,8 @@ defmodule AeMdw.Names do
 
   @spec fetch_names(pagination(), range(), order_by(), query(), cursor() | nil, boolean()) ::
           {:ok, cursor() | nil, [name()], cursor() | nil} | {:error, reason()}
-  def fetch_names(pagination, range, :expiration, query, cursor, expand?) do
+  def fetch_names(pagination, range, order_by, query, cursor, expand?)
+      when order_by in [:expiration, :deactivation] do
     cursor = deserialize_expiration_cursor(cursor)
     scope = deserialize_scope(range)
 
@@ -58,8 +59,7 @@ defmodule AeMdw.Names do
       {prev_cursor, expiration_keys, next_cursor} =
         query
         |> Map.drop(@pagination_params)
-        |> Enum.map(&convert_param/1)
-        |> Map.new()
+        |> Enum.into(%{}, &convert_param/1)
         |> build_expiration_streamer(scope, cursor)
         |> Collection.paginate(pagination)
 
@@ -78,8 +78,7 @@ defmodule AeMdw.Names do
       {prev_cursor, name_keys, next_cursor} =
         query
         |> Map.drop(@pagination_params)
-        |> Enum.map(&convert_param/1)
-        |> Map.new()
+        |> Enum.into(%{}, &convert_param/1)
         |> build_name_streamer(cursor)
         |> Collection.paginate(pagination)
 

--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -21,7 +21,7 @@ defmodule AeMdwWeb.NameController do
   import AeMdw.Util
 
   plug PaginatedPlug,
-       [order_by: ~w(expiration name)a]
+       [order_by: ~w(expiration deactivation name)a]
        when action in ~w(active_names inactive_names names auctions search search_v1)a
 
   @lifecycles_map %{

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -47,6 +47,35 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
       end
     end
 
+    test "it get active names backwards by default with by=expiration", %{conn: conn} do
+      assert %{"data" => names, "next" => next} =
+               conn |> get("/names/active?by=expiration") |> json_response(200)
+
+      expirations =
+        names
+        |> Enum.map(fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        |> Enum.reverse()
+
+      assert length(names) <= @default_limit
+      assert ^expirations = Enum.sort(expirations)
+
+      assert %{"data" => next_names, "prev" => prev_names} =
+               conn |> get(next) |> json_response(200)
+
+      if next do
+        next_expirations =
+          next_names
+          |> Enum.map(fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+          |> Enum.reverse()
+
+        assert length(next_names) <= @default_limit
+        assert ^next_expirations = Enum.sort(next_expirations)
+        assert Enum.at(expirations, @default_limit - 1) >= Enum.at(next_expirations, 0)
+
+        assert %{"data" => ^names} = conn |> get(prev_names) |> json_response(200)
+      end
+    end
+
     test "get active names forward with limit=4", %{conn: conn} do
       limit = 4
 
@@ -505,6 +534,35 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
     test "it get active names backwards without any filters", %{conn: conn} do
       assert %{"data" => names, "next" => next} =
                conn |> get("/v2/names", state: "active") |> json_response(200)
+
+      expirations =
+        names
+        |> Enum.map(fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        |> Enum.reverse()
+
+      assert length(names) <= @default_limit
+      assert ^expirations = Enum.sort(expirations)
+
+      assert %{"data" => next_names, "prev" => prev_names} =
+               conn |> get(next) |> json_response(200)
+
+      if next do
+        next_expirations =
+          next_names
+          |> Enum.map(fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+          |> Enum.reverse()
+
+        assert length(next_names) <= @default_limit
+        assert ^next_expirations = Enum.sort(next_expirations)
+        assert Enum.at(expirations, @default_limit - 1) >= Enum.at(next_expirations, 0)
+
+        assert %{"data" => ^names} = conn |> get(prev_names) |> json_response(200)
+      end
+    end
+
+    test "it get active names backwards by default with by=deactivation", %{conn: conn} do
+      assert %{"data" => names, "next" => next} =
+               conn |> get("/v2/names?by=deactivation", state: "active") |> json_response(200)
 
       expirations =
         names

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -181,7 +181,10 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
                |> json_response(200)
 
       expirations =
-        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height, "revoke" => revoke}} ->
+          revoke_height = if revoke, do: Util.txi_to_gen(revoke)
+          min(revoke_height, expire_height)
+        end)
 
       assert ^limit = length(names)
       assert ^expirations = Enum.sort(expirations)
@@ -190,8 +193,14 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
                conn |> get(next) |> json_response(200)
 
       next_expirations =
-        Enum.map(next_names, fn %{"info" => %{"expire_height" => expire_height}} ->
-          expire_height
+        Enum.map(next_names, fn %{
+                                  "info" => %{
+                                    "expire_height" => expire_height,
+                                    "revoke" => revoke
+                                  }
+                                } ->
+          revoke_height = if revoke, do: Util.txi_to_gen(revoke)
+          min(revoke_height, expire_height)
         end)
 
       assert ^limit = length(next_names)
@@ -669,7 +678,10 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
                |> json_response(200)
 
       expirations =
-        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height}} -> expire_height end)
+        Enum.map(names, fn %{"info" => %{"expire_height" => expire_height, "revoke" => revoke}} ->
+          revoke_height = if revoke, do: Util.txi_to_gen(revoke)
+          min(revoke_height, expire_height)
+        end)
 
       assert ^limit = length(names)
       assert ^expirations = Enum.sort(expirations)
@@ -678,8 +690,14 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
                conn |> get(next) |> json_response(200)
 
       next_expirations =
-        Enum.map(next_names, fn %{"info" => %{"expire_height" => expire_height}} ->
-          expire_height
+        Enum.map(next_names, fn %{
+                                  "info" => %{
+                                    "expire_height" => expire_height,
+                                    "revoke" => revoke
+                                  }
+                                } ->
+          revoke_height = if revoke, do: Util.txi_to_gen(revoke)
+          min(revoke_height, expire_height)
         end)
 
       assert ^limit = length(next_names)


### PR DESCRIPTION
## What

* Accept by=deactivation on /v2/names/* (by=expiration will be deprecated on /v1 deprecation)
* Change documentation to clarify the use of `by` parameter explaining that the sorting considers also the revoke height.

## Why

The v1 `/names/inactive?by=expiration` had always sorted not only by expiration but also included the revoked names. This  is needed to know which names were deactivated lately (or firstly depending on backward or forward direction) whether the name had expired or had being revoked.