### PR TITLE
fix: display unencoded block hash when not found

### DIFF
--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -77,13 +77,19 @@ defmodule AeMdw.Blocks do
 
   @spec fetch(State.t(), block_index() | block_hash()) :: {:ok, block()} | {:error, Error.t()}
   def fetch(state, block_hash) when is_binary(block_hash) do
-    case :aec_chain.get_block(block_hash) do
-      {:ok, _block} ->
-        # note: the `nil` here - for json formatting, we reuse AE node code
-        {:ok, Format.to_map(state, {:block, {nil, nil}, nil, block_hash})}
+    case Validate.id(block_hash) do
+      {:ok, encoded_hash} ->
+        case :aec_chain.get_block(encoded_hash) do
+          {:ok, _block} ->
+            # note: the `nil` here - for json formatting, we reuse AE node code
+            {:ok, Format.to_map(state, {:block, {nil, nil}, nil, encoded_hash})}
 
-      :error ->
-        {:error, Error.Input.NotFound.exception(value: block_hash)}
+          :error ->
+            {:error, Error.Input.NotFound.exception(value: block_hash)}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -77,19 +77,13 @@ defmodule AeMdw.Blocks do
 
   @spec fetch(State.t(), block_index() | block_hash()) :: {:ok, block()} | {:error, Error.t()}
   def fetch(state, block_hash) when is_binary(block_hash) do
-    case Validate.id(block_hash) do
-      {:ok, encoded_hash} ->
-        case :aec_chain.get_block(encoded_hash) do
-          {:ok, _block} ->
-            # note: the `nil` here - for json formatting, we reuse AE node code
-            {:ok, Format.to_map(state, {:block, {nil, nil}, nil, encoded_hash})}
-
-          :error ->
-            {:error, Error.Input.NotFound.exception(value: block_hash)}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
+    with {:ok, encoded_hash} <- Validate.id(block_hash),
+         {:ok, _block} <- :aec_chain.get_block(encoded_hash) do
+      # note: the `nil` here - for json formatting, we reuse AE node code
+      {:ok, Format.to_map(state, {:block, {nil, nil}, nil, encoded_hash})}
+    else
+      :error -> {:error, Error.Input.NotFound.exception(value: block_hash)}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/lib/ae_mdw_web/controllers/block_controller.ex
+++ b/lib/ae_mdw_web/controllers/block_controller.ex
@@ -24,9 +24,9 @@ defmodule AeMdwWeb.BlockController do
         blocki(conn, Map.put(params, "kbi", hash_or_kbi))
 
       :error ->
-        with {:ok, block_hash} <- Validate.id(hash_or_kbi),
-             {:ok, block} <- Blocks.fetch(state, block_hash) do
-          json(conn, block)
+        case Blocks.fetch(state, hash_or_kbi) do
+          {:ok, block} -> json(conn, block)
+          {:error, reason} -> {:error, reason}
         end
     end
   end

--- a/test/integration/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/block_controller_test.exs
@@ -279,6 +279,13 @@ defmodule Integration.AeMdwWeb.BlockControllerTest do
       assert json_response(conn, 400) ==
                %{"error" => "invalid range: #{range}"}
     end
+
+    test "when block is not found, it returns a 404 error message", %{conn: conn} do
+      hash = "kh_2bXDk3CW3qfFSriMtaFnQUKvNr4wNFZn3tPpRLmKCse4jHmt5U"
+      error_msg = "not found: #{hash}"
+
+      assert %{"error" => ^error_msg} = conn |> get("/v2/blocks/#{hash}") |> json_response(404)
+    end
   end
 
   ################


### PR DESCRIPTION
Previously the value displayed was the Elixir binary representation
(e.g. `<<210, 20, 143, ...>>`). Instead, the AE encoded hash is used
as displayed on the URL.