### PR TITLE
fix: get next block hash on async task

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,6 +1,13 @@
 alias AeMdw.Db.Model
 alias AeMdw.Db.Name
 alias AeMdw.Db.Util
+
+alias AeMdw.Contract
 alias AeMdw.Database
+alias AeMdw.Validate
+alias AeMdw.Sync.AsyncTasks
+
 require Model
 require Ex2ms
+
+alias AeMdw.Node.Db, as: DBN

--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -72,8 +72,11 @@ defmodule AeMdw.Aex9 do
         amounts when map_size(amounts) == 0 ->
           raise ErrInput.Aex9BalanceNotAvailable, value: "contract #{enc_ct(contract_pk)}"
 
+        %{{:address, <<>>} => nil} ->
+          %{}
+
         amounts ->
-          amounts
+          Map.delete(amounts, {:address, <<>>})
       end
     end
   end

--- a/lib/ae_mdw/node/db.ex
+++ b/lib/ae_mdw/node/db.ex
@@ -16,21 +16,42 @@ defmodule AeMdw.Node.Db do
   @typep height_hash() :: {hash_type(), pos_integer(), binary()}
 
   @spec get_blocks(Blocks.block_hash(), Blocks.block_hash()) :: tuple()
-  def get_blocks(kb_hash, next_gen_kb_hash) do
-    {:aec_db.get_block(kb_hash), get_micro_blocks(next_gen_kb_hash)}
+  def get_blocks(kb_hash, next_kb_hash) do
+    {:aec_db.get_block(kb_hash), get_micro_blocks(next_kb_hash)}
   end
 
   @spec get_micro_blocks(Blocks.block_hash()) :: list()
-  def get_micro_blocks(next_gen_kb_hash) do
-    next_gen_kb_hash
+  def get_micro_blocks(next_kb_hash) do
+    next_kb_hash
     |> :aec_db.get_header()
     |> :aec_headers.prev_hash()
     |> Stream.unfold(&micro_block_walker/1)
     |> Enum.reverse()
   end
 
-  @spec get_tx_data(binary()) :: tuple()
+  @spec get_next_hash(Blocks.block_hash(), Blocks.mbi()) :: Blocks.block_hash()
+  def get_next_hash(next_kb_hash, mbi) do
+    next_kb_hash
+    |> get_micro_blocks()
+    |> Enum.reduce_while(0, fn mblock, index ->
+      if index == mbi + 1 do
+        ok_mb_hash =
+          mblock
+          |> :aec_blocks.to_micro_header()
+          |> :aec_headers.hash_header()
 
+        {:halt, ok_mb_hash}
+      else
+        {:cont, index + 1}
+      end
+    end)
+    |> case do
+      {:ok, mb_hash} -> mb_hash
+      _mb_count -> next_kb_hash
+    end
+  end
+
+  @spec get_tx_data(binary()) :: tuple()
   def get_tx_data(<<_::256>> = tx_hash) do
     {block_hash, signed_tx} = :aec_db.find_tx_with_location(tx_hash)
     {type, tx_rec} = :aetx.specialize_type(:aetx_sign.tx(signed_tx))

--- a/lib/ae_mdw/sync/async_tasks/derive_aex9_presence.ex
+++ b/lib/ae_mdw/sync/async_tasks/derive_aex9_presence.ex
@@ -10,7 +10,6 @@ defmodule AeMdw.Sync.AsyncTasks.DeriveAex9Presence do
   alias AeMdw.Database
   alias AeMdw.Db.Contract, as: DBContract
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Util
   alias AeMdw.Log
 
   require Model
@@ -20,24 +19,23 @@ defmodule AeMdw.Sync.AsyncTasks.DeriveAex9Presence do
 
   @spec process(args :: list()) :: :ok
   def process([contract_pk, kbi, mbi, create_txi]) do
-    next_hash =
-      {kbi, mbi}
-      |> Util.next_bi!()
-      |> Util.read_block!()
-      |> Model.block(:hash)
-
     Log.info("[:derive_aex9_presence] #{inspect(contract_pk)} ...")
 
     {time_delta, {balances, _last_block_tuple}} =
       :timer.tc(fn ->
+        Model.block(hash: next_kb_hash) = Database.fetch!(Model.Block, {kbi + 1, -1})
+        next_hash = DBN.get_next_hash(next_kb_hash, mbi)
+
         DBN.aex9_balances(contract_pk, {nil, kbi, next_hash})
       end)
 
     Log.info("[:derive_aex9_presence] #{inspect(contract_pk)} after #{time_delta / @microsecs}s")
 
-    Enum.each(
-      balances,
-      fn {{:address, account_pk}, amount} ->
+    if map_size(balances) == 0 do
+      m_empty_balance = Model.aex9_balance(index: {contract_pk, <<>>})
+      Database.dirty_write(Model.Aex9Balance, m_empty_balance)
+    else
+      Enum.each(balances, fn {{:address, account_pk}, amount} ->
         DBContract.aex9_write_presence(contract_pk, create_txi, account_pk)
 
         m_balance =
@@ -47,8 +45,8 @@ defmodule AeMdw.Sync.AsyncTasks.DeriveAex9Presence do
           )
 
         Database.dirty_write(Model.Aex9Balance, m_balance)
-      end
-    )
+      end)
+    end
 
     :ok
   end

