### PR TITLE
fix: use valid name auction route as specified in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4237,7 +4237,7 @@ This is a list of the exceptions together with the changes that need to be done:
 * `/blocks/:range_or_dir` - Can now be accessed via `/v2/blocks?scope=gen:100-200` or `/v2/blocks?direction=forward`. In addition, each block now has a list of micro_blocks sorted by time, instead of it being a map.
 * `/blocki/:id` - Was renamed to `/v2/blocks/:id`.
 * `/blocki/:kbi/:mbi` - Was renamed to `/v2/blocks/:kbi/:mbi`.
-* `/name/auction/:id` - Was renamed to `/v2/names/:id/auctions`.
+* `/name/auction/:id` - Was renamed to `/v2/names/:id/auction`.
 * `/name/pointers/:id` - Was renamed to `/v2/names/:id/pointers`.
 * `/name/pointees/:id` - Was renamed to `/v2/names/:id/pointees`.
 * `/name/:id` - Was renamed to `/v2/names/:id`.

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -49,7 +49,7 @@ defmodule AeMdwWeb.Router do
       get "/txs", TxController, :txs
       get "/txs/:hash_or_index", TxController, :tx
 
-      get "/names/:id/auctions", NameController, :auction
+      get "/names/:id/auction", NameController, :auction
       get "/names/:id/pointers", NameController, :pointers
       get "/names/:id/pointees", NameController, :pointees
       get "/names/auctions", NameController, :auctions


### PR DESCRIPTION
A name is only linked to a single auction