### PR TITLE
fix: handle update aex9 state on contract create logs

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -168,7 +168,7 @@ defmodule AeMdw.Db.Contract do
     State.put(state, Model.ContractCall, m_call)
   end
 
-  @spec logs_write(state(), block_index() | nil, txi(), txi(), Contract.call()) :: state()
+  @spec logs_write(state(), block_index(), txi(), txi(), Contract.call()) :: state()
   def logs_write(state, block_index, create_txi, txi, call_rec) do
     contract_pk = :aect_call.contract_pubkey(call_rec)
     raw_logs = :aect_call.log(call_rec)

--- a/lib/ae_mdw/db/mutations/contract_create_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_create_mutation.ex
@@ -3,25 +3,29 @@ defmodule AeMdw.Db.ContractCreateMutation do
   Processes contract_create_tx.
   """
 
+  alias AeMdw.Blocks
   alias AeMdw.Contract
   alias AeMdw.Db.Contract, as: DBContract
   alias AeMdw.Db.State
   alias AeMdw.Txs
 
   @derive AeMdw.Db.Mutation
-  defstruct [:txi, :call_rec]
+  defstruct [:block_index, :txi, :call_rec]
 
   @opaque t() :: %__MODULE__{
+            block_index: Blocks.block_index(),
             txi: Txs.txi(),
             call_rec: Contract.call()
           }
 
   @spec new(
+          Blocks.block_index(),
           Txs.txi(),
           Contract.call()
         ) :: t()
-  def new(txi, call_rec) do
+  def new(block_index, txi, call_rec) do
     %__MODULE__{
+      block_index: block_index,
       txi: txi,
       call_rec: call_rec
     }
@@ -30,6 +34,7 @@ defmodule AeMdw.Db.ContractCreateMutation do
   @spec execute(t(), State.t()) :: State.t()
   def execute(
         %__MODULE__{
+          block_index: block_index,
           txi: txi,
           call_rec: call_rec
         },
@@ -40,6 +45,6 @@ defmodule AeMdw.Db.ContractCreateMutation do
     state
     |> State.inc_stat(:contracts_created)
     |> State.cache_put(:ct_create_sync_cache, contract_pk, txi)
-    |> DBContract.logs_write(nil, txi, txi, call_rec)
+    |> DBContract.logs_write(block_index, txi, txi, call_rec)
   end
 end

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -136,7 +136,7 @@ defmodule AeMdw.Db.Sync.Transaction do
         events_mutations,
         [
           aex9_create_contract_mutation,
-          ContractCreateMutation.new(txi, call_rec)
+          ContractCreateMutation.new(block_index, txi, call_rec)
         ]
       ])
     else

--- a/test/ae_mdw/db/contract_create_mutation_test.exs
+++ b/test/ae_mdw/db/contract_create_mutation_test.exs
@@ -1,0 +1,73 @@
+defmodule AeMdw.Db.ContractCreateMutationTest do
+  use ExUnit.Case, async: false
+
+  import AeMdw.Node.ContractCallFixtures
+  import Mock
+
+  alias AeMdw.Db.ContractCreateMutation
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Sync.Contract, as: SyncContract
+  alias AeMdw.Db.Sync.Origin
+  alias AeMdw.Sync.AsyncTasks
+
+  setup_all _context do
+    AsyncTasks.Supervisor.start_link([])
+
+    :ok
+  end
+
+  describe "execute" do
+    test "creates contract with init aex9 log" do
+      remote_pk = :crypto.strong_rand_bytes(32)
+      remote_meta_info = {"aex9t", "AEX9t", 18}
+
+      with_mocks [
+        {
+          AeMdw.Contract,
+          [],
+          [
+            is_aex9?: fn ct_pk -> ct_pk == remote_pk end,
+            aex9_meta_info: fn ct_pk -> ct_pk == remote_pk && {:ok, remote_meta_info} end
+          ]
+        }
+      ] do
+        block_index = {492_393, 0}
+        create_txi1 = 21_608_343
+        call_rec1 = call_rec("no_log", remote_pk, create_txi1)
+
+        state1 =
+          State.commit(State.new(), [
+            ContractCreateMutation.new(block_index, create_txi1, call_rec1),
+            SyncContract.aex9_create_contract_mutation(remote_pk, block_index, create_txi1),
+            Origin.origin_mutations(
+              :contract_create_tx,
+              nil,
+              remote_pk,
+              create_txi1,
+              :crypto.strong_rand_bytes(32)
+            )
+          ])
+
+        assert 1 == State.get_stat(state1, :contracts_created, 0)
+        assert {:ok, create_txi1} == State.cache_get(state1, :ct_create_sync_cache, remote_pk)
+
+        create_txi2 = create_txi1 + 1
+        contract_pk = :crypto.strong_rand_bytes(32)
+        call_rec2 = call_rec("remote_log", contract_pk, remote_pk, create_txi2)
+
+        state2 =
+          State.commit(state1, [ContractCreateMutation.new(block_index, create_txi2, call_rec2)])
+
+        assert 2 == State.get_stat(state2, :contracts_created, 0)
+        assert {:ok, create_txi2} == State.cache_get(state2, :ct_create_sync_cache, contract_pk)
+
+        assert %{enqueue_buffer: enqueue_buffer} = :sys.get_state(AsyncTasks.Producer)
+
+        assert Enum.any?(
+                 enqueue_buffer,
+                 &(&1 == {:update_aex9_state, [remote_pk], [block_index, create_txi2]})
+               )
+      end
+    end
+  end
+end

--- a/test/ae_mdw/db/contract_create_mutation_test.exs
+++ b/test/ae_mdw/db/contract_create_mutation_test.exs
@@ -10,12 +10,6 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
   alias AeMdw.Db.Sync.Origin
   alias AeMdw.Sync.AsyncTasks
 
-  setup_all _context do
-    AsyncTasks.Supervisor.start_link([])
-
-    :ok
-  end
-
   describe "execute" do
     test "creates contract with init aex9 log" do
       remote_pk = :crypto.strong_rand_bytes(32)
@@ -31,6 +25,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
           ]
         }
       ] do
+        AsyncTasks.Supervisor.start_link([])
         block_index = {492_393, 0}
         create_txi1 = 21_608_343
         call_rec1 = call_rec("no_log", remote_pk, create_txi1)

--- a/test/support/ae_mdw/node/contract_call_fixtures.ex
+++ b/test/support/ae_mdw/node/contract_call_fixtures.ex
@@ -1,9 +1,10 @@
 defmodule AeMdw.Node.ContractCallFixtures do
   @moduledoc false
 
-  @type fname() :: String.t()
-  @type fun_arg_res() :: map()
-  @type call_record() :: tuple()
+  @typep pubkey :: AeMdw.Node.Db.pubkey()
+  @type fname :: String.t()
+  @type fun_arg_res :: map()
+  @type call_record :: tuple()
 
   @spec fun_args_res(fname()) :: %{arguments: list(), function: fname(), result: map()}
   def fun_args_res("mint") do
@@ -339,6 +340,35 @@ defmodule AeMdw.Node.ContractCallFixtures do
           <<65, 110, 123, 208, 148, 244, 99, 197, 242, 18, 123, 8, 185, 211, 87, 178, 24, 148,
             241, 255, 75, 209, 104, 190, 48, 36, 223, 251, 112, 185, 157, 10>>
         ], "16"}
+     ]}
+  end
+
+  @spec call_rec(fname(), pubkey(), AeMdw.Txs.txi()) :: call_record()
+  def call_rec("no_log", contract_pk, txi) do
+    {:call,
+     <<7, 3, 220, 129, 25, 69, 185, 205, 148, 53, 54, 115, 161, 72, 225, 149, 238, 18, 80, 50,
+       185, 167, 125, 140, 71, 128, 149, 100, 229, 81, 223, 196>>, {:id, :account, <<1::256>>},
+     41, txi, {:id, :contract, contract_pk}, 1_000_000_000, 22_929,
+     <<159, 2, 160, 111, 0, 117, 208, 6, 235, 44, 43, 240, 108, 173, 15, 111, 153, 4, 169, 116,
+       46, 60, 160, 41, 181, 143, 70, 46, 129, 67, 189, 118, 173, 96, 204>>, :ok, []}
+  end
+
+  @spec call_rec(fname(), pubkey(), pubkey(), AeMdw.Txs.txi()) :: call_record()
+  def call_rec("remote_log", contract_pk, remote_pk, txi) do
+    {:call,
+     <<7, 3, 220, 129, 25, 69, 185, 205, 148, 53, 54, 115, 161, 72, 225, 149, 238, 18, 80, 50,
+       185, 167, 125, 140, 71, 128, 149, 100, 229, 81, 223, 196>>, {:id, :account, <<1::256>>},
+     41, txi, {:id, :contract, contract_pk}, 1_000_000_000, 22_929,
+     <<159, 2, 160, 111, 0, 117, 208, 6, 235, 44, 43, 240, 108, 173, 15, 111, 153, 4, 169, 116,
+       46, 60, 160, 41, 181, 143, 70, 46, 129, 67, 189, 118, 173, 96, 204>>, :ok,
+     [
+       {remote_pk,
+        [
+          <<165, 104, 218, 83, 242, 206, 42, 48, 134, 199, 10, 251, 46, 174, 228, 68, 181, 162,
+            20, 101, 150, 189, 240, 53, 189, 254, 113, 142, 221, 171, 31, 107>>,
+          <<83, 107, 86, 97, 199, 199, 69, 232, 131, 106, 241, 190, 181, 55, 62, 215, 254, 27,
+            189, 54, 54, 3, 152, 10, 245, 52, 84, 143, 225, 73, 60, 7>>
+        ], "1"}
      ]}
   end
 end


### PR DESCRIPTION
## What /Why

Fix contract creation having aex9 logs.

## Validation steps

`elixir --sname aeternity@localhost -S mix test test/ae_mdw/db/contract_create_mutation_test.exs`