### PR TITLE
fix: remove blocks cache displayed on /v2/blocks

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,9 +34,7 @@ config :ae_mdw,
   sync: true,
   # email address where to send sync crash notification
   operators: [],
-  contract_cache_expiration_minutes: 1440,
-  # 5 days default generations cache expiration
-  generations_cache_expiration_minutes: 7200
+  contract_cache_expiration_minutes: 1440
 
 # Configures the endpoint
 config :ae_mdw, AeMdwWeb.Endpoint,

--- a/lib/ae_mdw_web/supervisor.ex
+++ b/lib/ae_mdw_web/supervisor.ex
@@ -1,15 +1,12 @@
 defmodule AeMdwWeb.Supervisor do
   use Supervisor
 
-  alias AeMdw.Blocks
-
   @spec start_link([]) :: {:ok, pid()}
   def start_link([]),
     do: Supervisor.start_link(__MODULE__, [], name: __MODULE__)
 
   @impl true
   def init([]) do
-    Blocks.create_cache_table()
     children = [AeMdwWeb.Endpoint]
 
     Supervisor.init(children, strategy: :one_for_one)


### PR DESCRIPTION
This was generating invalid results, because blocks were cached too much time.

It also provides very little performance benefit (if at all)