### PR TITLE
refactor: enable credo and move dry run code to specific module

### DIFF
--- a/lib/ae_mdw/aexn_contracts.ex
+++ b/lib/ae_mdw/aexn_contracts.ex
@@ -7,6 +7,7 @@ defmodule AeMdw.AexnContracts do
 
   alias AeMdw.Contract
   alias AeMdw.Db.Model
+  alias AeMdw.DryRun.Runner
   alias AeMdw.Node.Db, as: NodeDb
   alias AeMdw.Log
 
@@ -89,7 +90,7 @@ defmodule AeMdw.AexnContracts do
   defp call_contract(contract_pk, method, args \\ []) do
     top_hash = NodeDb.top_height_hash(false)
 
-    case Contract.call_contract(contract_pk, top_hash, method, args) do
+    case Runner.call_contract(contract_pk, top_hash, method, args) do
       {:ok, return} ->
         {:ok, return}
 

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -155,8 +155,7 @@ defmodule AeMdw.Db.Sync.Transaction do
        }) do
     contract_pk = :aect_call_tx.contract_pubkey(tx)
 
-    {fun_arg_res, call_rec} =
-      Contract.call_tx_info(tx, contract_pk, block_hash, &Contract.to_map/1)
+    {fun_arg_res, call_rec} = Contract.call_tx_info(tx, contract_pk, block_hash)
 
     child_mutations =
       if :aect_call.return_type(call_rec) == :ok do

--- a/lib/ae_mdw/dry_run/contract.ex
+++ b/lib/ae_mdw/dry_run/contract.ex
@@ -18,7 +18,7 @@ defmodule AeMdw.DryRun.Contract do
           AeMdw.Contract.method_name(),
           AeMdw.Contract.method_args(),
           pos_integer()
-        ) :: tuple()
+        ) :: AeMdw.Node.aetx()
   def new_call_tx(caller_pk, contract_pk, block_hash, function_name, args, gas \\ @gas) do
     {_tx_env, trees} = :aetx_env.tx_env_and_trees_from_hash(:aetx_contract, block_hash)
     contracts = :aec_trees.contracts(trees)

--- a/lib/ae_mdw/dry_run/runner.ex
+++ b/lib/ae_mdw/dry_run/runner.ex
@@ -4,10 +4,19 @@ defmodule AeMdw.DryRun.Runner do
   """
 
   alias AeMdw.DryRun.Contract
+  alias AeMdw.Node.Db, as: DBN
 
-  @typep pubkey() :: AeMdw.Node.Db.pubkey()
-  @typep block_hash() :: AeMdw.Blocks.block_hash()
-  @typep height() :: AeMdw.Blocks.height()
+  @typep block_hash :: AeMdw.Blocks.block_hash()
+  @typep method_name :: AeMdw.Contract.method_name()
+  @typep method_args :: AeMdw.Contract.method_args()
+
+  @typep node_call_res :: {:ok, AeMdw.Node.aect_call()} | {:error, any()}
+
+  @type node_run_request :: map()
+  @type run_tx_res :: {AeMdw.Node.tx_type(), node_call_res()}
+  @type node_event :: tuple()
+  @type node_run_result :: {[run_tx_res()], [node_event()]}
+  @type call_return :: any()
 
   # arbitrary new pk to run the calls
   @runner_pk <<13, 24, 60, 171, 170, 28, 99, 114, 174, 14, 112, 19, 49, 53, 233, 194, 46, 149,
@@ -17,28 +26,49 @@ defmodule AeMdw.DryRun.Runner do
   @low_gas_limit_factor 1.5
   @extension_methods ["aex9_extensions", "aex141_extensions"]
 
+  @spec call_contract(DBN.pubkey(), method_name(), method_args()) ::
+          {:ok, call_return()} | {:error, binary() | :dry_run_error} | :revert
+  def call_contract(contract_pk, function_name, args),
+    do: call_contract(contract_pk, DBN.top_height_hash(false), function_name, args)
+
+  @spec call_contract(DBN.pubkey(), DBN.height_hash(), method_name(), method_args()) ::
+          {:ok, call_return()} | {:error, binary() | :dry_run_error} | :revert
+  def call_contract(contract_pk, {_type, height, block_hash}, function_name, args) do
+    contract_pk
+    |> new_contract_call_tx(height, block_hash, function_name, args)
+    |> dry_run(block_hash)
+    |> case do
+      {:ok, {[contract_call_tx: {:ok, call_res}], _events}} ->
+        case :aect_call.return_type(call_res) do
+          :ok ->
+            res_binary = :aect_call.return_value(call_res)
+            {:ok, :aeb_fate_encoding.deserialize(res_binary)}
+
+          :error ->
+            {:error, :aect_call.return_value(call_res)}
+
+          :revert ->
+            :revert
+        end
+
+      {:error, _internal_error_msg} ->
+        {:error, :dry_run_error}
+    end
+  end
+
   @doc """
