### PR TITLE
refactor: dirty reads + add Store abstraction

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -53,7 +53,7 @@ defmodule AeMdw.Db.Contract do
 
   @spec aex9_write_new_presence(state(), pubkey(), integer(), pubkey()) :: {boolean(), state()}
   def aex9_write_new_presence(state, contract_pk, txi, account_pk) do
-    if aex9_presence_exists?(contract_pk, account_pk, txi) do
+    if aex9_presence_exists?(state, contract_pk, account_pk, txi) do
       {false, state}
     else
       {true, aex9_write_presence(state, contract_pk, txi, account_pk)}
@@ -112,11 +112,12 @@ defmodule AeMdw.Db.Contract do
     end)
   end
 
-  @spec aex9_presence_exists?(pubkey(), pubkey(), integer()) :: boolean()
-  def aex9_presence_exists?(contract_pk, account_pk, txi) do
+  @spec aex9_presence_exists?(State.t(), pubkey(), pubkey(), integer()) :: boolean()
+  def aex9_presence_exists?(state, contract_pk, account_pk, txi) do
     txi_search_prev = txi + 1
 
-    case Database.prev_key(
+    case State.prev(
+           state,
            Model.Aex9AccountPresence,
            {account_pk, txi_search_prev, contract_pk}
          ) do

--- a/lib/ae_mdw/db/db_store.ex
+++ b/lib/ae_mdw/db/db_store.ex
@@ -1,0 +1,45 @@
+defmodule AeMdw.Db.DbStore do
+  @moduledoc """
+  Store implementation with operations reading/writing on the database directly,
+  without the need for a transaction.
+  """
+
+  alias AeMdw.Database
+
+  @derive AeMdw.Db.Store
+  defstruct []
+
+  @typep key() :: Database.key()
+  @typep record() :: Database.record()
+  @typep table() :: Database.table()
+  @opaque t() :: %__MODULE__{}
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @spec put(t(), table(), record()) :: t()
+  def put(store, table, record) do
+    Database.dirty_write(table, record)
+
+    store
+  end
+
+  @spec get(t(), table(), key()) :: {:ok, record()} | :not_found
+  def get(_store, table, key), do: Database.get(table, key)
+
+  @spec delete(t(), table(), key()) :: t()
+  def delete(store, table, key) do
+    Database.dirty_delete(table, key)
+
+    store
+  end
+
+  @spec next(t(), table(), key() | nil) :: {:ok, key()} | :none
+  def next(_store, table, key), do: Database.next_key(table, key)
+
+  @spec prev(t(), table(), key() | nil) :: {:ok, key()} | :none
+  def prev(_store, table, key), do: Database.prev_key(table, key)
+
+  @spec count_keys(t(), table()) :: non_neg_integer()
+  def count_keys(_store, table), do: Database.count(table)
+end

--- a/lib/ae_mdw/db/int_transfer.ex
+++ b/lib/ae_mdw/db/int_transfer.ex
@@ -7,7 +7,6 @@ defmodule AeMdw.Db.IntTransfer do
   alias AeMdw.Txs
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
-  alias AeMdw.Database
   alias AeMdw.Collection
 
   require Ex2ms
@@ -114,7 +113,7 @@ defmodule AeMdw.Db.IntTransfer do
       _other_height_kind -> false
     end)
     |> Enum.map(fn key ->
-      Model.int_transfer_tx(amount: amount) = Database.fetch!(Model.IntTransferTx, key)
+      Model.int_transfer_tx(amount: amount) = State.fetch!(state, Model.IntTransferTx, key)
       amount
     end)
     |> Enum.sum()

--- a/lib/ae_mdw/db/mutations/names_expiration_mutation.ex
+++ b/lib/ae_mdw/db/mutations/names_expiration_mutation.ex
@@ -5,7 +5,6 @@ defmodule AeMdw.Db.NamesExpirationMutation do
 
   alias AeMdw.Blocks
   alias AeMdw.Collection
-  alias AeMdw.Database
   alias AeMdw.Db.Model
   alias AeMdw.Db.Name
   alias AeMdw.Db.State
@@ -35,7 +34,7 @@ defmodule AeMdw.Db.NamesExpirationMutation do
     state
     |> Collection.stream(Model.AuctionExpiration, {height, <<>>})
     |> Stream.take_while(&match?({^height, _plain_name}, &1))
