### PR TITLE
feat: set low gas limit relative to Node base gas

### DIFF
--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -171,9 +171,9 @@ defmodule AeMdw.Contract do
   def call_contract(contract_pk, function_name, args),
     do: call_contract(contract_pk, DBN.top_height_hash(false), function_name, args)
 
-  def call_contract(contract_pk, {_type, _height, block_hash}, function_name, args) do
+  def call_contract(contract_pk, {_type, height, block_hash}, function_name, args) do
     contract_pk
-    |> DryRun.Runner.new_contract_call_tx(block_hash, function_name, args)
+    |> DryRun.Runner.new_contract_call_tx(height, block_hash, function_name, args)
     |> DryRun.Runner.dry_run(block_hash)
     |> case do
       {:ok, {[contract_call_tx: {:ok, call_res}], _events}} ->

--- a/lib/ae_mdw/dry_run/contract.ex
+++ b/lib/ae_mdw/dry_run/contract.ex
@@ -9,7 +9,7 @@ defmodule AeMdw.DryRun.Contract do
   @typep block_hash() :: <<_::256>>
 
   @abi_fate_sophia_1 3
-  @gas 10_000_000_000_000_000_000
+  @gas 10_000_000_000_000_000_000_000
 
   @spec new_call_tx(
           pubkey(),
@@ -41,12 +41,18 @@ defmodule AeMdw.DryRun.Contract do
       abi_version: abi_version(),
       amount: 0,
       gas: gas,
-      gas_price: div(min_gas_price(), 1000),
+      gas_price: min_gas_price(),
       call_data: call_data,
       fee: 200 * min_gas_price()
     }
     |> :aect_call_tx.new()
     |> Util.ok!()
+  end
+
+  @spec call_tx_base_gas(AeMdw.Blocks.height()) :: pos_integer()
+  def call_tx_base_gas(height) do
+    protocol = :aec_hard_forks.protocol_effective_at_height(height)
+    :aec_governance.tx_base_gas(:contract_call_tx, protocol, abi_version())
   end
 
   defp min_gas_price do

--- a/lib/ae_mdw/dry_run/runner.ex
+++ b/lib/ae_mdw/dry_run/runner.ex
@@ -5,15 +5,16 @@ defmodule AeMdw.DryRun.Runner do
 
   alias AeMdw.DryRun.Contract
 
-  @typep pubkey() :: <<_::256>>
-  @typep block_hash() :: <<_::256>>
+  @typep pubkey() :: AeMdw.Node.Db.pubkey()
+  @typep block_hash() :: AeMdw.Blocks.block_hash()
+  @typep height() :: AeMdw.Blocks.height()
 
   # arbitrary new pk to run the calls
   @runner_pk <<13, 24, 60, 171, 170, 28, 99, 114, 174, 14, 112, 19, 49, 53, 233, 194, 46, 149,
                172, 14, 114, 22, 38, 51, 153, 136, 58, 149, 27, 56, 30, 105>>
 
   @amount trunc(:math.pow(10, 35))
-  @extension_gas_limit 100_000
+  @low_gas_limit_factor 1.5
   @extension_methods ["aex9_extensions", "aex141_extensions"]
 
   @doc """
@@ -29,20 +30,28 @@ defmodule AeMdw.DryRun.Runner do
   @doc """
   Creates a contract call transaction record (without running it).
   """
-  @spec new_contract_call_tx(pubkey(), block_hash(), String.t(), list()) :: tuple()
-  def new_contract_call_tx(contract_pk, block_hash, function_name, args)
-      when function_name in @extension_methods do
+  @spec new_contract_call_tx(
+          pubkey(),
+          height(),
+          block_hash(),
+          AeMdw.Contract.method_name(),
+          AeMdw.Contract.method_args()
+        ) :: tuple()
+  def new_contract_call_tx(contract_pk, height, block_hash, function_name, args)
+      when function_name == "meta_info" or function_name in @extension_methods do
+    base_gas = Contract.call_tx_base_gas(height)
+
     Contract.new_call_tx(
       @runner_pk,
       contract_pk,
       block_hash,
       function_name,
       args,
-      @extension_gas_limit
+      trunc(base_gas * @low_gas_limit_factor)
     )
   end
 
-  def new_contract_call_tx(contract_pk, block_hash, function_name, args) do
+  def new_contract_call_tx(contract_pk, _height, block_hash, function_name, args) do
     Contract.new_call_tx(@runner_pk, contract_pk, block_hash, function_name, args)
   end
 end


### PR DESCRIPTION
## What

Set dynamic low `gas limit` relative to Node base gas for aexn `meta_info` and `aex*_extensions` methods

## Why

Refs #713 

## Validation steps

aex9 (mainnet)
```
iex(aeternity@localhost)1> pk = Validate.id! "ct_M9yohHgcLjhpp1Z8SaA1UTmRMQzR4FWjJHajGga8KBoZTEPwC"
<<45, 195, 148, 17, 5, 88, 182, 202, 65, 160, 150, 218, 33, 163, 136, 171, 149,
  101, 165, 178, 212, 56, 89, 23, 172, 233, 200, 126, 138, 235, 158, 11>>
iex(aeternity@localhost)2> AeMdw.AexnContracts.call_extensions(:aex9, pk)                          
{:ok, ["allowances", "mintable", "burnable", "swappable"]}
```

aex141 (testnet)
```
iex(aeternity@localhost)3> pk = Validate.id! "ct_AC8mHZ4xucA6mjk6gtXMDbs3FtHYds3Wm1oWdKYHhPyBtm9vj"
<<20, 223, 25, 21, 30, 145, 133, 175, 231, 153, 252, 160, 158, 79, 250, 88, 43,
  242, 20, 103, 189, 134, 72, 165, 194, 232, 24, 220, 161, 234, 79, 236>>
iex(aeternity@localhost)4> AeMdw.AexnContracts.call_extensions(:aex141, pk)                        
{:ok, ["mintable", "burnable"]}
```