### PR TITLE
chore: revert swagger name operation names

### DIFF
--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -801,7 +801,7 @@ defmodule AeMdwWeb.NameController do
     description("Get name information for given acount/owner")
     produces(["application/json"])
     deprecated(false)
-    operation_id("get_names_owned_by")
+    operation_id("get_owned_by")
     tag("Middleware")
 
     parameters do
@@ -880,7 +880,7 @@ defmodule AeMdwWeb.NameController do
     description("Get pointers for given name.")
     produces(["application/json"])
     deprecated(false)
-    operation_id("get_name_pointers")
+    operation_id("get_pointers_by_id")
     tag("Middleware")
 
     parameters do
@@ -899,7 +899,7 @@ defmodule AeMdwWeb.NameController do
     description("Get names pointing to a particular pubkey.")
     produces(["application/json"])
     deprecated(false)
-    operation_id("get_name_pointees")
+    operation_id("get_pointees_by_id")
     tag("Middleware")
 
     parameters do


### PR DESCRIPTION
Since the SDK client depends on operation names to programatially
generate the client API, we're reverting the swagger v1 endpoint names
so that it doesn't introduce breaking changes.

In the future, a new swagger file will be added with all of the new
and updated operations containing v2 endpoints.

refs #179