### PR TITLE
fix: handle requests for blocks that don't exist gracefully

### DIFF
--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -50,13 +50,13 @@ defmodule AeMdw.Blocks do
 
     cursor = deserialize_cursor(cursor)
 
-    {range_first, range_last} =
+    range =
       case range do
         nil -> {0, last_gen}
-        {:gen, %Range{first: first, last: last}} -> {max(first, 0), min(last, last_gen)}
+        {:gen, %Range{first: first, last: last}} -> {first, last}
       end
 
-    case Util.build_gen_pagination(cursor, direction, range_first, range_last, limit) do
+    case Util.build_gen_pagination(cursor, direction, range, limit, last_gen) do
       {:ok, prev_cursor, range, next_cursor} ->
         {serialize_cursor(prev_cursor), render_blocks(range, last_gen, sort_mbs?),
          serialize_cursor(next_cursor)}

--- a/test/ae_mdw/util_test.exs
+++ b/test/ae_mdw/util_test.exs
@@ -1,0 +1,31 @@
+defmodule AeMdw.UtilTest do
+  use ExUnit.Case
+
+  alias AeMdw.Util
+
+  describe "build_gen_pagination/5" do
+    test "when forward and range_first exceeds last_gen, it returns error" do
+      assert :error = Util.build_gen_pagination(nil, :forward, {400, 500}, 10, 300)
+    end
+
+    test "when backward and range_first exceeds last_gen, it returns error" do
+      assert :error = Util.build_gen_pagination(nil, :backward, {200, 500}, 10, 100)
+    end
+
+    test "when limit exceeds last gen, it returns results up to the valid point" do
+      assert {:ok, nil, range, nil} =
+               Util.build_gen_pagination(nil, :forward, {400, 450}, 20, 409)
+
+      assert ^range = Range.new(400, 409)
+    end
+
+    test "when cursor is outside last_gen, it returns error" do
+      assert :error = Util.build_gen_pagination(500, :forward, {400, 500}, 20, 400)
+    end
+
+    test "when cursor + length is outside last_gen, it returns up to the valid point" do
+      assert {:ok, 380, range, nil} = Util.build_gen_pagination(400, :forward, {0, 500}, 20, 410)
+      assert ^range = Range.new(400, 410)
+    end
+  end
+end


### PR DESCRIPTION
Fixes non-existent blocks querying (e.g. https://mainnet.aeternity.art/blocks/1000000-1000000)