### PR TITLE
feat: add store to serve async tasks

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -244,6 +244,7 @@ defmodule AeMdw.Application do
   end
 
   def start_phase(:start_sync, _start_type, []) do
+    AeMdw.Db.AsyncStore.init()
     AeMdw.Db.Aex9BalancesCache.init()
 
     if Application.fetch_env!(:ae_mdw, :sync) do

--- a/lib/ae_mdw/db/async_store.ex
+++ b/lib/ae_mdw/db/async_store.ex
@@ -1,0 +1,89 @@
+defmodule AeMdw.Db.AsyncStore do
+  @moduledoc """
+  Implementation of Store protocol to be used by asynchronous tasks.
+
+  Its operations have immediate in-memory effect (not persisted) and
+  is backed by a cache with TTL of 1 day.
+  """
+
+  alias AeMdw.Database
+  alias AeMdw.EtsCache
+
+  @derive AeMdw.Db.Store
+  defstruct tid: nil
+
+  @table_id :single_async_store
+  @ttl_minutes 24 * 60
+
+  @typep key() :: Database.key()
+  @typep record() :: Database.record()
+  @typep table() :: Database.table()
+  @opaque t() :: %__MODULE__{tid: :single_async_store}
+
+  @spec init() :: :ok
+  def init do
+    EtsCache.new(@table_id, @ttl_minutes, :ordered_set)
+    :ok
+  end
+
+  @spec instance() :: t()
+  def instance do
+    %__MODULE__{tid: @table_id}
+  end
+
+  @spec put(t(), table(), record()) :: t()
+  def put(%__MODULE__{tid: tid} = store, table, record) do
+    EtsCache.put(tid, {table, elem(record, 1)}, record)
+
+    store
+  end
+
+  @spec get(t(), table(), key()) :: {:ok, record()} | :not_found
+  def get(%__MODULE__{tid: tid}, table, key) do
+    case EtsCache.get(tid, {table, key}) do
+      {record, _time} -> {:ok, record}
+      nil -> :not_found
+    end
+  end
+
+  @spec delete(t(), table(), key()) :: t()
+  def delete(%__MODULE__{tid: tid} = store, table, key) do
+    EtsCache.del(tid, {table, key})
+
+    store
+  end
+
+  @spec next(t(), table(), key() | nil) :: {:ok, key()} | :none
+  def next(%__MODULE__{tid: tid}, table, key) do
+    case EtsCache.next(tid, {table, key}) do
+      nil -> :none
+      {_table, next_key} -> {:ok, next_key}
+    end
+  end
+
+  @spec prev(t(), table(), key() | nil) :: {:ok, key()} | :none
+  def prev(%__MODULE__{tid: tid}, table, key) do
+    case EtsCache.prev(tid, {table, key}) do
+      nil -> :none
+      {_table, prev_key} -> {:ok, prev_key}
+    end
+  end
+
+  @spec count_keys(t(), table()) :: non_neg_integer()
+  def count_keys(%__MODULE__{tid: tid}, table) do
+    do_count_keys(tid, table, nil, 0)
+  end
+
+  defp do_count_keys(tid, table, key, count) do
+    case EtsCache.next(tid, {table, key}) do
+      {^table, next_key} -> do_count_keys(tid, table, next_key, count + 1)
+      _other_table_or_nil -> count
+    end
+  end
+
+  @spec clear_tables(t()) :: :ok
+  def clear_tables(%__MODULE__{tid: tid}) do
+    EtsCache.clear(tid)
+    :ok
+  end
+end

--- a/lib/ae_mdw/ets_cache.ex
+++ b/lib/ae_mdw/ets_cache.ex
@@ -53,6 +53,8 @@ defmodule AeMdw.EtsCache do
     end
   end
 
+  def clear(table), do: :ets.delete_all_objects(table)
+
   def purge(table, max_age_msecs) do
     boundary = time() - max_age_msecs
 

--- a/lib/ae_mdw/node/db.ex
+++ b/lib/ae_mdw/node/db.ex
@@ -87,12 +87,14 @@ defmodule AeMdw.Node.Db do
     |> Enum.reverse()
   end
 
-  @spec get_key_block_hash(Blocks.height()) :: Blocks.block_hash()
+  @spec get_key_block_hash(Blocks.height()) :: Blocks.block_hash() | nil
   def get_key_block_hash(height) do
-    {:ok, next_kb_header} = :aec_chain.get_key_header_by_height(height)
-    {:ok, next_kb_hash} = :aec_headers.hash_header(next_kb_header)
-
-    next_kb_hash
+    with {:ok, next_kb_header} <- :aec_chain.get_key_header_by_height(height),
+         {:ok, next_kb_hash} <- :aec_headers.hash_header(next_kb_header) do
+      next_kb_hash
+    else
+      {:error, :chain_too_short} -> nil
+    end
   end
 
   @spec get_next_hash(Blocks.block_hash(), Blocks.mbi()) :: Blocks.block_hash()

