### PR TITLE
ci: speedup check formatted and credo

### DIFF
--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -1,0 +1,16 @@
+name: 'Node setup'
+
+inputs:
+  deploy-key:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup node
+      shell: bash
+      run: |
+        curl -L https://github.com/aeternity/aeternity/releases/download/v6.4.0/aeternity-v6.4.0-ubuntu-x86_64.tar.gz -o aeternity.tgz \
+        && mkdir -p ${NODEROOT}/rel/aeternity && tar xf aeternity.tgz -C ${NODEROOT}/rel/aeternity && cp -rf ${NODEROOT}/rel/aeternity/lib/ ${NODEROOT}
+
+  

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -43,10 +43,8 @@ jobs:
           otp-version: 22.3.4.24
           elixir-version: 1.10.4
 
-      - name: Setup node
-        run: |
-          curl -L https://github.com/aeternity/aeternity/releases/download/v6.4.0/aeternity-v6.4.0-ubuntu-x86_64.tar.gz -o aeternity.tgz \
-          && mkdir -p ${NODEROOT}/rel/aeternity && tar xvf aeternity.tgz -C ${NODEROOT}/rel/aeternity && cp -rf ${NODEROOT}/rel/aeternity/lib/ ${NODEROOT}
+      - name: Node Setup
+        uses: ./.github/actions/node-setup
 
       - name: Get dependencies
         run: mix deps.get
@@ -58,23 +56,29 @@ jobs:
     name: Automated linting
     runs-on: ubuntu-latest
 
+    env:
+      NODEROOT: ./node/local
+
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Common tests setup
-        uses: ./.github/actions/tests-common
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: 22.3.4.24
+          elixir-version: 1.10.4
 
-      - name: Setup dependencies
-        run: make docker-deps
+      - name: Get dependencies
+        run: mix deps.get
 
       - name: Reset master
         if: ${{ github.ref != 'refs/heads/master' }}
         run: |
           git branch -f master origin/master
 
-      - run: make docker-lint
+      - run: mix format --check-formatted && mix credo diff master
+
 
   dialyzer:
     name: Dialyzer

--- a/Makefile
+++ b/Makefile
@@ -79,17 +79,9 @@ help:
 ## DOCKER TARGETS
 ################################################################################
 
-.PHONY: docker-lint
-docker-lint:
-	$(call docker_execute,./scripts/lint.sh)
-
 .PHONY: docker-test
 docker-test:
 	$(call docker_execute,./scripts/test.sh)
-
-.PHONY: docker-coveralls
-docker-coveralls:
-	$(call docker_execute,./scripts/coveralls.sh)
 
 .PHONY: docker-dialyzer
 docker-dialyzer:

--- a/scripts/coveralls.sh
+++ b/scripts/coveralls.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -xe
-
-MIX_ENV=test elixir --sname aeternity@localhost -S mix coveralls.github
-
-exit 0


### PR DESCRIPTION
## What

Change static analysis tasks to run without docker.

## Why

Setting up dependencies with docker takes about 3m.

