### PR TITLE
chore: clear state hash for every key block

### DIFF
--- a/lib/ae_mdw/db/mutations/key_block_mutation.ex
+++ b/lib/ae_mdw/db/mutations/key_block_mutation.ex
@@ -23,5 +23,6 @@ defmodule AeMdw.Db.KeyBlockMutation do
     state
     |> State.put(Model.Block, key_block)
     |> State.clear_stats()
+    |> State.clear_cache()
   end
 end

--- a/lib/ae_mdw/db/state.ex
+++ b/lib/ae_mdw/db/state.ex
@@ -171,6 +171,9 @@ defmodule AeMdw.Db.State do
     end
   end
 
+  @spec clear_cache(t()) :: t()
+  def clear_cache(state), do: %__MODULE__{state | cache: %{}}
+
   @spec enqueue(t(), job_type(), list(), list()) :: t()
   def enqueue(%__MODULE__{jobs: jobs} = state, job_type, dedup_args, extra_args \\ []),
     do: %__MODULE__{state | jobs: Map.put(jobs, {job_type, dedup_args}, extra_args)}


### PR DESCRIPTION
Since the cache was never being cleared, many of the name/oracle
records started to accumulate, flooding the memory and reducing
syncing performance.

This won't affect the performance for the last generations executed
in-memory, they are in-memory and rapidly accessed anyway.