-    |> Enum.map(&Database.fetch!(Model.AuctionExpiration, &1))
+    |> Enum.map(&State.fetch!(state, Model.AuctionExpiration, &1))
     |> Enum.reduce(new_state, fn Model.expiration(
                                    index: {_height, plain_name},
                                    value: auction_timeout

--- a/lib/ae_mdw/db/store.ex
+++ b/lib/ae_mdw/db/store.ex
@@ -1,0 +1,38 @@
+defprotocol AeMdw.Db.Store do
+  @moduledoc """
+  Abstraction that provides a basic sorted key-value store.
+  """
+
+  alias AeMdw.Database
+
+  @typep key() :: Database.key()
+  @typep record() :: Database.record()
+  @typep table() :: Database.table()
+
+  @spec put(t(), table(), record()) :: t()
+  def put(store, table, record)
+
+  @spec get(t(), table(), key()) :: {:ok, record()} | :not_found
+  def get(store, table, key)
+
+  @spec delete(t(), table(), key()) :: t()
+  def delete(store, table, key)
+
+  @spec next(t(), table(), key() | nil) :: {:ok, key()} | :none
+  def next(store, table, key)
+
+  @spec prev(t(), table(), key() | nil) :: {:ok, key()} | :none
+  def prev(store, table, key)
+
+  @spec count_keys(t(), table()) :: non_neg_integer()
+  def count_keys(store, table)
+end
+
+defimpl AeMdw.Db.Store, for: Any do
+  def put(%mod{} = store, table, record), do: mod.put(store, table, record)
+  def get(%mod{} = store, table, key), do: mod.get(store, table, key)
+  def delete(%mod{} = store, table, key), do: mod.delete(store, table, key)
+  def next(%mod{} = store, table, key), do: mod.next(store, table, key)
+  def prev(%mod{} = store, table, key), do: mod.prev(store, table, key)
+  def count_keys(%mod{} = store, table), do: mod.count_keys(store, table)
+end

--- a/lib/ae_mdw/db/txn_db_store.ex
+++ b/lib/ae_mdw/db/txn_db_store.ex
@@ -1,0 +1,55 @@
+defmodule AeMdw.Db.TxnDbStore do
+  @moduledoc """
+  Store implementation with operations accessing the Database through an open
+  transaction.
+  """
+
+  alias AeMdw.Database
+
+  @derive AeMdw.Db.Store
+  defstruct [:txn]
+
+  @typep key() :: Database.key()
+  @typep record() :: Database.record()
+  @typep table() :: Database.table()
+  @opaque t() :: %__MODULE__{
+            txn: Database.transaction()
+          }
+
+  @spec transaction((t() -> term())) :: term()
+  def transaction(fun) do
+    txn = Database.transaction_new()
+
+    result = fun.(%__MODULE__{txn: txn})
+
+    Database.transaction_commit(txn)
+
+    result
+  end
+
+  @spec put(t(), table(), record()) :: t()
+  def put(%__MODULE__{txn: txn} = store, table, record) do
+    Database.write(txn, table, record)
+
+    store
+  end
+
+  @spec get(t(), table(), key()) :: {:ok, record()} | :not_found
+  def get(%__MODULE__{txn: txn}, table, key), do: Database.dirty_fetch(txn, table, key)
+
+  @spec delete(t(), table(), key()) :: t()
+  def delete(%__MODULE__{txn: txn} = store, table, key) do
+    Database.delete(txn, table, key)
+
+    store
+  end
+
+  @spec next(t(), table(), key() | nil) :: {:ok, key()} | :none
+  def next(%__MODULE__{txn: txn}, table, key), do: Database.dirty_next(txn, table, key)
+
+  @spec prev(t(), table(), key() | nil) :: {:ok, key()} | :none
+  def prev(%__MODULE__{txn: txn}, table, key), do: Database.dirty_prev(txn, table, key)
+
+  @spec count_keys(t(), table()) :: non_neg_integer()
+  def count_keys(%__MODULE__{txn: txn}, table), do: Database.dirty_count(txn, table)
+end

--- a/lib/ae_mdw/sync/async_tasks/stats.ex
+++ b/lib/ae_mdw/sync/async_tasks/stats.ex
@@ -74,7 +74,7 @@ defmodule AeMdw.Sync.AsyncTasks.Stats do
   end
 
   defp update_db_count() do
-    db_pending_count = Database.count_keys(Model.AsyncTasks)
+    db_pending_count = Database.count(Model.AsyncTasks)
     :ets.update_element(@tab, @stats_key, {@db_count_pos, db_pending_count})
   end
 

--- a/test/ae_mdw/db/mutations/stats_mutation_test.exs
+++ b/test/ae_mdw/db/mutations/stats_mutation_test.exs
@@ -230,11 +230,11 @@ defmodule AeMdw.Db.StatsMutationTest do
       with_mocks [
         {Database, [],
          [
-           dirty_fetch: fn
-             _txn, Model.TotalStat, ^height -> {:ok, Model.total_stat(active_auctions: 1)}
-             _txn, Model.InactiveName, _plain_name -> {:ok, Model.name()}
+           get: fn
+             Model.TotalStat, ^height -> {:ok, Model.total_stat(active_auctions: 1)}
+             Model.InactiveName, _plain_name -> {:ok, Model.name()}
            end,
-           count_keys: fn
+           count: fn
              Model.ActiveName -> 3
              Model.ActiveOracle -> 4
              Model.AuctionExpiration -> 5
@@ -305,7 +305,7 @@ defmodule AeMdw.Db.StatsMutationTest do
       with_mocks [
         {Database, [],
          [
-           dirty_fetch: fn _txn, Model.TotalStat, ^height ->
+           get: fn Model.TotalStat, ^height ->
              {:ok, Model.total_stat(active_auctions: 1)}
            end
          ]},

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -23,19 +23,17 @@ defmodule AeMdwWeb.OracleControllerTest do
       with_mocks [
         {Database, [],
          [
-           next_key: fn
-             ActiveOracleExpiration, :backward, nil ->
+           prev_key: fn
+             ActiveOracleExpiration, nil ->
                {:ok, TS.oracle_expiration_key(1)}
 
-             ActiveOracleExpiration, :backward, {exp, plain_name} ->
+             ActiveOracleExpiration, {exp, plain_name} ->
                {:ok, {exp - 1, "a#{plain_name}"}}
 
-             InactiveOracleExpiration, :backward, nil ->
-               :none
-
-             _tab, :forward, nil ->
+             InactiveOracleExpiration, nil ->
                :none
            end,
+           next_key: fn _tab, nil -> :none end,
            last_key: fn Block -> {:ok, last_gen} end,
            fetch!: fn _tab, _pk -> oracle end
          ]},
@@ -65,14 +63,14 @@ defmodule AeMdwWeb.OracleControllerTest do
       with_mocks [
         {Database, [],
          [
-           next_key: fn
-             ActiveOracleExpiration, :backward, nil -> {:ok, {1, "a"}}
-             ActiveOracleExpiration, :backward, {0, _plain_name} -> :none
-             ActiveOracleExpiration, :backward, {exp, "a"} -> {:ok, {exp - 1, "a"}}
-             InactiveOracleExpiration, :backward, nil -> {:ok, {1, "b"}}
-             InactiveOracleExpiration, :backward, {0, "b"} -> :none
-             InactiveOracleExpiration, :backward, {exp, "b"} -> {:ok, {exp - 1, "b"}}
-             _tab, :forward, _key -> :none
+           next_key: fn _tab, _key -> :none end,
+           prev_key: fn
+             ActiveOracleExpiration, nil -> {:ok, {1, "a"}}
+             ActiveOracleExpiration, {0, _plain_name} -> :none
+             ActiveOracleExpiration, {exp, "a"} -> {:ok, {exp - 1, "a"}}
+             InactiveOracleExpiration, nil -> {:ok, {1, "b"}}
+             InactiveOracleExpiration, {0, "b"} -> :none
+             InactiveOracleExpiration, {exp, "b"} -> {:ok, {exp - 1, "b"}}
            end,
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> oracle end
@@ -103,11 +101,11 @@ defmodule AeMdwWeb.OracleControllerTest do
          [
            last_key: fn Block -> {:ok, TS.last_gen()} end,
            fetch!: fn _tab, _oracle_pk -> oracle end,
-           next_key: fn
-             _tab, :backward, ^key1 -> {:ok, key2}
-             _tab, :backward, nil -> {:ok, key1}
-             _tab, :backward, ^key2 -> :none
-             _tab, :forward, _key -> :none
+           next_key: fn _tab, _key -> :none end,
+           prev_key: fn
+             _tab, ^key1 -> {:ok, key2}
+             _tab, nil -> {:ok, key1}
+             _tab, ^key2 -> :none
            end
          ]},
         {Oracle, [], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},
@@ -134,7 +132,8 @@ defmodule AeMdwWeb.OracleControllerTest do
         {Database, [],
          [
            last_key: fn Block -> {:ok, TS.last_gen()} end,
-           next_key: fn ActiveOracleExpiration, _dir, _key -> {:ok, expiration_key} end,
+           next_key: fn ActiveOracleExpiration, _key -> {:ok, expiration_key} end,
+           prev_key: fn ActiveOracleExpiration, _key -> {:ok, expiration_key} end,
            fetch!: fn _tab, _oracle_pk -> TS.oracle() end
          ]},
         {Oracle, [], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},


### PR DESCRIPTION
This Store abstraction will be the basic protocol that the memory
store will need to implement later on. Wanted to add it on a separate
PR.

Additionally, update all mutation reads to make sure they are read
from data belonging to the transaction.

Next up: `MemStore` implementation