### PR TITLE
chore: remove unused Db.Util functions

### DIFF
--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -9,6 +9,7 @@ defmodule AeMdw.Blocks do
   alias AeMdw.Db.State
   alias AeMdw.Db.Util, as: DbUtil
   alias AeMdw.Database
+  alias AeMdw.Node.Db
   alias AeMdw.Util
   alias AeMdw.Validate
   alias AeMdw.Txs
@@ -69,7 +70,7 @@ defmodule AeMdw.Blocks do
          {:ok, _block} <- :aec_chain.get_block(encoded_hash) do
       header = :aec_db.get_header(encoded_hash)
 
-      {:ok, :aec_headers.serialize_for_client(header, DbUtil.prev_block_type(header))}
+      {:ok, :aec_headers.serialize_for_client(header, Db.prev_block_type(header))}
     else
       :error -> {:error, Error.Input.NotFound.exception(value: block_hash)}
       {:error, reason} -> {:error, reason}
@@ -108,7 +109,7 @@ defmodule AeMdw.Blocks do
         |> Enum.map(fn Model.block(index: {_height, _mbi}, hash: hash) ->
           header = :aec_db.get_header(hash)
 
-          :aec_headers.serialize_for_client(header, DbUtil.prev_block_type(header))
+          :aec_headers.serialize_for_client(header, Db.prev_block_type(header))
         end)
 
       put_mbs_from_db(key_block, micro_blocks, sort_mbs?)

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -96,7 +96,7 @@ defmodule AeMdw.Db.Name do
 
   @spec expire_after(Blocks.height()) :: Blocks.height()
   def expire_after(auction_end) do
-    auction_end + :aec_governance.name_claim_max_expiration(DbUtil.proto_vsn(auction_end))
+    auction_end + :aec_governance.name_claim_max_expiration(Db.proto_vsn(auction_end))
   end
 
   @spec expire_name(state(), Blocks.height(), Names.plain_name()) :: state()

--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -5,7 +5,6 @@ defmodule AeMdw.Db.Sync.Name do
   alias AeMdw.Db.Model
   alias AeMdw.Db.Mutation
   alias AeMdw.Db.Name
-  alias AeMdw.Db.Util, as: DbUtil
   alias AeMdw.Names
   alias AeMdw.Db.NameClaimMutation
   alias AeMdw.Db.State
@@ -26,7 +25,7 @@ defmodule AeMdw.Db.Sync.Name do
     {:ok, name_hash} = :aens.get_name_hash(plain_name)
     owner_pk = Validate.id!(:aens_claim_tx.account_id(tx))
     name_fee = :aens_claim_tx.name_fee(tx)
-    proto_vsn = DbUtil.proto_vsn(height)
+    proto_vsn = Db.proto_vsn(height)
     is_lima? = proto_vsn >= Node.lima_vsn()
     timeout = :aec_governance.name_claim_bid_timeout(plain_name, proto_vsn)
 

--- a/lib/ae_mdw/db/util.ex
+++ b/lib/ae_mdw/db/util.ex
@@ -1,18 +1,17 @@
 defmodule AeMdw.Db.Util do
-  # credo:disable-for-this-file
+  @moduledoc false
+
   alias AeMdw.Blocks
   alias AeMdw.Collection
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
   alias AeMdw.Txs
 
-  require Logger
   require Model
-
-  import AeMdw.Util
 
   @typep state() :: State.t()
 
+  @spec read_tx!(state(), Txs.txi()) :: Model.tx()
   def read_tx!(state, txi), do: State.fetch!(state, Model.Tx, txi)
 
   @spec read_block!(state(), Blocks.block_index()) :: Model.block()
@@ -28,107 +27,12 @@ defmodule AeMdw.Db.Util do
     txi
   end
 
+  @spec last_gen(state()) :: Blocks.height()
   def last_gen(state) do
     case State.prev(state, Model.Block, nil) do
       {:ok, {height, _mbi}} -> height
       :none -> raise RuntimeError, message: "can't get last key for table Model.Block"
     end
