### PR TITLE
fix: broadcast in-memory blocks

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -16,6 +16,7 @@ defmodule AeMdw.Application do
   alias AeMdw.NodeHelper
   alias AeMdw.Sync.Watcher
   alias AeMdw.Util
+  alias AeMdwWeb.Websocket.Broadcaster
 
   require Model
 
@@ -218,6 +219,9 @@ defmodule AeMdw.Application do
 
   defp init(:tables) do
     :ets.new(:tx_sync_cache, [:named_table, :ordered_set, :public])
+
+    {ets_table, ets_expiration} = Broadcaster.ets_config()
+    EtsCache.new(ets_table, ets_expiration)
 
     AeMdw.Sync.AsyncTasks.Stats.init()
     AeMdw.Sync.AsyncTasks.Store.init()

--- a/lib/ae_mdw/ets_cache.ex
+++ b/lib/ae_mdw/ets_cache.ex
@@ -7,6 +7,9 @@ defmodule AeMdw.EtsCache do
   @cache_types [:set, :ordered_set, :bag, :duplicate_bag]
   @cache_access [:public, :private, :protected]
 
+  @type table() :: atom()
+  @type expiration() :: non_neg_integer()
+
   ################################################################################
 
   def new(name, expiration_minutes, type \\ :set, access \\ :public, concurrency \\ true)

--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -18,10 +18,10 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
   def start_link(_arg), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
 
   @impl GenServer
-  def init(:ok) do
-    EtsCache.new(@hashes_table, @expiration_minutes)
-    {:ok, :no_state}
-  end
+  def init(:ok), do: {:ok, :no_state}
+
+  @spec ets_config() :: {EtsCache.table(), EtsCache.expiration()}
+  def ets_config(), do: {@hashes_table, @expiration_minutes}
 
   @spec broadcast_key_block(tuple(), :node | :mdw) :: :ok
   def broadcast_key_block(block, source) do


### PR DESCRIPTION
This state check will avoid sending the same mb/kb multiple times, which happens when re-syncing in-memory gens.

refs #808 