-  Executes a transaction on a certain state of the chain.
+  Executes a single transaction on a certain state of the chain.
   """
-  @spec dry_run(tuple() | map(), block_hash()) :: {:ok, tuple()}
+  @spec dry_run(AeMdw.Node.aetx() | node_run_request(), block_hash()) ::
+          {:ok, node_run_result()} | {:error, iodata()}
   def dry_run(tx_or_call_req, block_hash) do
     accounts = [%{pub_key: @runner_pk, amount: @amount}]
     txs = (is_tuple(tx_or_call_req) && [{:tx, tx_or_call_req}]) || [{:call_req, tx_or_call_req}]
     :aec_dry_run.dry_run(block_hash, accounts, txs, tx_events: false)
   end
 
-  @doc """
-  Creates a contract call transaction record (without running it).
-  """
-  @spec new_contract_call_tx(
-          pubkey(),
-          height(),
-          block_hash(),
-          AeMdw.Contract.method_name(),
-          AeMdw.Contract.method_args()
-        ) :: tuple()
-  def new_contract_call_tx(contract_pk, height, block_hash, function_name, args)
-      when function_name == "meta_info" or function_name in @extension_methods do
+  defp new_contract_call_tx(contract_pk, height, block_hash, function_name, args)
+       when function_name == "meta_info" or function_name in @extension_methods do
     base_gas = Contract.call_tx_base_gas(height)
 
     Contract.new_call_tx(
@@ -51,7 +81,7 @@ defmodule AeMdw.DryRun.Runner do
     )
   end
 
-  def new_contract_call_tx(contract_pk, _height, block_hash, function_name, args) do
+  defp new_contract_call_tx(contract_pk, _height, block_hash, function_name, args) do
     Contract.new_call_tx(@runner_pk, contract_pk, block_hash, function_name, args)
   end
 end

--- a/lib/ae_mdw/node.ex
+++ b/lib/ae_mdw/node.ex
@@ -40,6 +40,7 @@ defmodule AeMdw.Node do
   @opaque signed_tx() :: tuple()
   @opaque aetx() :: tuple()
   @opaque tx() :: tuple()
+  @opaque aect_call :: tuple()
 
   defmodule Oracle do
     @moduledoc false

--- a/lib/ae_mdw/node/db.ex
+++ b/lib/ae_mdw/node/db.ex
@@ -2,7 +2,7 @@ defmodule AeMdw.Node.Db do
   @moduledoc false
 
   alias AeMdw.Blocks
-  alias AeMdw.Contract
+  alias AeMdw.DryRun.Runner
   alias AeMdw.Db.Model
   alias AeMdw.Log
 
@@ -107,7 +107,7 @@ defmodule AeMdw.Node.Db do
   @spec aex9_balance(pubkey(), pubkey(), height_hash()) ::
           {integer() | nil, height_hash()}
   def aex9_balance(contract_pk, account_pk, {type, height, hash}) do
-    case Contract.call_contract(contract_pk, {type, height, hash}, "balance", [
+    case Runner.call_contract(contract_pk, {type, height, hash}, "balance", [
            {:address, account_pk}
          ]) do
       {:ok, {:variant, [0, 1], 1, {amt}}} -> {amt, {type, height, hash}}
@@ -126,7 +126,7 @@ defmodule AeMdw.Node.Db do
   @spec aex9_balances!(pubkey(), height_hash()) :: {map(), height_hash()}
   def aex9_balances!(contract_pk, {type, height, hash}) do
     {:ok, addr_map} =
-      Contract.call_contract(
+      Runner.call_contract(
         contract_pk,
         {type, height, hash},
         "balances",
@@ -142,7 +142,7 @@ defmodule AeMdw.Node.Db do
 
   @spec aex9_balances(pubkey(), height_hash()) :: {map(), height_hash()}
   def aex9_balances(contract_pk, {_type, _height, _hash} = height_hash) do
-    case Contract.call_contract(
+    case Runner.call_contract(
            contract_pk,
            height_hash,
            "balances",

--- a/test/ae_mdw/db/sync/transaction_test.exs
+++ b/test/ae_mdw/db/sync/transaction_test.exs
@@ -6,11 +6,12 @@ defmodule AeMdw.Db.Sync.TransactionTest do
   alias AeMdw.AexnContracts
   alias AeMdw.Database
   alias AeMdw.Contract
+  alias AeMdw.DryRun.Runner
+  alias AeMdw.Db.AexnCreateContractMutation
   alias AeMdw.Db.Sync.Transaction
   alias AeMdw.Db.Model
   alias AeMdw.EtsCache
   alias AeMdw.Validate
-  alias AeMdw.Db.AexnCreateContractMutation
 
   import AeMdwWeb.BlockchainSim, only: [with_blockchain: 3, spend_tx: 3]
   import AeMdw.Node.ContractCallFixtures
@@ -110,7 +111,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
       with_mocks [
         {Contract, [],
          [
-           call_tx_info: fn _tx, ^contract_pk, _block_hash, _to_map ->
+           call_tx_info: fn _tx, ^contract_pk, _block_hash ->
              {
                fun_args_res("create_pair"),
                call_rec("create_pair")
@@ -169,8 +170,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
            get_init_call_rec: fn _tx, _hash ->
              {:call, <<1::256>>, {:id, :account, <<2::256>>}, 1, 123_456,
               {:id, :contract, contract_pk}, 1_000_000_000, 1_234, "?", :ok, []}
-           end,
-           call_contract: fn _pk, _hash, "extensions", [] -> {:ok, ["mintable"]} end
+           end
          ]},
         {AexnContracts, [],
          [
@@ -179,6 +179,10 @@ defmodule AeMdw.Db.Sync.TransactionTest do
            has_aex141_signatures?: fn pk -> pk == contract_pk end,
            call_extensions: fn :aex141, _pk -> {:ok, ["mintable"]} end,
            has_valid_aex141_extensions?: fn _extensions, _pk -> true end
+         ]},
+        {Runner, [],
+         [
+           call_contract: fn _pk, _hash, "extensions", [] -> {:ok, ["mintable"]} end
          ]}
       ] do
         mutations =


### PR DESCRIPTION
## What / Why

- Enable credo on `AeMdw.Contract`
- Refactor `AeMdw.Contract` to single responsibility (move dry run code to its own module)
- Add spec types for dry run

## Validation steps

Create a aex141 or aex9 contract