### PR TITLE
feat: dry-run balances only once per contract and block

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -244,6 +244,8 @@ defmodule AeMdw.Application do
   end
 
   def start_phase(:start_sync, _start_type, []) do
+    AeMdw.Db.Aex9BalancesCache.init()
+
     if Application.fetch_env!(:ae_mdw, :sync) do
       Watcher.start_sync()
     end

--- a/lib/ae_mdw/db/aex9_balances_cache.ex
+++ b/lib/ae_mdw/db/aex9_balances_cache.ex
@@ -1,0 +1,44 @@
+defmodule AeMdw.Db.Aex9BalancesCache do
+  @moduledoc """
+  Cache of aex9 balances in order to call the contract a single time for the same block.
+  """
+  alias AeMdw.Node.Db, as: NodeDb
+
+  alias AeMdw.Blocks
+  alias AeMdw.EtsCache
+
+  @typep balances :: %{{:address, NodeDb.pubkey()} => integer()}
+  @table :aex9_balances
+  @expire_minutes 24 * 60
+
+  @spec init() :: :ok
+  def init do
+    EtsCache.new(@table, @expire_minutes, :ordered_set)
+    :ok
+  end
+
+  @spec get(NodeDb.pubkey(), Blocks.block_index(), Blocks.block_hash()) ::
+          {:ok, balances()} | :not_found
+  def get(contract_pk, block_index, block_hash) do
+    case EtsCache.get(@table, {contract_pk, block_index, block_hash}) do
+      {balances, _time} -> {:ok, balances}
+      nil -> :not_found
+    end
+  end
+
+  @spec put(NodeDb.pubkey(), Blocks.block_index(), Blocks.block_hash(), balances()) :: :ok
+  def put(contract_pk, height, block_hash, balances) do
+    EtsCache.put(@table, {contract_pk, height, block_hash}, balances)
+    :ok
+  end
+
+  @spec purge(NodeDb.pubkey(), Blocks.block_index()) :: :ok
+  def purge(contract_pk, block_index) do
+    with {^contract_pk, ^block_index, hash} <-
+           EtsCache.next(@table, {contract_pk, block_index, <<>>}) do
+      EtsCache.del(@table, {contract_pk, block_index, hash})
+    end
+
+    :ok
+  end
+end

--- a/lib/ae_mdw/ets_cache.ex
+++ b/lib/ae_mdw/ets_cache.ex
@@ -1,4 +1,7 @@
 defmodule AeMdw.EtsCache do
+  # credo:disable-for-this-file
+  @moduledoc false
+
   require Ex2ms
 
   @cache_types [:set, :ordered_set, :bag, :duplicate_bag]
@@ -35,6 +38,20 @@ defmodule AeMdw.EtsCache do
 
   def del(table, key),
     do: :ets.delete(table, key)
+
+  def next(table, key) do
+    case :ets.next(table, key) do
+      :"$end_of_table" -> nil
+      next_key -> next_key
+    end
+  end
+
+  def prev(table, key) do
+    case :ets.prev(table, key) do
+      :"$end_of_table" -> nil
+      prev_key -> prev_key
+    end
+  end
 
   def purge(table, max_age_msecs) do
     boundary = time() - max_age_msecs


### PR DESCRIPTION
## What

Get balances for same contract and same block only once (avoid multiple costly dry-run) during in-memory sync.

## Why

Refs #211 (not in parallel yet but one step further)
Refs #749 

## Notes

On next PRs:

- Use this Aex9BalanceCache on endpoints read operations (possibly with another implementation of Db.Store protocol).
- Run aex9 tasks asynchronously (restore behaviour reviewing producer-consumer)
- Use only Aex9BalanceCache for in-memory sync and as data source to persist aex9 records (don't use State/MemStore to save parallel and asynchronous aex9 results)
- Handle forks and intercept tasks belonging to invalid blocks  