--- a/priv/migrations/20220406151722_derive_aex9_presence_and_balance.ex
+++ b/priv/migrations/20220406151722_derive_aex9_presence_and_balance.ex
@@ -1,0 +1,55 @@
+defmodule AeMdw.Migrations.DeriveAex9PresenceAndBalance do
+  @moduledoc """
+  Initializes aex9 presence and balance.
+  """
+
+  alias AeMdw.Database
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Util
+  alias AeMdw.Log
+  alias AeMdw.Sync.AsyncTasks
+
+  require Model
+
+  @spec run(boolean()) :: {:ok, {non_neg_integer(), non_neg_integer()}}
+  def run(_from_start?) do
+    begin = DateTime.utc_now()
+
+    indexed_count =
+      fetch_aex9_pubkeys()
+      |> Enum.map(fn contract_pk ->
+        create_txi = fetch_aex9_txi(contract_pk)
+        {kbi, mbi} = fetch_txi_bi(create_txi)
+        AsyncTasks.Producer.enqueue(:derive_aex9_presence, [contract_pk, kbi, mbi, create_txi])
+      end)
+      |> Enum.count()
+
+    AsyncTasks.Producer.commit_enqueued()
+
+    duration = DateTime.diff(DateTime.utc_now(), begin)
+    Log.info("Indexed #{indexed_count} records in #{duration}s")
+
+    {:ok, {indexed_count, duration}}
+  end
+
+  defp fetch_aex9_pubkeys() do
+    Model.Aex9ContractPubkey
+    |> Database.all_keys()
+    |> Enum.filter(fn contract_pk ->
+      case Database.next_key(Model.Aex9Balance, {contract_pk, nil}) do
+        {:ok, {^contract_pk, _account_pk}} -> false
+        _not_found -> true
+      end
+    end)
+  end
+
+  defp fetch_aex9_txi(contract_pk) do
+    Model.aex9_contract_pubkey(txi: txi) = Database.fetch!(Model.Aex9ContractPubkey, contract_pk)
+    txi
+  end
+
+  defp fetch_txi_bi(create_txi) do
+    Model.tx(block_index: block_index) = Util.read_tx!(create_txi)
+    block_index
+  end
+end

--- a/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
@@ -265,6 +265,30 @@ defmodule Integration.AeMdwWeb.Aex9ControllerTest do
         assert is_integer(balance) and balance >= 0
       end)
     end
+
+    test "gets accounts balances for a contract with less than 100 amounts", %{conn: conn} do
+      contract_id = "ct_RDRJC5EySx4TcLtGRWYrXfNgyWzEDzssThJYPd9kdLeS5ECaA"
+      conn = get(conn, "/aex9/balances/#{contract_id}")
+
+      assert %{
+               "amounts" => amounts,
+               "contract_id" => ^contract_id
+             } = json_response(conn, 200)
+
+      assert is_map(amounts) and map_size(amounts) > 0 and map_size(amounts) < 100
+    end
+
+    test "returns the empty amounts for aex9 contract without balance", %{conn: conn} do
+      contract_id = "ct_U7whpYJo4xXoXjEpw39mWEPKgKM2kgSZk9em5FLK8Xq2FrRWE"
+      conn = get(conn, "/aex9/balances/#{contract_id}")
+
+      assert %{
+               "amounts" => amounts,
+               "contract_id" => ^contract_id
+             } = json_response(conn, 200)
+
+      assert is_map(amounts) and map_size(amounts) == 0
+    end
   end
 
   describe "balance" do

--- a/test/integration/ae_mdw_web/controllers/aex9_token_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/aex9_token_controller_test.exs
@@ -183,6 +183,15 @@ defmodule Integration.AeMdwWeb.Aex9TokenControllerTest do
       end
     end
 
+    test "returns the empty amounts for aex9 contract without balance", %{conn: conn} do
+      contract_id = "ct_U7whpYJo4xXoXjEpw39mWEPKgKM2kgSZk9em5FLK8Xq2FrRWE"
+
+      assert %{"data" => [], "next" => nil} =
+               conn
+               |> get("/v2/aex9/#{contract_id}/balances")
+               |> json_response(200)
+    end
+
     test "when not an aex9 contract, it returns an error", %{conn: conn} do
       non_existent_id = "ct_y7gojSY8rXW6tztE9Ftqe3kmNrqEXsREiPwGCeG3MJL38jkFo"
       error_msg = "not AEX9 contract: #{non_existent_id}"


### PR DESCRIPTION
## What

* Safely gets the hash of next block to compute the aex9 balance during async task processing.
* Initialize aex9 balance with empty mapping to differentiate from `balance is not yet available` condition (`Aex9BalanceNotAvailable` exception)

## Why

Closes #615 

## Validation steps
```
INTEGRATION_TEST=1 elixir --sname aeternity@localhost -S mix test.integration  test/integration/ae_mdw_web/controllers/aex9_controller_test.exs:269

INTEGRATION_TEST=1 elixir --sname aeternity@localhost -S mix test.integration  test/integration/ae_mdw_web/controllers/aex9_controller_test.exs:281
```

## Notes
Other issues involving cached aex9 balance that will be handled in a following PR.