### PR TITLE
feat: display mdw gens processed per min on the status page

### DIFF
--- a/lib/ae_mdw/db/status.ex
+++ b/lib/ae_mdw/db/status.ex
@@ -18,6 +18,7 @@ defmodule AeMdw.Db.Status do
     mdw_syncing? = Server.syncing?()
     {:ok, version} = :application.get_key(:ae_mdw, :vsn)
     async_tasks_counters = Stats.counters()
+    gens_per_minute = Server.gens_per_min()
 
     %{
       node_version: :aeu_info.get_version(),
@@ -32,7 +33,8 @@ defmodule AeMdw.Db.Status do
       mdw_async_tasks: async_tasks_counters,
       # MDW is always 1 generation behind
       mdw_synced: node_height == mdw_height + 1,
-      mdw_syncing: mdw_syncing?
+      mdw_syncing: mdw_syncing?,
+      mdw_gens_per_minute: round(gens_per_minute * 100) / 100
     }
   end
 


### PR DESCRIPTION
Example of the status response:

```
{
  "mdw_async_tasks": {
    "long_tasks": 0,
    "producer_buffer": 1,
    "total_pending": 3
  },
  "mdw_gens_per_minute": 345.19,
  "mdw_height": 341556,
  "mdw_revision": "b9aa4a8",
  "mdw_synced": false,
  "mdw_syncing": true,
  "mdw_tx"_index: 17680520,
  "mdw_version": "1.8.1",
  "node_height": 588976,
  "node_progress": 100,
  "node_revision": "39941357ac8491d890155c2ccbcd0571fbf3f5a0",
  "node_syncing": false,
  "node_version": "6.4.0"
}
```