### PR TITLE
refactor: invalidate aexn contract

### DIFF
--- a/lib/ae_mdw/db/rocksdb_cf.ex
+++ b/lib/ae_mdw/db/rocksdb_cf.ex
@@ -129,14 +129,14 @@ defmodule AeMdw.Db.RocksDbCF do
   def dirty_prev(txn, table, seek_index) do
     {:ok, it} = RocksDb.dirty_iterator(txn, table)
 
-    iterator_prev_key(it, table, seek_index)
+    iterator_prev_key(it, seek_index)
   end
 
   @spec prev_key(table(), key()) :: {:ok, key()} | :not_found
   def prev_key(table, seek_index) do
     {:ok, it} = RocksDb.iterator(table)
 
-    iterator_prev_key(it, table, seek_index)
+    iterator_prev_key(it, seek_index)
   end
 
   @spec dirty_put(table(), record()) :: :ok | {:error, any}
@@ -227,7 +227,7 @@ defmodule AeMdw.Db.RocksDbCF do
     key_res
   end
 
-  defp iterator_prev_key(it, table, seek_index) do
+  defp iterator_prev_key(it, seek_index) do
     seek_key = :sext.encode(seek_index)
 
     key_res =
@@ -240,7 +240,7 @@ defmodule AeMdw.Db.RocksDbCF do
           end
 
         :not_found ->
-          last_key(table)
+          :not_found
       end
 
     RocksDb.iterator_close(it)

--- a/test/ae_mdw/db/contract_call_mutation_test.exs
+++ b/test/ae_mdw/db/contract_call_mutation_test.exs
@@ -92,12 +92,15 @@ defmodule AeMdw.Db.ContractCallMutationTest do
       )
 
       kb_hash = <<123_452::256>>
-      Database.dirty_write(Model.Block, Model.block(index: {kbi + 1, -1}, hash: kb_hash))
       next_mb_hash = Validate.id!("mh_2Kf3h4eYi77yvMg9HtLMLX9zJtThm6xBCbefCbKQpSi8Rxrcgy")
 
       with_mocks [
         {AeMdw.Node.Db, [],
          [
+           get_key_block_hash: fn height ->
+             assert ^height = kbi + 1
+             kb_hash
+           end,
            get_next_hash: fn ^kb_hash, ^mbi -> next_mb_hash end,
            aex9_balances: fn ^contract_pk, {:micro, ^kbi, ^next_mb_hash} ->
              balances = %{{:address, account_pk} => 100_000_000_000_000_002}
@@ -178,7 +181,6 @@ defmodule AeMdw.Db.ContractCallMutationTest do
       )
 
       kb_hash = <<123_454::256>>
-      Database.dirty_write(Model.Block, Model.block(index: {kbi + 1, -1}, hash: kb_hash))
       next_mb_hash = Validate.id!("mh_9943pc2nXD7BaJjZMwaAYd5Jk4DbPY3THDoh8Sfgy7nTyrZ41")
 
       with_mocks [

--- a/test/ae_mdw/sync/invalidate_test.exs
+++ b/test/ae_mdw/sync/invalidate_test.exs
@@ -1,0 +1,58 @@
+defmodule AeMdw.Db.Sync.InvalidateTest do
+  use ExUnit.Case, async: false
+
+  alias AeMdw.Database
+  alias AeMdw.Db.Aex9CreateContractMutation
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Sync.Invalidate
+  alias AeMdw.Db.WriteMutation
+
+  require Model
+
+  describe "aexn_key_dels" do
+    test "return empty lists" do
+      assert %{
+               Model.AexnContract => [],
+               Model.AexnContractName => [],
+               Model.AexnContractSymbol => []
+             } = Invalidate.aexn_key_dels(100..1000)
+    end
+
+    test "return keys to delete within the txi range" do
+      pk1 = :crypto.strong_rand_bytes(32)
+      pk2 = :crypto.strong_rand_bytes(32)
+      pk3 = :crypto.strong_rand_bytes(32)
+      create_txi1 = abs(System.unique_integer())
+      create_txi2 = create_txi1 + 10
+      create_txi3 = create_txi1 + 20
+      meta_info1 = {"name1", "SYM1", 18}
+      meta_info2 = {"name2", "SYM2", 18}
+      meta_info3 = {"name3", "SYM3", 18}
+
+      rev_origin1 = {create_txi1, :contract_create_tx, pk1}
+      rev_origin2 = {create_txi2, :contract_create_tx, pk2}
+      rev_origin3 = {create_txi3, :contract_create_tx, pk3}
+
+      on_exit(fn ->
+        Database.dirty_delete(Model.RevOrigin, rev_origin1)
+        Database.dirty_delete(Model.RevOrigin, rev_origin2)
+        Database.dirty_delete(Model.RevOrigin, rev_origin3)
+      end)
+
+      Database.commit([
+        WriteMutation.new(Model.RevOrigin, Model.rev_origin(index: rev_origin1)),
+        WriteMutation.new(Model.RevOrigin, Model.rev_origin(index: rev_origin2)),
+        WriteMutation.new(Model.RevOrigin, Model.rev_origin(index: rev_origin3)),
+        Aex9CreateContractMutation.new(pk1, meta_info1, {10, 0}, create_txi1),
+        Aex9CreateContractMutation.new(pk2, meta_info2, {11, 0}, create_txi2),
+        Aex9CreateContractMutation.new(pk3, meta_info3, {12, 0}, create_txi3)
+      ])
+
+      assert %{
+               Model.AexnContract => [{:aex9, ^pk3}, {:aex9, ^pk2}],
+               Model.AexnContractName => [{:aex9, "name3", ^pk3}, {:aex9, "name2", ^pk2}],
+               Model.AexnContractSymbol => [{:aex9, "SYM3", ^pk3}, {:aex9, "SYM2", ^pk2}]
+             } = Invalidate.aexn_key_dels(create_txi2..(create_txi2 + 100))
+    end
+  end
+end


### PR DESCRIPTION
## What

- Invalidates/delestes all aexn records within a txi range
- Eliminates use of RevAex9Contract

## Why

Continuation of https://github.com/aeternity/ae_mdw/pull/667#issue-1226739507
Refs https://github.com/aeternity/ae_mdw/issues/629

## Validation steps

`elixir --sname aeternity@localhost -S mix test test/ae_mdw/sync/invalidate_test.exs`