### PR TITLE
fix: use single-block transactions to avoid duplicated deletions

### DIFF
--- a/lib/ae_mdw/db/mutations/oracles_expiration_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracles_expiration_mutation.ex
@@ -27,6 +27,7 @@ defmodule AeMdw.Db.OraclesExpirationMutation do
     state
     |> Collection.stream(Model.ActiveOracleExpiration, {height, <<>>})
     |> Stream.take_while(&match?({^height, _pk}, &1))
+    |> Enum.to_list()
     |> Enum.reduce(state, fn {^height, pubkey}, state ->
       Oracle.expire_oracle(state, height, pubkey)
     end)


### PR DESCRIPTION
Reading an already deleted key on a transaction will return the deleted
record anyway, so not chunking multiple blocks into a single transaction
will reduce the chances of it happening.