### PR TITLE
refactor: extract expand/top params into the PaginationPlug

### DIFF
--- a/lib/ae_mdw/util.ex
+++ b/lib/ae_mdw/util.ex
@@ -6,6 +6,12 @@ defmodule AeMdw.Util do
   alias AeMdw.Collection
   alias AeMdw.Db.State
 
+  @type opt() :: {:expand?, boolean()} | {:top?, boolean()}
+  @type opts() :: [opt()]
+
+  @spec expand?(opts()) :: boolean()
+  def expand?(opts), do: Keyword.get(opts, :expand?, false)
+
   def id(x), do: x
 
   def one!([x]), do: x

--- a/lib/ae_mdw_web/controllers/aex9_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex9_controller.ex
@@ -25,8 +25,7 @@ defmodule AeMdwWeb.Aex9Controller do
     only: [
       handle_input: 2,
       paginate: 4,
-      parse_range: 1,
-      presence?: 2
+      parse_range: 1
     ]
 
   import AeMdwWeb.Helpers.AexnHelper
@@ -308,10 +307,10 @@ defmodule AeMdwWeb.Aex9Controller do
     end
   end
 
-  defp balance_reply(%Conn{assigns: %{state: state}} = conn, contract_pk, account_pk) do
+  defp balance_reply(%Conn{assigns: %{state: state, opts: opts}} = conn, contract_pk, account_pk) do
     {amount, {type, height, hash}} =
-      if top?(conn) do
-        DBN.aex9_balance(contract_pk, account_pk, top?(conn))
+      if top?(opts) do
+        DBN.aex9_balance(contract_pk, account_pk, top?(opts))
       else
         case Aex9.fetch_amount_and_keyblock(state, contract_pk, account_pk) do
           {:ok, {amount, kb_height_hash}} ->
@@ -394,9 +393,9 @@ defmodule AeMdwWeb.Aex9Controller do
     json(conn, balances)
   end
 
-  defp balances_reply(%Conn{assigns: %{state: state}} = conn, contract_pk) do
-    amounts = Aex9.fetch_balances(state, contract_pk, top?(conn))
-    hash_tuple = DBN.top_height_hash(top?(conn))
+  defp balances_reply(%Conn{assigns: %{state: state, opts: opts}} = conn, contract_pk) do
+    amounts = Aex9.fetch_balances(state, contract_pk, top?(opts))
+    hash_tuple = DBN.top_height_hash(top?(opts))
     json(conn, balances_to_map({amounts, hash_tuple}, contract_pk))
   end
 
@@ -498,7 +497,7 @@ defmodule AeMdwWeb.Aex9Controller do
     end
   end
 
-  defp top?(conn), do: presence?(conn, "top")
+  defp top?(opts), do: Keyword.get(opts, :top?, false)
 
   defp map_balances_range(range, get_balance_func) do
     range

--- a/lib/ae_mdw_web/controllers/oracle_controller.ex
+++ b/lib/ae_mdw_web/controllers/oracle_controller.ex
@@ -14,39 +14,38 @@ defmodule AeMdwWeb.OracleController do
   ##########
 
   @spec oracle(Conn.t(), map()) :: Conn.t()
-  def oracle(%Conn{assigns: %{state: state}} = conn, %{"id" => id} = params) do
+  def oracle(%Conn{assigns: %{state: state, opts: opts}} = conn, %{"id" => id}) do
     with {:ok, oracle_pk} <- Validate.id(id, [:oracle_pubkey]),
-         {:ok, oracle} <- Oracles.fetch(state, oracle_pk, Util.expand?(params)) do
+         {:ok, oracle} <- Oracles.fetch(state, oracle_pk, opts) do
       json(conn, oracle)
     end
   end
 
   @spec inactive_oracles(Conn.t(), map()) :: Conn.t()
   def inactive_oracles(%Conn{assigns: assigns} = conn, _params) do