-  end
-
-  def ensure_key!(tab, getter) do
-    case apply(__MODULE__, getter, [tab]) do
-      :"$end_of_table" ->
-        raise RuntimeError, message: "can't get #{getter} key for table #{tab}"
-
-      k ->
-        k
-    end
-  end
-
-  def collect_keys(tab, acc, start_key, next_fn, progress_fn) do
-    case next_fn.(tab, start_key) do
-      :"$end_of_table" ->
-        acc
-
-      next_key ->
-        case progress_fn.(next_key, acc) do
-          {:halt, res_acc} -> res_acc
-          {:cont, next_acc} -> collect_keys(tab, next_acc, next_key, next_fn, progress_fn)
-        end
-    end
-  end
-
-  def do_writes(tab_xs, db_write) when is_function(db_write, 2),
-    do: Enum.each(tab_xs, fn {tab, xs} -> Enum.each(xs, &db_write.(tab, &1)) end)
-
-  def tx_val(tx_rec, field),
-    do: tx_val(tx_rec, elem(tx_rec, 0), field)
-
-  def tx_val(tx_rec, tx_type, field),
-    do: elem(tx_rec, Enum.find_index(AeMdw.Node.tx_fields(tx_type), &(&1 == field)) + 1)
-
-  def gen_collect(table, init_key_probe, key_tester, progress, new, add, return) do
-    return.(
-      case progress.(table, init_key_probe) do
-        :"$end_of_table" ->
-          new.()
-
-        start_key ->
-          case key_tester.(start_key) do
-            false ->
-              new.()
-
-            other ->
-              init_acc =
-                case other do
-                  :skip -> new.()
-                  true -> add.(start_key, new.())
-                end
-
-              collect_keys(table, init_acc, start_key, progress, fn key, acc ->
-                case key_tester.(key) do
-                  false -> {:halt, acc}
-                  true -> {:cont, add.(key, acc)}
-                  :skip -> {:cont, acc}
-                end
-              end)
-          end
-      end
-    )
-  end
-
-  ##########
-
-  def msecs(msecs) when is_integer(msecs) and msecs > 0, do: msecs
-  def msecs(%Date{} = d), do: msecs(date_time(d))
-  def msecs(%DateTime{} = d), do: DateTime.to_unix(d) * 1000
-
-  def date_time(%DateTime{} = dt),
-    do: dt
-
-  def date_time(msecs) when is_integer(msecs) and msecs > 0,
-    do: DateTime.from_unix(div(msecs, 1000)) |> ok!
-
-  def date_time(%Date{} = d) do
-    {:ok, dt, 0} = DateTime.from_iso8601(Date.to_iso8601(d) <> " 00:00:00.0Z")
-    dt
-  end
-
-  def prev_block_type(header) do
-    prev_hash = :aec_headers.prev_hash(header)
-    prev_key_hash = :aec_headers.prev_key_hash(header)
-
-    cond do
-      :aec_headers.height(header) == 0 -> :key
-      prev_hash == prev_key_hash -> :key
-      true -> :micro
-    end
-  end
-
-  def proto_vsn(height) do
-    hps = AeMdw.Node.height_proto()
-    [{vsn, _} | _] = Enum.drop_while(hps, fn {_vsn, min_h} -> height < min_h end)
-    vsn
   end
 
   @spec block_txi(state(), Blocks.block_index()) :: Txs.txi() | nil

--- a/test/ae_mdw/db/name_claim_mutation_test.exs
+++ b/test/ae_mdw/db/name_claim_mutation_test.exs
@@ -57,7 +57,7 @@ defmodule AeMdw.Db.NameClaimMutationTest do
     )
 
     with_mocks [
-      {AeMdw.Db.Util, [], [proto_vsn: fn _height -> 3 end]}
+      {AeMdw.Node.Db, [], [proto_vsn: fn _height -> 3 end]}
     ] do
       tx
       |> Sync.Name.name_claim_mutations(tx_hash, block_index, txi)

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -12,8 +12,8 @@ defmodule AeMdwWeb.NameControllerTest do
   alias AeMdw.Db.Model.InactiveNameExpiration
   alias AeMdw.Db.Model.Tx
   alias AeMdw.Db.Name
-  alias AeMdw.Db.Util, as: DbUtil
   alias AeMdw.Database
+  alias AeMdw.Node.Db
   alias AeMdw.Validate
   alias AeMdw.TestSamples, as: TS
   alias AeMdw.Txs
@@ -447,7 +447,7 @@ defmodule AeMdwWeb.NameControllerTest do
          [
            fetch!: fn _state, _hash -> %{"tx" => %{"account_id" => <<>>}} end
          ]},
-        {DbUtil, [],
+        {Db, [],
          [
            proto_vsn: fn _height -> 1 end
          ]}
@@ -508,7 +508,7 @@ defmodule AeMdwWeb.NameControllerTest do
          [
            fetch!: fn _state, _hash -> %{"tx" => %{"account_id" => <<>>}} end
          ]},
-        {DbUtil, [],
+        {Db, [],
          [
            proto_vsn: fn _height -> 1 end
          ]}
@@ -553,7 +553,7 @@ defmodule AeMdwWeb.NameControllerTest do
          [
            fetch!: fn _state, _hash -> %{"tx" => %{"account_id" => <<>>}} end
          ]},
-        {DbUtil, [],
+        {Db, [],
          [
            proto_vsn: fn _height -> 1 end
          ]}

--- a/test/integration/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/block_controller_test.exs
@@ -6,6 +6,7 @@ defmodule Integration.AeMdwWeb.BlockControllerTest do
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
   alias AeMdw.Db.Util, as: DbUtil
+  alias AeMdw.Node.Db
   alias AeMdwWeb.TestUtil
   alias AeMdw.Error.Input, as: ErrInput
 
@@ -242,7 +243,7 @@ defmodule Integration.AeMdwWeb.BlockControllerTest do
       {:ok, _block} ->
         header = :aec_db.get_header(block_hash)
 
-        :aec_headers.serialize_for_client(header, DbUtil.prev_block_type(header))
+        :aec_headers.serialize_for_client(header, Db.prev_block_type(header))
 
       :error ->
         raise ErrInput.NotFound, value: enc_block_hash


### PR DESCRIPTION
Also, moving Node-related functions to Node.Db, and out of Db.Util