--- a/test/ae_mdw/aex9_test.exs
+++ b/test/ae_mdw/aex9_test.exs
@@ -1,0 +1,101 @@
+defmodule AeMdw.Aex9Test do
+  use ExUnit.Case
+
+  alias AeMdw.Aex9
+  alias AeMdw.Db.State
+
+  import AeMdwWeb.Helpers.AexnHelper, only: [enc_ct: 1, enc_id: 1]
+  import Mock
+
+  describe "fetch_balances" do
+    test "gets contract balances from async store" do
+      ct_pk = :crypto.strong_rand_bytes(32)
+      {kbi, mbi} = block_index = {123_456, 3}
+      next_kbi = kbi + 1
+      call_txi = 12_345_678
+
+      next_kb_hash = :crypto.strong_rand_bytes(32)
+      next_mb_hash = :crypto.strong_rand_bytes(32)
+
+      balances =
+        for _i <- 1..10, into: %{} do
+          account_pk = :crypto.strong_rand_bytes(32)
+          amount = Enum.random(1_000_000_000..9_999_999_999)
+          {{:address, account_pk}, amount}
+        end
+
+      with_mocks [
+        {AeMdw.Node.Db, [],
+         [
+           get_key_block_hash: fn
+             ^next_kbi ->
+               next_kb_hash
+           end,
+           get_next_hash: fn ^next_kb_hash, ^mbi -> next_mb_hash end,
+           aex9_balances: fn ^ct_pk, {:micro, ^kbi, ^next_mb_hash} ->
+             {balances, nil}
+           end
+         ]}
+      ] do
+        state = State.enqueue(State.new(), :update_aex9_state, [ct_pk], [block_index, call_txi])
+        assert %State{} = State.commit_mem(state, [])
+
+        assert balances == Aex9.fetch_balances(nil, ct_pk, false)
+      end
+    end
+  end
+
+  describe "fetch_balance" do
+    test "gets account balance from async store" do
+      ct_pk = :crypto.strong_rand_bytes(32)
+      {kbi, mbi} = block_index = {123_456, 3}
+      next_kbi = kbi + 1
+      call_txi = 12_345_678
+
+      next_kb_hash = :crypto.strong_rand_bytes(32)
+      next_mb_hash = :crypto.strong_rand_bytes(32)
+
+      account_pk = :crypto.strong_rand_bytes(32)
+      amount = Enum.random(1_000_000_000..9_999_999_999)
+
+      balances =
+        for _i <- 1..10, into: %{} do
+          account_pk = :crypto.strong_rand_bytes(32)
+          amount = Enum.random(1_000_000_000..9_999_999_999)
+          {{:address, account_pk}, amount}
+        end
+        |> Map.put({:address, account_pk}, amount)
+
+      with_mocks [
+        {
+          AeMdw.AexnContracts,
+          [],
+          [
+            is_aex9?: fn pk -> pk == ct_pk end
+          ]
+        },
+        {AeMdw.Node.Db, [],
+         [
+           get_key_block_hash: fn
+             ^next_kbi ->
+               next_kb_hash
+           end,
+           get_next_hash: fn ^next_kb_hash, ^mbi -> next_mb_hash end,
+           aex9_balances: fn ^ct_pk, {:micro, ^kbi, ^next_mb_hash} ->
+             {balances, nil}
+           end
+         ]}
+      ] do
+        state = State.enqueue(State.new(), :update_aex9_state, [ct_pk], [block_index, call_txi])
+        assert %State{} = State.commit_mem(state, [])
+
+        assert {:ok,
+                %{
+                  contract: enc_ct(ct_pk),
+                  account: enc_id(account_pk),
+                  amount: amount
+                }} == Aex9.fetch_balance(nil, ct_pk, account_pk)
+      end
+    end
+  end
+end

--- a/test/ae_mdw/db/state_test.exs
+++ b/test/ae_mdw/db/state_test.exs
@@ -1,0 +1,59 @@
+defmodule AeMdw.Db.StateTest do
+  use ExUnit.Case
+
+  alias AeMdw.Db.AsyncStore
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+
+  import Mock
+
+  require Model
+
+  describe "commit_mem" do
+    test "saves aex9 state into ets store" do
+      ct_pk = :crypto.strong_rand_bytes(32)
+      {kbi, mbi} = block_index = {123_456, 2}
+      next_kbi = kbi + 1
+      call_txi = 12_345_678
+
+      next_kb_hash = :crypto.strong_rand_bytes(32)
+      next_mb_hash = :crypto.strong_rand_bytes(32)
+      account_pk = :crypto.strong_rand_bytes(32)
+      amount = Enum.random(1_000_000_000..9_999_999_999)
+
+      with_mocks [
+        {AeMdw.Node.Db, [],
+         [
+           get_key_block_hash: fn
+             ^next_kbi ->
+               next_kb_hash
+           end,
+           get_next_hash: fn ^next_kb_hash, ^mbi -> next_mb_hash end,
+           aex9_balances: fn ^ct_pk, {:micro, ^kbi, ^next_mb_hash} ->
+             balances = %{{:address, account_pk} => amount}
+
+             {balances, nil}
+           end
+         ]}
+      ] do
+        state = State.enqueue(State.new(), :update_aex9_state, [ct_pk], [block_index, call_txi])
+        assert %State{} = State.commit_mem(state, [])
+
+        ets_state = State.new(AsyncStore.instance())
+        presence_key = {account_pk, ct_pk}
+        balance_key = {ct_pk, account_pk}
+
+        assert {:ok, Model.aex9_account_presence(index: ^presence_key, txi: ^call_txi)} =
+                 State.get(ets_state, Model.Aex9AccountPresence, presence_key)
+
+        assert {:ok,
+                Model.aex9_balance(
+                  index: ^balance_key,
+                  block_index: ^block_index,
+                  txi: ^call_txi,
+                  amount: ^amount
+                )} = State.get(ets_state, Model.Aex9Balance, balance_key)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

* Add in-memory `Store` that can be used by (multiple) async tasks
* Change AEX9 tasks to use this `Store`
* Handles :chain_too_short condition when updating aex9 state for the last microblocks

## Why

Shared in-memory among multiple processes (tasks) in order to allow writing to the same `State`.
Refs #749