### PR TITLE
fix: remove aex9 presence for remote calls

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -216,7 +216,7 @@ defmodule AeMdw.Db.Contract do
       aex9_contract_pk = which_aexn_contract_pubkey(contract_pk, addr)
 
       if is_aex9_transfer?(evt_hash, aex9_contract_pk) do
-        write_aex9_records(state3, aex9_contract_pk, txi, i, args)
+        write_aex9_records(state3, txi, i, args)
       else
         state3
       end
@@ -368,7 +368,7 @@ defmodule AeMdw.Db.Contract do
     &(byte_size(&1) >= len && :binary.part(&1, 0, len) == prefix)
   end
 
-  defp write_aex9_records(state, contract_pk, txi, i, [from_pk, to_pk, <<amount::256>>]) do
+  defp write_aex9_records(state, txi, i, [from_pk, to_pk, <<amount::256>>]) do
     m_transfer = Model.aex9_transfer(index: {from_pk, txi, to_pk, amount, i})
     m_rev_transfer = Model.rev_aex9_transfer(index: {to_pk, txi, from_pk, amount, i})
     m_idx_transfer = Model.idx_aex9_transfer(index: {txi, i, from_pk, to_pk, amount})
@@ -379,7 +379,6 @@ defmodule AeMdw.Db.Contract do
     |> State.put(Model.RevAex9Transfer, m_rev_transfer)
     |> State.put(Model.IdxAex9Transfer, m_idx_transfer)
     |> State.put(Model.Aex9PairTransfer, m_pair_transfer)
-    |> aex9_write_presence(contract_pk, txi, to_pk)
   end
 
   defp fetch_aex9_balance_or_new(state, contract_pk, account_pk) do

--- a/lib/ae_mdw_web/controllers/aex9_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex9_controller.ex
@@ -8,7 +8,6 @@ defmodule AeMdwWeb.Aex9Controller do
   alias AeMdw.Error.Input, as: ErrInput
   alias AeMdw.Node.Db, as: DBN
   alias AeMdw.Db.Contract
-  alias AeMdw.Db.Origin
   alias AeMdw.Db.Util
   alias AeMdw.Aex9
   alias AeMdwWeb.DataStreamPlug, as: DSPlug
@@ -341,9 +340,8 @@ defmodule AeMdwWeb.Aex9Controller do
       contracts
       |> Enum.map(fn {contract_pk, txi_list} ->
         {amount, _} = DBN.aex9_balance(contract_pk, account_pk, height_hash)
-        create_txi = Origin.tx_index!({:contract, contract_pk})
         call_txi = List.last(txi_list)
-        {amount, create_txi, call_txi, contract_pk}
+        {amount, call_txi, contract_pk}
       end)
       |> Enum.map(&balance_to_map/1)
 


### PR DESCRIPTION
## What

- Skips writing `Aex9AccountPresence` for remote calls

## Why

- Aex9 balances are not yet computed for remote calls (shall be part of the scope of #308)

## Notes

- Additionally this PR fixes test cases used to test the root cause of the error