-    %{state: state, pagination: pagination, cursor: cursor, expand?: expand?} = assigns
+    %{state: state, pagination: pagination, cursor: cursor, opts: opts} = assigns
 
     {prev_cursor, oracles, next_cursor} =
-      Oracles.fetch_inactive_oracles(state, pagination, cursor, expand?)
+      Oracles.fetch_inactive_oracles(state, pagination, cursor, opts)
 
     Util.paginate(conn, prev_cursor, oracles, next_cursor)
   end
 
   @spec active_oracles(Conn.t(), map()) :: Conn.t()
   def active_oracles(%Conn{assigns: assigns} = conn, _params) do
-    %{state: state, pagination: pagination, cursor: cursor, expand?: expand?} = assigns
+    %{state: state, pagination: pagination, cursor: cursor, opts: opts} = assigns
 
     {prev_cursor, oracles, next_cursor} =
-      Oracles.fetch_active_oracles(state, pagination, cursor, expand?)
+      Oracles.fetch_active_oracles(state, pagination, cursor, opts)
 
     Util.paginate(conn, prev_cursor, oracles, next_cursor)
   end
 
   @spec oracles(Conn.t(), map()) :: Conn.t()
   def oracles(%Conn{assigns: assigns, query_params: query_params} = conn, _params) do
-    %{state: state, pagination: pagination, cursor: cursor, expand?: expand?, scope: scope} =
-      assigns
+    %{state: state, pagination: pagination, cursor: cursor, opts: opts, scope: scope} = assigns
 
-    case Oracles.fetch_oracles(state, pagination, scope, query_params, cursor, expand?) do
+    case Oracles.fetch_oracles(state, pagination, scope, query_params, cursor, opts) do
       {:ok, prev_cursor, oracles, next_cursor} ->
         Util.paginate(conn, prev_cursor, oracles, next_cursor)
 

--- a/lib/ae_mdw_web/plugs/paginated_plug.ex
+++ b/lib/ae_mdw_web/plugs/paginated_plug.ex
@@ -34,7 +34,7 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
       conn
       |> assign(:pagination, {direction, is_reversed?, limit, !is_nil(cursor)})
       |> assign(:cursor, cursor)
-      |> assign(:expand?, Map.get(params, "expand", "false") != "false")
+      |> assign(:opts, extract_opts(params))
       |> assign(:order_by, order_by)
       |> assign(:scope, scope)
       |> assign(:offset, {limit, page})
@@ -166,4 +166,11 @@ defmodule AeMdwWeb.Plugs.PaginatedPlug do
   defp extract_page(_params), do: {:ok, 1}
 
   defp extract_is_reversed(params), do: {:ok, match?(%{"rev" => "1"}, params)}
+
+  defp extract_opts(params) do
+    [
+      expand?: Map.get(params, "expand", "false") != "false",
+      top: Map.get(params, "top", "false") != "false"
+    ]
+  end
 end

--- a/lib/ae_mdw_web/util.ex
+++ b/lib/ae_mdw_web/util.ex
@@ -9,21 +9,6 @@ defmodule AeMdwWeb.Util do
   alias Phoenix.Controller
   alias Plug.Conn
 
-  # credo:disable-for-next-line
-  def expand?(query_params), do: presence?(query_params, "expand")
-
-  # credo:disable-for-next-line
-  def presence?(%Plug.Conn{query_params: query_params}, name),
-    do: presence?(query_params, name)
-
-  # credo:disable-for-next-line
-  def presence?(%{} = query_params, name) do
-    case Map.get(query_params, name, :not_found) do
-      x when x in [nil, "true", [nil], ["true"], "", [""]] -> true
-      _val -> false
-    end
-  end
-
   @spec parse_range(binary()) :: {:ok, Range.t()} | {:error, binary}
   def parse_range(range) do
     case String.split(range, "-") do


### PR DESCRIPTION
Since both `expand` and `top` params are used in many different
endpoints, they are now being extracted in the PaginationPlug.

This will also allow adding a new `tx_hash` parameter for displaying
tx hashes instead of txis.