### PR TITLE
chore: execute async tasks when evaluating in-memory blocks

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -13,7 +13,6 @@ defmodule AeMdw.Db.Contract do
   alias AeMdw.Log
   alias AeMdw.Node
   alias AeMdw.Node.Db
-  alias AeMdw.Sync.AsyncTasks
   alias AeMdw.Validate
 
   require Ex2ms
@@ -362,12 +361,12 @@ defmodule AeMdw.Db.Contract do
       with false <- State.exists?(state, Model.AexnContract, {:aex9, contract_pk}),
            {:ok, extensions} <- AexnContracts.call_extensions(:aex9, contract_pk),
            {:ok, aex9_meta_info} <- AexnContracts.call_meta_info(contract_pk) do
-        AsyncTasks.Producer.enqueue(:derive_aex9_presence, [contract_pk, kbi, mbi, txi])
-        aexn_creation_write(state, :aex9, aex9_meta_info, contract_pk, txi, extensions)
+        state
+        |> State.enqueue(:derive_aex9_presence, [contract_pk, kbi, mbi, txi])
+        |> aexn_creation_write(:aex9, aex9_meta_info, contract_pk, txi, extensions)
       else
         true ->
-          AsyncTasks.Producer.enqueue(:update_aex9_state, [contract_pk], [block_index, txi])
-          state
+          State.enqueue(state, :update_aex9_state, [contract_pk], [block_index, txi])
 
         :error ->
           state

--- a/lib/ae_mdw/db/mutations/aexn_create_contract_mutation.ex
+++ b/lib/ae_mdw/db/mutations/aexn_create_contract_mutation.ex
@@ -7,7 +7,6 @@ defmodule AeMdw.Db.AexnCreateContractMutation do
   alias AeMdw.Db.Contract, as: DBContract
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
-  alias AeMdw.Sync.AsyncTasks
   alias AeMdw.Txs
 
   @derive AeMdw.Db.Mutation
@@ -75,9 +74,9 @@ defmodule AeMdw.Db.AexnCreateContractMutation do
       )
 
     if aexn_type == :aex9 do
-      AsyncTasks.Producer.enqueue(:derive_aex9_presence, [contract_pk, kbi, mbi, create_txi])
+      State.enqueue(state, :derive_aex9_presence, [contract_pk, kbi, mbi, create_txi])
+    else
+      state
     end
-
-    state
   end
 end

--- a/lib/ae_mdw/db/mutations/contract_call_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_call_mutation.ex
@@ -9,7 +9,6 @@ defmodule AeMdw.Db.ContractCallMutation do
   alias AeMdw.Db.Contract, as: DBContract
   alias AeMdw.Db.Origin
   alias AeMdw.Db.State
-  alias AeMdw.Sync.AsyncTasks
   alias AeMdw.Txs
 
   @derive AeMdw.Db.Mutation
@@ -60,9 +59,12 @@ defmodule AeMdw.Db.ContractCallMutation do
         state
       ) do
     # update balance on any aex9 call
-    if AexnContracts.is_aex9?(contract_pk) do
-      AsyncTasks.Producer.enqueue(:update_aex9_state, [contract_pk], [block_index, txi])
-    end
+    state =
+      if AexnContracts.is_aex9?(contract_pk) do
+        State.enqueue(state, :update_aex9_state, [contract_pk], [block_index, txi])
+      else
+        state
+      end
 
     create_txi =
       case State.cache_get(state, :ct_create_sync_cache, contract_pk) do

--- a/lib/ae_mdw/sync/async_tasks/consumer.ex
+++ b/lib/ae_mdw/sync/async_tasks/consumer.ex
@@ -5,6 +5,7 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
   use GenServer
 
   alias AeMdw.Db.Model
+  alias AeMdw.Db.Mutation
   alias AeMdw.Log
 
   alias AeMdw.Sync.AsyncTasks.Producer
