### PR TITLE
refactor: process in-memory async tasks asynchronously

### DIFF
--- a/lib/ae_mdw/sync/async_tasks/consumer.ex
+++ b/lib/ae_mdw/sync/async_tasks/consumer.ex
@@ -5,7 +5,6 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
   use GenServer
 
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Mutation
   alias AeMdw.Log
 
   alias AeMdw.Sync.AsyncTasks.Producer
@@ -120,12 +119,6 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
     timer_ref = if not is_long?, do: ok!(:timer.send_after(@task_timeout_msecs, :timeout))
 
     {task, timer_ref}
-  end
-
-  @spec mutations(Model.async_task_type(), Model.async_task_args()) :: [Mutation.t()]
-  def mutations(task_type, args) do
-    mod = @type_mod[task_type]
-    apply(mod, :mutations, [args])
   end
 
   #

--- a/test/ae_mdw/db/state_test.exs
+++ b/test/ae_mdw/db/state_test.exs
@@ -1,58 +1,32 @@
 defmodule AeMdw.Db.StateTest do
   use ExUnit.Case
 
-  alias AeMdw.Db.AsyncStore
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
+  alias AeMdw.Sync.AsyncTasks.Producer
 
   import Mock
 
   require Model
 
   describe "commit_mem" do
-    test "saves aex9 state into ets store" do
+    test "it queues async tasks" do
       ct_pk = :crypto.strong_rand_bytes(32)
-      {kbi, mbi} = block_index = {123_456, 2}
-      next_kbi = kbi + 1
+      block_index = {123_456, 2}
       call_txi = 12_345_678
 
-      next_kb_hash = :crypto.strong_rand_bytes(32)
-      next_mb_hash = :crypto.strong_rand_bytes(32)
-      account_pk = :crypto.strong_rand_bytes(32)
-      amount = Enum.random(1_000_000_000..9_999_999_999)
-
       with_mocks [
-        {AeMdw.Node.Db, [],
-         [
-           get_key_block_hash: fn
-             ^next_kbi ->
-               next_kb_hash
-           end,
-           get_next_hash: fn ^next_kb_hash, ^mbi -> next_mb_hash end,
-           aex9_balances: fn ^ct_pk, {:micro, ^kbi, ^next_mb_hash} ->
-             balances = %{{:address, account_pk} => amount}
-
-             {balances, nil}
-           end
-         ]}
+        {Producer, [],
+         commit_enqueued: fn -> :ok end, enqueue: fn _job, _dedup_args, _args -> :ok end}
       ] do
         state = State.enqueue(State.new(), :update_aex9_state, [ct_pk], [block_index, call_txi])
-        assert %State{} = State.commit_mem(state, [])
 
-        ets_state = State.new(AsyncStore.instance())
-        presence_key = {account_pk, ct_pk}
-        balance_key = {ct_pk, account_pk}
+        State.commit_mem(state, [])
 
-        assert {:ok, Model.aex9_account_presence(index: ^presence_key, txi: ^call_txi)} =
-                 State.get(ets_state, Model.Aex9AccountPresence, presence_key)
+        assert [^block_index, ^call_txi] = Map.fetch!(state.jobs, {:update_aex9_state, [ct_pk]})
 
-        assert {:ok,
-                Model.aex9_balance(
-                  index: ^balance_key,
-                  block_index: ^block_index,
-                  txi: ^call_txi,
-                  amount: ^amount
-                )} = State.get(ets_state, Model.Aex9Balance, balance_key)
+        assert_called(Producer.enqueue(:update_aex9_state, :_, :_))
+        assert_called(Producer.commit_enqueued())
       end
     end
   end


### PR DESCRIPTION
This will keep the in-memory state from loading the AEx9 data.