### PR TITLE
ci: speed up dialyzer running without docker

### DIFF
--- a/.github/actions/mdw-setup/action.yml
+++ b/.github/actions/mdw-setup/action.yml
@@ -1,0 +1,17 @@
+name: 'Mdw setup'
+
+inputs:
+  deploy-key:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: erlef/setup-beam@v1
+      with:
+        otp-version: 22.3.4.24
+        elixir-version: 1.10.4
+
+    - name: Get Mdw dependencies
+      shell: bash
+      run: mix deps.get

--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -1,4 +1,4 @@
-name: 'Mdw and Node setup'
+name: 'Node setup'
 
 inputs:
   deploy-key:
@@ -7,15 +7,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: 22.3.4.24
-        elixir-version: 1.10.4
-
-    - name: Get Mdw dependencies
-      shell: bash
-      run: mix deps.get
-
     - name: Setup Node
       shell: bash
       run: |

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -38,8 +38,11 @@ jobs:
         with:
           fetch-depth: 0
           
-      - name: Mdw and Node Setup
-        uses: ./.github/actions/mdw-node-setup
+      - name: Mdw Setup
+        uses: ./.github/actions/mdw-setup
+
+      - name: Node Setup
+        uses: ./.github/actions/node-setup
 
       - name: Execute coverage
         run: elixir --sname aeternity@localhost -S mix coveralls
@@ -56,13 +59,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: 22.3.4.24
-          elixir-version: 1.10.4
-
-      - name: Get dependencies
-        run: mix deps.get
+      - name: Mdw Setup
+        uses: ./.github/actions/mdw-setup
 
       - name: Reset master
         if: ${{ github.ref != 'refs/heads/master' }}
@@ -95,18 +93,15 @@ jobs:
         id: plt-cache
         with:
           path: priv/plts
-          key: plts-v6-${{ hashFiles('mix.lock') }}
+          key: plts-v7-${{ hashFiles('mix.lock') }}
 
-      - name: Common tests setup
-        uses: ./.github/actions/tests-common
-
-      - name: Setup dependencies
-        run: make docker-deps
+      - name: Mdw Setup
+        uses: ./.github/actions/mdw-setup
 
       - name: Create PLTs
         if: steps.plt-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p priv/plts
-          make docker-dialyzer-plt
+          mix dialyzer --plt
 
-      - run: make docker-dialyzer
+      - run: mix dialyzer

--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,6 @@ help:
 docker-test:
 	$(call docker_execute,./scripts/test.sh)
 
-.PHONY: docker-dialyzer
-docker-dialyzer:
-	$(call docker_execute,./scripts/dialyzer.sh)
-
 .PHONY: docker-shell
 docker-shell:
 	$(call docker_execute,/bin/bash)
@@ -94,10 +90,6 @@ docker-shell:
 .PHONY: docker-deps
 docker-deps:
 	$(call docker_execute,/bin/bash -c "mix deps.get")
-
-.PHONY: docker-dialyzer-plt
-docker-dialyzer-plt:
-	$(call docker_execute,/bin/bash -c "mix dialyzer --plt")
 
 define docker_execute
 	docker-compose run --rm \


### PR DESCRIPTION
Decrease `dialyzer` CI job time from 4m50s to 1m12s by not using docker.
