### PR TITLE
chore: raise detailed message when deleting txn missing key

### DIFF
--- a/lib/ae_mdw/database.ex
+++ b/lib/ae_mdw/database.ex
@@ -155,6 +155,10 @@ defmodule AeMdw.Database do
 
   @spec delete(transaction(), table(), key()) :: :ok
   def delete(txn, table, key) do
+    if not RocksDbCF.exists?(txn, table, key) do
+      raise "Txn delete on missing key: #{table}, #{inspect(key)}"
+    end
+
     :ok = RocksDbCF.delete(txn, table, key)
   end
 

--- a/lib/ae_mdw/db/rocksdb_cf.ex
+++ b/lib/ae_mdw/db/rocksdb_cf.ex
@@ -89,6 +89,16 @@ defmodule AeMdw.Db.RocksDbCF do
     end
   end
 
+  @spec exists?(transaction(), table(), key()) :: boolean()
+  def exists?(txn, table, index) do
+    key = :sext.encode(index)
+
+    case RocksDb.dirty_get(txn, table, key) do
+      {:ok, _value} -> true
+      :not_found -> false
+    end
+  end
+
   @spec first_key(table()) :: {:ok, key()} | :not_found
   def first_key(table) do
     {:ok, it} = RocksDb.iterator(table)

--- a/test/ae_mdw/database_test.exs
+++ b/test/ae_mdw/database_test.exs
@@ -91,4 +91,18 @@ defmodule AeMdw.DatabaseTest do
       end)
     end
   end
+
+  describe "delete/3" do
+    test "raises error when key doesn't exist" do
+      txn = Database.transaction_new()
+      Database.write(txn, Model.Block, Model.block(index: {123, 0}))
+
+      refute :not_found == Database.dirty_fetch(txn, Model.Block, {123, 0})
+      assert :ok = Database.delete(txn, Model.Block, {123, 0})
+
+      assert_raise RuntimeError, "Txn delete on missing key: #{Model.Block}, {123, 0}", fn ->
+        Database.delete(txn, Model.Block, {123, 0})
+      end
+    end
+  end
 end

--- a/test/ae_mdw/db/rocksdbcf_test.exs
+++ b/test/ae_mdw/db/rocksdbcf_test.exs
@@ -128,6 +128,13 @@ defmodule AeMdw.Db.RocksDbCFTest do
       assert :ok = RocksDbCF.put(txn, Model.Tx, m_tx)
       refute RocksDbCF.exists?(Model.Tx, txi)
     end
+
+    test "returns true when key exists in transaction", %{txn: txn} do
+      txi = System.unique_integer() |> abs()
+      m_tx = Model.tx(index: txi)
+      assert :ok = RocksDbCF.put(txn, Model.Tx, m_tx)
+      assert RocksDbCF.exists?(txn, Model.Tx, txi)
+    end
   end
 
   describe "first_key/1" do


### PR DESCRIPTION
## What

Check if key exists before deleting on db transaction 

## Why

Raise detailed message when key is missing.

## Notes

The missing key being deleted was from a record not indexed by 1.11