### PR TITLE
fix: write block_index to aex9 balance

### DIFF
--- a/lib/ae_mdw/db/mutations/derive_aex9_presence_mutation.ex
+++ b/lib/ae_mdw/db/mutations/derive_aex9_presence_mutation.ex
@@ -4,6 +4,7 @@ defmodule AeMdw.Db.DeriveAex9PresenceMutation do
   """
 
   alias AeMdw.Aex9
+  alias AeMdw.Blocks
   alias AeMdw.Db.Contract
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
@@ -13,20 +14,22 @@ defmodule AeMdw.Db.DeriveAex9PresenceMutation do
   require Model
 
   @derive AeMdw.Db.Mutation
-  defstruct [:contract_pk, :create_txi, :balances]
+  defstruct [:contract_pk, :block_index, :create_txi, :balances]
 
   @typep aex9_balance() :: {Db.pubkey(), Aex9.amount()}
 
   @opaque t() :: %__MODULE__{
             contract_pk: Db.pubkey(),
+            block_index: Blocks.block_index(),
             create_txi: Txs.txi(),
             balances: [aex9_balance()]
           }
 
-  @spec new(Db.pubkey(), Txs.txi(), [aex9_balance()]) :: t()
-  def new(contract_pk, create_txi, balances) do
+  @spec new(Db.pubkey(), Blocks.block_index(), Txs.txi(), [aex9_balance()]) :: t()
+  def new(contract_pk, block_index, create_txi, balances) do
     %__MODULE__{
       contract_pk: contract_pk,
+      block_index: block_index,
       create_txi: create_txi,
       balances: balances
     }
@@ -36,6 +39,7 @@ defmodule AeMdw.Db.DeriveAex9PresenceMutation do
   def execute(
         %__MODULE__{
           contract_pk: contract_pk,
+          block_index: block_index,
           create_txi: create_txi,
           balances: balances
         },
@@ -45,6 +49,7 @@ defmodule AeMdw.Db.DeriveAex9PresenceMutation do
       m_balance =
         Model.aex9_balance(
           index: {contract_pk, account_pk},
+          block_index: block_index,
           amount: amount
         )
 

--- a/lib/ae_mdw/sync/async_tasks/derive_aex9_presence.ex
+++ b/lib/ae_mdw/sync/async_tasks/derive_aex9_presence.ex
@@ -41,10 +41,9 @@ defmodule AeMdw.Sync.AsyncTasks.DeriveAex9Presence do
           {account_pk, amount}
         end)
 
-      mutation = DeriveAex9PresenceMutation.new(contract_pk, create_txi, balances)
-      state = State.new()
+      mutation = DeriveAex9PresenceMutation.new(contract_pk, {kbi, mbi}, create_txi, balances)
 
-      State.commit(state, [mutation])
+      State.commit(State.new(), [mutation])
     end
 
     :ok

--- a/test/ae_mdw/sync/async_tasks/derive_aex9_presence_test.exs
+++ b/test/ae_mdw/sync/async_tasks/derive_aex9_presence_test.exs
@@ -1,0 +1,55 @@
+defmodule AeMdw.Sync.AsyncTasks.DeriveAex9PresenceTest do
+  use ExUnit.Case
+
+  alias AeMdw.Database
+  alias AeMdw.Db.Model
+  alias AeMdw.Sync.AsyncTasks.DeriveAex9Presence
+  alias AeMdw.Validate
+
+  import Mock
+
+  require Model
+
+  describe "process/1" do
+    test "writes aex9 presence and balance" do
+      kbi = 319_506
+      mbi = 101
+      create_txi = 16_063_684
+      amount1 = 323_838_000_000_000_000_000
+      amount2 = 198_554_400_000_000_000_000
+      kb_hash = Validate.id!("kh_2DQZpzmoTVvUUtRtLsamt2j6cN43YRcMtP6S8YCMehZ8DAbety")
+      Database.dirty_write(Model.Block, Model.block(index: {kbi + 1, -1}, hash: kb_hash))
+
+      next_mb_hash = Validate.id!("mh_2ShoazmibMsaaLfY9wnENSxJJATcD2HtyjHQPn9JCnUbsGPY18")
+      contract_pk = Validate.id("ct_ypGRSB6gEy8koLg6a4WRdShTfRsh9HfkMkxsE2SMCBk3JdkNP")
+      account_pk1 = Validate.id!("ak_2EETVuL9MaN8XjzeKVn42swLSf3fHpUTDMK1CEHnckRNKeK8z5")
+      account_pk2 = Validate.id!("ak_2pwi3Dqwmx84FMwU1KFUmnxpEABAkSo5L2o4LhAxWZBs9c57kX")
+
+      with_mocks [
+        {AeMdw.Node.Db, [],
+         [
+           get_next_hash: fn ^kb_hash, ^mbi -> next_mb_hash end,
+           aex9_balances: fn ^contract_pk, {nil, ^kbi, ^next_mb_hash} = block_tuple ->
+             balances = %{
+               {:address, account_pk1} => amount1,
+               {:address, account_pk2} => amount2
+             }
+
+             {balances, block_tuple}
+           end
+         ]}
+      ] do
+        DeriveAex9Presence.process([contract_pk, kbi, mbi, create_txi])
+
+        assert Model.aex9_balance(amount: ^amount1) =
+                 Database.fetch!(Model.Aex9Balance, {contract_pk, account_pk1})
+
+        assert Model.aex9_balance(amount: ^amount2) =
+                 Database.fetch!(Model.Aex9Balance, {contract_pk, account_pk2})
+
+        assert Database.exists?(Model.Aex9AccountPresence, {account_pk1, create_txi, contract_pk})
+        assert Database.exists?(Model.Aex9AccountPresence, {account_pk2, create_txi, contract_pk})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rebasing is sometimes cumbersome ...

- Fixes regression on aex9 balance after in-memory state.
- Adds test case to prevent similar case and to validate that both aex9 balance and presence were written.

PS: This requires a sync from scratch and a following PR will add the txi.