### PR TITLE
fix: ignore aex9 balances only when there's a single <<>> balance

### DIFF
--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -75,7 +75,7 @@ defmodule AeMdw.Aex9 do
         amounts when map_size(amounts) == 0 ->
           raise ErrInput.Aex9BalanceNotAvailable, value: "contract #{enc_ct(contract_pk)}"
 
-        %{{:address, <<>>} => nil} ->
+        %{{:address, <<>>} => nil} = amounts when map_size(amounts) == 1 ->
           %{}
 
         amounts ->


### PR DESCRIPTION
This record with <<>> account_pk and nil amount is created to display
to the user that the contract has not yet being processed for
balances.