@@ -25,6 +26,8 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
     derive_aex9_presence: DeriveAex9Presence,
     update_aex9_state: UpdateAex9State
   }
+
+  @type job_type() :: Model.async_task_type()
 
   # @max_retries 2
   # @backoff_msecs 10_000
@@ -119,6 +122,12 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
     timer_ref = if not is_long?, do: ok!(:timer.send_after(@task_timeout_msecs, :timeout))
 
     {task, timer_ref}
+  end
+
+  @spec mutations(Model.async_task_type(), Model.async_task_args()) :: [Mutation.t()]
+  def mutations(task_type, args) do
+    mod = @type_mod[task_type]
+    apply(mod, :mutations, [args])
   end
 
   #

--- a/lib/ae_mdw/sync/async_tasks/update_aex9_presence.ex
+++ b/lib/ae_mdw/sync/async_tasks/update_aex9_presence.ex
@@ -7,6 +7,7 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9State do
   alias AeMdw.Node.Db, as: DBN
 
   alias AeMdw.Db.Model
+  alias AeMdw.Db.Mutation
   alias AeMdw.Db.State
   alias AeMdw.Db.UpdateAex9PresenceMutation
   alias AeMdw.Log
@@ -39,6 +40,21 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9State do
     State.commit(State.new(), [mutation])
 
     :ok
+  end
+
+  @spec mutations(args :: list()) :: [Mutation.t()]
+  def mutations([contract_pk, {kbi, mbi} = block_index, call_txi]) do
+    next_kb_hash = DBN.get_key_block_hash(kbi + 1)
+    next_hash = DBN.get_next_hash(next_kb_hash, mbi)
+    type = if next_hash == next_kb_hash, do: :key, else: :micro
+
+    {balances, _height_hash} = DBN.aex9_balances(contract_pk, {type, kbi, next_hash})
+
+    balances = Enum.map(balances, fn {{:address, account_pk}, amount} -> {account_pk, amount} end)
+
+    [
+      UpdateAex9PresenceMutation.new(contract_pk, block_index, call_txi, balances)
+    ]
   end
 
   defp enc_ct(<<pk::binary-32>>), do: :aeser_api_encoder.encode(:contract_pubkey, pk)

--- a/lib/ae_mdw/sync/server.ex
+++ b/lib/ae_mdw/sync/server.ex
@@ -37,7 +37,6 @@ defmodule AeMdw.Sync.Server do
   alias AeMdw.Db.Status
   alias AeMdw.Db.Sync.Block
   alias AeMdw.Log
-  alias AeMdw.Sync.AsyncTasks.Producer
   alias AeMdwWeb.Websocket.Broadcaster
 
   require Logger
@@ -295,8 +294,6 @@ defmodule AeMdw.Sync.Server do
         |> Enum.flat_map(fn {_block_index, _block, block_mutations} -> block_mutations end)
 
       new_state = State.commit_db(state, chunk_mutations)
-
-      Producer.commit_enqueued()
 
       Enum.each(blocks_mutations_chunk, fn {{_height, mbi} = _block_index, block,
                                             _block_mutations} ->

--- a/test/ae_mdw/db/contract_create_mutation_test.exs
+++ b/test/ae_mdw/db/contract_create_mutation_test.exs
@@ -58,11 +58,9 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
         assert 2 == State.get_stat(state2, :contracts_created, 0)
         assert {:ok, create_txi2} == State.cache_get(state2, :ct_create_sync_cache, contract_pk)
 
-        assert %{enqueue_buffer: enqueue_buffer} = :sys.get_state(AsyncTasks.Producer)
-
         assert Enum.any?(
-                 enqueue_buffer,
-                 &(&1 == {:update_aex9_state, [remote_pk], [block_index, create_txi2]})
+                 state2.jobs,
+                 &(&1 == {{:update_aex9_state, [remote_pk]}, [block_index, create_txi2]})
                )
       end
     end


### PR DESCRIPTION
This will be done synchronously, but using Task.async_stream/3 for
better performance.