### PR TITLE
feat: synchronize async tasks write

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,6 +1,7 @@
 alias AeMdw.Db.Model
 alias AeMdw.Db.Name
 alias AeMdw.Db.Util
+alias AeMdw.Db.State
 
 alias AeMdw.Contract
 alias AeMdw.Database

--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -226,6 +226,9 @@ defmodule AeMdw.Application do
     AeMdw.Sync.AsyncTasks.Stats.init()
     AeMdw.Sync.AsyncTasks.Store.init()
 
+    AeMdw.Db.AsyncStore.init()
+    AeMdw.Db.Aex9BalancesCache.init()
+
     AeMdw.Db.RocksDbCF.init_tables()
   end
 
@@ -248,9 +251,6 @@ defmodule AeMdw.Application do
   end
 
   def start_phase(:start_sync, _start_type, []) do
-    AeMdw.Db.AsyncStore.init()
-    AeMdw.Db.Aex9BalancesCache.init()
-
     if Application.fetch_env!(:ae_mdw, :sync) do
       Watcher.start_sync()
     end

--- a/lib/ae_mdw/db/async_store.ex
+++ b/lib/ae_mdw/db/async_store.ex
@@ -7,6 +7,7 @@ defmodule AeMdw.Db.AsyncStore do
   """
 
   alias AeMdw.Database
+  alias AeMdw.Db.Mutation
   alias AeMdw.EtsCache
 
   @derive AeMdw.Db.Store
@@ -29,6 +30,15 @@ defmodule AeMdw.Db.AsyncStore do
   @spec instance() :: t()
   def instance do
     %__MODULE__{tid: @table_id}
+  end
+
+  @spec mutations(t()) :: [Mutation.t()]
+  def mutations(%__MODULE__{tid: tid}) do
+    tid
+    |> EtsCache.all()
+    |> Enum.map(fn {{table, _key}, record, _time} ->
+      AeMdw.Db.WriteMutation.new(table, record)
+    end)
   end
 
   @spec put(t(), table(), record()) :: t()
@@ -81,8 +91,8 @@ defmodule AeMdw.Db.AsyncStore do
     end
   end
 
-  @spec clear_tables(t()) :: :ok
-  def clear_tables(%__MODULE__{tid: tid}) do
+  @spec clear(t()) :: :ok
+  def clear(%__MODULE__{tid: tid}) do
     EtsCache.clear(tid)
     :ok
   end

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -66,11 +66,17 @@ defmodule AeMdw.Db.Contract do
   @spec aex9_write_presence(state(), pubkey(), integer(), pubkey()) :: state()
   def aex9_write_presence(state, contract_pk, txi, account_pk) do
     m_acc_presence = Model.aex9_account_presence(index: {account_pk, contract_pk}, txi: txi)
-    m_idx_presence = Model.idx_aex9_account_presence(index: {txi, account_pk, contract_pk})
 
-    state
-    |> State.put(Model.Aex9AccountPresence, m_acc_presence)
-    |> State.put(Model.IdxAex9AccountPresence, m_idx_presence)
+    State.put(state, Model.Aex9AccountPresence, m_acc_presence)
+  end
+
+  @spec aex9_delete_presence(state(), pubkey(), pubkey()) :: state()
+  def aex9_delete_presence(state, account_pk, contract_pk) do
+    if State.exists?(state, Model.Aex9AccountPresence, {account_pk, contract_pk}) do
+      State.delete(state, Model.Aex9AccountPresence, {account_pk, contract_pk})
+    else
+      state
+    end
   end
 
   @spec aex9_transfer_balance(state(), pubkey(), pubkey(), pubkey(), non_neg_integer()) :: state()

--- a/lib/ae_mdw/db/mutations/async_store_mutation.ex
+++ b/lib/ae_mdw/db/mutations/async_store_mutation.ex
@@ -1,0 +1,23 @@
+defmodule AeMdw.Db.AsyncStoreMutation do
+  @moduledoc """
+  Writes all AsyncStore records to a state.
+  """
+
+  alias AeMdw.Db.State
+  alias AeMdw.Sync.AsyncStoreServer
+
+  @derive AeMdw.Db.Mutation
+  defstruct []
+
+  @opaque t() :: %__MODULE__{}
+
+  @spec new() :: t()
+  def new() do
+    %__MODULE__{}
+  end
+
+  @spec execute(t(), State.t()) :: State.t()
+  def execute(%__MODULE__{}, state) do
+    AsyncStoreServer.write_async_store(state)
+  end
+end

--- a/lib/ae_mdw/db/mutations/purge_aex9_state_mutation.ex
+++ b/lib/ae_mdw/db/mutations/purge_aex9_state_mutation.ex
@@ -1,0 +1,51 @@
+defmodule AeMdw.Db.PurgeAex9StateMutation do
+  @moduledoc """
+  Deletes aex9 balances and presence for invalidated balances.
+  """
+
+  alias AeMdw.Db.Contract
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Node.Db
+
+  require Model
+
+  @derive AeMdw.Db.Mutation
+  defstruct [:contract_pk, :accounts_pks]
+
+  @opaque t() :: %__MODULE__{
+            contract_pk: Db.pubkey(),
+            accounts_pks: [Db.pubkey()]
+          }
+
+  @spec new(Db.pubkey(), [Db.pubkey()]) :: t()
+  def new(contract_pk, accounts_pks) do
+    %__MODULE__{
+      contract_pk: contract_pk,
+      accounts_pks: accounts_pks
+    }
+  end
+
+  @spec execute(t(), State.t()) :: State.t()
+  def execute(
+        %__MODULE__{
+          contract_pk: contract_pk,
+          accounts_pks: accounts_pks
+        },
+        state
+      ) do
+    Enum.reduce(accounts_pks, state, fn account_pk, state ->
+      state
+      |> Contract.aex9_delete_presence(account_pk, contract_pk)
+      |> safe_delete_balance(contract_pk, account_pk)
+    end)
+  end
+
+  defp safe_delete_balance(state, contract_pk, account_pk) do
+    if State.exists?(state, Model.Aex9Balance, {contract_pk, account_pk}) do
+      State.delete(state, Model.Aex9Balance, {contract_pk, account_pk})
+    else
+      state
+    end
+  end
+end

--- a/lib/ae_mdw/ets_cache.ex
+++ b/lib/ae_mdw/ets_cache.ex
@@ -24,8 +24,10 @@ defmodule AeMdw.EtsCache do
   end
 
   @spec put(table(), key(), val()) :: true
-  def put(table, key, val),
-    do: :ets.insert(table, {key, val, time()})
+  def put(table, key, val), do: :ets.insert(table, {key, val, time()})
+
+  @spec all(table()) :: [tuple()]
+  def all(table), do: :ets.tab2list(table)
 
   @spec get(table(), key()) :: val() | nil
   def get(table, key) do
@@ -41,6 +43,10 @@ defmodule AeMdw.EtsCache do
   @spec del(table(), key()) :: true
   def del(table, key),
     do: :ets.delete(table, key)
+
+  @spec member(table(), key()) :: boolean()
+  def member(table, key),
+    do: :ets.member(table, key)
 
   @spec next(table(), key()) :: key() | nil
   def next(table, key) do

--- a/lib/ae_mdw/sync/async_store_server.ex
+++ b/lib/ae_mdw/sync/async_store_server.ex
@@ -44,8 +44,6 @@ defmodule AeMdw.Sync.AsyncStoreServer do
         _from,
         %{last_db_kbi: last_db_kbi} = state
       ) do
-    # IO.inspect {kbi, Database.exists?(Model.Block, block_index)}, label: :write_mutations
-    # IO.inspect {kbi, last_db_kbi}
     if Database.exists?(Model.Block, block_index) || kbi <= last_db_kbi do
       TxnDbStore.transaction(fn store ->
         txn_state = State.new(store)

--- a/lib/ae_mdw/sync/async_store_server.ex
+++ b/lib/ae_mdw/sync/async_store_server.ex
@@ -1,0 +1,94 @@
+defmodule AeMdw.Sync.AsyncStoreServer do
+  @moduledoc """
+  Synchronizes writing the result of async tasks to AsyncStore with the writes to State
+  having the AsyncStore as the source of mutations during database commit.
+
+  Since async tasks completion time is unknown, writing AsyncStore records to disk
+  needs to be synchronized with `AeMdw.Sync.Server` commit. If the block related to
+  the async task was already commited to database, the async task result is not written
+  to AsyncStore but persisted direclty.
+  """
+  use GenServer
+
+  alias AeMdw.Database
+  alias AeMdw.Db.AsyncStore
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Mutation
+  alias AeMdw.Db.State
+  alias AeMdw.Db.TxnDbStore
+
+  @spec start_link([]) :: GenServer.on_start()
+  def start_link([]) do
+    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  @spec init(:ok) :: {:ok, %{last_db_kbi: AeMdw.Blocks.height()}}
+  @impl GenServer
+  def init(:ok) do
+    {:ok, %{last_db_kbi: 0}}
+  end
+
+  @spec write_mutations(AeMdw.Blocks.block_index(), [Mutation.t()]) :: :ok
+  def write_mutations(block_index, async_mutations) do
+    GenServer.call(__MODULE__, {:write_mutations, block_index, async_mutations})
+  end
+
+  @spec write_async_store(State.t()) :: State.t()
+  def write_async_store(db_state) do
+    GenServer.call(__MODULE__, {:write_store, db_state})
+  end
+
+  @impl GenServer
+  def handle_call(
+        {:write_mutations, {kbi, _mbi} = block_index, mutations},
+        _from,
+        %{last_db_kbi: last_db_kbi} = state
+      ) do
+    # IO.inspect {kbi, Database.exists?(Model.Block, block_index)}, label: :write_mutations
+    # IO.inspect {kbi, last_db_kbi}
+    if Database.exists?(Model.Block, block_index) || kbi <= last_db_kbi do
+      TxnDbStore.transaction(fn store ->
+        txn_state = State.new(store)
+
+        mutations
+        |> Enum.reject(&is_nil/1)
+        |> Enum.each(&Mutation.execute(&1, txn_state))
+      end)
+    else
+      async_state = State.new(AsyncStore.instance())
+
+      mutations
+      |> Enum.reject(&is_nil/1)
+      |> Enum.each(&Mutation.execute(&1, async_state))
+    end
+
+    {:reply, :ok, state}
+  end
+
+  @impl GenServer
+  def handle_call({:write_store, db_state}, _from, _state) do
+    new_state =
+      AsyncStore.instance()
+      |> AsyncStore.mutations()
+      |> Enum.reduce(db_state, &Mutation.execute/2)
+
+    AsyncStore.clear(AsyncStore.instance())
+
+    {:reply, new_state, %{last_db_kbi: last_db_kbi(db_state)}}
+  end
+
+  defp last_db_kbi(db_state) do
+    case State.prev(db_state, Model.Block, {nil, nil}) do
+      {:ok, {kbi, mbi}} ->
+        if mbi == -1 do
+          {:ok, {kbi, _mbi}} = State.prev(db_state, Model.Block, {kbi, mbi})
+          kbi
+        else
+          kbi
+        end
+
+      :none ->
+        0
+    end
+  end
+end

--- a/lib/ae_mdw/sync/async_tasks/consumer.ex
+++ b/lib/ae_mdw/sync/async_tasks/consumer.ex
@@ -5,7 +5,6 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
   use GenServer
 
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Mutation
   alias AeMdw.Log
 
   alias AeMdw.Sync.AsyncTasks.Producer
@@ -25,7 +24,7 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
     update_aex9_state: UpdateAex9State
   }
 
-  @type job_type() :: Model.async_task_type()
+  @type task_type() :: Model.async_task_type()
 
   # @max_retries 2
   # @backoff_msecs 10_000
@@ -120,12 +119,6 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
     timer_ref = if not is_long?, do: ok!(:timer.send_after(@task_timeout_msecs, :timeout))
 
     {task, timer_ref}
-  end
-
-  @spec mutations(Model.async_task_type(), Model.async_task_args()) :: [Mutation.t()]
-  def mutations(task_type, args) do
-    mod = @type_mod[task_type]
-    apply(mod, :mutations, [args])
   end
 
   #

--- a/lib/ae_mdw/sync/async_tasks/supervisor.ex
+++ b/lib/ae_mdw/sync/async_tasks/supervisor.ex
@@ -9,8 +9,6 @@ defmodule AeMdw.Sync.AsyncTasks.Supervisor do
   alias AeMdw.Sync.AsyncTasks.Producer
   alias AeMdw.Sync.AsyncTasks.TaskSupervisor
 
-  @num_consumers 3
-
   @spec start_link(any()) :: Supervisor.on_start()
   def start_link(_args) do
     Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
@@ -28,7 +26,7 @@ defmodule AeMdw.Sync.AsyncTasks.Supervisor do
   end
 
   defp consumers() do
-    for id <- 1..@num_consumers do
+    for id <- 1..System.schedulers_online() do
       %{
         id: "#{Consumer}#{id}",
         start: {Consumer, :start_link, [[]]}

--- a/lib/ae_mdw/sync/async_tasks/update_aex9_state.ex
+++ b/lib/ae_mdw/sync/async_tasks/update_aex9_state.ex
@@ -4,15 +4,15 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9State do
   """
   @behaviour AeMdw.Sync.AsyncTasks.Work
 
-  alias AeMdw.Node.Db, as: DBN
-
   alias AeMdw.Db.Aex9BalancesCache
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Mutation
-  alias AeMdw.Db.State
+  alias AeMdw.Db.PurgeAex9StateMutation
   alias AeMdw.Db.WriteMutation
   alias AeMdw.Db.UpdateAex9StateMutation
   alias AeMdw.Log
+
+  alias AeMdw.Node.Db, as: DBN
+  alias AeMdw.Sync.AsyncStoreServer
 
   require Model
   require Logger
@@ -20,38 +20,47 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9State do
   @microsecs 1_000_000
 
   @spec process(args :: list()) :: :ok
-  def process([contract_pk, _block_index, _call_txi] = args) do
-    Log.info("[update_aex9_state] #{inspect(enc_ct(contract_pk))} ...")
+  def process([contract_pk, block_index, _call_txi] = args) do
+    {time_delta, {write_mutation, delete_mutation}} = :timer.tc(fn -> mutations(args) end)
 
-    {time_delta, mutations} = :timer.tc(fn -> mutations(args) end)
+    Log.info("[update_aex9_state] #{enc_ct(contract_pk)} after #{time_delta / @microsecs}s")
 
-    Log.info(
-      "[update_aex9_state] #{inspect(enc_ct(contract_pk))} after #{time_delta / @microsecs}s"
-    )
-
-    State.commit(State.new(), mutations)
+    AsyncStoreServer.write_mutations(block_index, [
+      delete_mutation,
+      write_mutation
+    ])
 
     :ok
   end
 
-  @spec mutations(args :: list()) :: [Mutation.t()]
-  def mutations([contract_pk, block_index, call_txi]) do
-    balances = aex9_balances(contract_pk, block_index)
+  defp mutations([contract_pk, block_index, call_txi]) do
+    {balances, purged_balances} = aex9_balances(contract_pk, block_index)
 
     if map_size(balances) == 0 do
       m_empty_balance = Model.aex9_balance(index: {contract_pk, <<>>})
 
-      [
-        WriteMutation.new(Model.Aex9Balance, m_empty_balance)
-      ]
+      {
+        WriteMutation.new(Model.Aex9Balance, m_empty_balance),
+        purge_mutation(contract_pk, purged_balances)
+      }
     else
       balances_list =
         Enum.map(balances, fn {{:address, account_pk}, amount} -> {account_pk, amount} end)
 
-      [
-        UpdateAex9StateMutation.new(contract_pk, block_index, call_txi, balances_list)
-      ]
+      {
+        UpdateAex9StateMutation.new(contract_pk, block_index, call_txi, balances_list),
+        purge_mutation(contract_pk, purged_balances)
+      }
     end
+  end
+
+  defp purge_mutation(_pk, purged_balances) when map_size(purged_balances) == 0, do: nil
+
+  defp purge_mutation(contract_pk, purged_balances) do
+    accounts_list =
+      Enum.map(purged_balances, fn {{:address, account_pk}, _amount} -> account_pk end)
+
+    PurgeAex9StateMutation.new(contract_pk, accounts_list)
   end
 
   defp aex9_balances(contract_pk, block_index) do
@@ -59,14 +68,14 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9State do
 
     case Aex9BalancesCache.get(contract_pk, block_index, next_hash) do
       {:ok, balances} ->
-        balances
+        {balances, %{}}
 
       :not_found ->
-        Aex9BalancesCache.purge(contract_pk, block_index)
+        purged_balances = Aex9BalancesCache.purge(contract_pk, block_index)
         {balances, _height_hash} = DBN.aex9_balances(contract_pk, {type, height, next_hash})
         Aex9BalancesCache.put(contract_pk, block_index, next_hash, balances)
 
-        balances
+        {balances, purged_balances}
     end
   end
 

--- a/lib/ae_mdw/sync/supervisor.ex
+++ b/lib/ae_mdw/sync/supervisor.ex
@@ -7,6 +7,7 @@ defmodule AeMdw.Sync.Supervisor do
 
   alias AeMdw.Sync.Server
   alias AeMdw.Sync.Watcher
+  alias AeMdw.Sync.AsyncStoreServer
 
   @spec start_link(term()) :: Supervisor.on_start()
   def start_link(init_arg) do
@@ -18,6 +19,7 @@ defmodule AeMdw.Sync.Supervisor do
     children = [
       Server,
       Watcher,
+      AsyncStoreServer,
       {Task.Supervisor, name: Server.task_supervisor()}
     ]
 

--- a/test/ae_mdw/db/async_store_test.exs
+++ b/test/ae_mdw/db/async_store_test.exs
@@ -2,32 +2,34 @@ defmodule AeMdw.Db.AsyncStoreTest do
   use ExUnit.Case
 
   alias AeMdw.Db.AsyncStore
+  alias AeMdw.Db.Model
   alias AeMdw.Db.Store
 
+  require Model
+
   describe "next/2" do
-    test "it returns the next value" do
+    test "it returns the next value from same table" do
       store = AsyncStore.instance()
+
+      txi1 = Enum.random(100_000_000..999_999_999)
+      txi2 = txi1 + 1
+
+      on_exit(fn ->
+        store
+        |> Store.delete(Model.Tx, txi1)
+        |> Store.delete(Model.Tx, txi2)
+        |> Store.delete(Model.Type, {:ga_meta_tx, txi1})
+      end)
 
       store =
         store
-        |> Store.put(:table, {:record, :key1, :val1})
-        |> Store.put(:table, {:record, :key2, :val2})
+        |> Store.put(Model.Tx, Model.tx(index: txi1))
+        |> Store.put(Model.Tx, Model.tx(index: txi2))
+        |> Store.put(Model.Type, Model.type(index: {:ga_meta_tx, txi1}))
 
-      assert {:ok, :key1} = Store.next(store, :table, :key0)
-      assert {:ok, :key2} = Store.next(store, :table, :key1)
-      assert :none = Store.next(store, :table, :key2)
-    end
-
-    test "when other tables present, it doesn't return values from them" do
-      store = AsyncStore.instance()
-
-      store =
-        store
-        |> Store.put(:table1, {:record, :key1, :val1})
-        |> Store.put(:table1, {:record, :key2, :val2})
-        |> Store.put(:table2, {:record, :key3, :val3})
-
-      assert :none = Store.next(store, :table1, :key2)
+      assert {:ok, ^txi1} = Store.next(store, Model.Tx, txi1 - 1)
+      assert {:ok, ^txi2} = Store.next(store, Model.Tx, txi1)
+      assert :none = Store.next(store, Model.Tx, 999_999_999)
     end
   end
 end

--- a/test/ae_mdw/db/state_test.exs
+++ b/test/ae_mdw/db/state_test.exs
@@ -1,59 +1,192 @@
 defmodule AeMdw.Db.StateTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
+  alias AeMdw.AsyncTaskTestUtil
+  alias AeMdw.Database
+  alias AeMdw.Db.Aex9BalancesCache
+  alias AeMdw.Db.AexnCreateContractMutation
   alias AeMdw.Db.AsyncStore
+  alias AeMdw.Db.MemStore
   alias AeMdw.Db.Model
+  alias AeMdw.Db.NullStore
   alias AeMdw.Db.State
+  alias AeMdw.Db.WriteMutation
+  alias AeMdw.Sync.AsyncTasks
+  alias AeMdw.Sync.AsyncTasks.Store
+
+  require Model
 
   import Mock
 
-  require Model
+  @kb_hash :crypto.strong_rand_bytes(32)
+  @next_hash :crypto.strong_rand_bytes(32)
+
+  setup_all _ do
+    AsyncTasks.Supervisor.start_link([])
+    Process.sleep(200)
+    :ok
+  end
+
+  setup_with_mocks([
+    {AeMdw.Node.Db, [],
+     [
+       get_key_block_hash: fn _height -> @kb_hash end,
+       get_next_hash: fn _kb_hash, _mbi -> @next_hash end
+     ]}
+  ]) do
+    :ok
+  end
+
+  describe "commit_db" do
+    test "persists db-only aex9 tasks and saves results into database" do
+      ct_pk = :crypto.strong_rand_bytes(32)
+      block_index = {567_890, 2}
+      call_txi = 12_345_678
+
+      account_pk = :crypto.strong_rand_bytes(32)
+      amount = Enum.random(1_000_000_000..9_999_999_999)
+      balances = %{{:address, account_pk} => amount}
+
+      Aex9BalancesCache.put(ct_pk, block_index, @next_hash, balances)
+
+      State.new()
+      |> State.enqueue(:update_aex9_state, [ct_pk], [block_index, call_txi])
+      |> State.commit_db([WriteMutation.new(Model.Block, Model.block(index: block_index))], false)
+
+      tasks =
+        Model.AsyncTask
+        |> Database.all_keys()
+        |> Enum.map(fn key -> Database.fetch!(Model.AsyncTask, key) end)
+
+      assert Enum.any?(tasks, fn
+               Model.async_task(
+                 index: {_ts, :update_aex9_state},
+                 args: [^ct_pk],
+                 extra_args: [^block_index, ^call_txi]
+               ) ->
+                 true
+
+               _other ->
+                 false
+             end)
+
+      AsyncTaskTestUtil.wakeup_consumers()
+
+      assert Enum.any?(1..10, fn _i ->
+               Process.sleep(100)
+
+               match?(
+                 {:ok,
+                  Model.aex9_account_presence(
+                    index: {^account_pk, ^ct_pk},
+                    txi: ^call_txi
+                  )},
+                 Database.fetch(Model.Aex9AccountPresence, {account_pk, ct_pk})
+               )
+             end)
+    end
+
+    test "doesn't enqueue aex9 task again after enqueued by on-memory sync" do
+      ct_pk = :crypto.strong_rand_bytes(32)
+      block_index = {567_890, 2}
+      call_txi = 12_345_679
+
+      Aex9BalancesCache.put(ct_pk, block_index, @next_hash, %{
+        {:address, :crypto.strong_rand_bytes(32)} => <<>>
+      })
+
+      dedup_args = [ct_pk]
+      extra_args = [block_index, call_txi]
+
+      NullStore.new()
+      |> MemStore.new()
+      |> State.new()
+      |> State.enqueue(:update_aex9_state, dedup_args, extra_args)
+      |> State.commit_mem([])
+
+      AsyncTaskTestUtil.wakeup_consumers()
+
+      assert {task_index, _time} =
+               AeMdw.EtsCache.get(
+                 :async_tasks_added,
+                 {:update_aex9_state, dedup_args, extra_args}
+               )
+
+      assert Enum.any?(1..10, fn _i ->
+               Process.sleep(100)
+
+               nil ==
+                 Enum.find(Store.fetch_unprocessed(), fn Model.async_task(args: args) ->
+                   args == dedup_args
+                 end)
+             end)
+
+      State.new()
+      |> State.enqueue(:update_aex9_state, dedup_args, extra_args)
+      |> State.commit_db([WriteMutation.new(Model.Block, Model.block(index: block_index))], false)
+
+      assert {^task_index, _time} =
+               AeMdw.EtsCache.get(
+                 :async_tasks_added,
+                 {:update_aex9_state, dedup_args, extra_args}
+               )
+    end
+  end
 
   describe "commit_mem" do
     test "saves aex9 state into ets store" do
       ct_pk = :crypto.strong_rand_bytes(32)
-      {kbi, mbi} = block_index = {123_456, 2}
-      next_kbi = kbi + 1
-      call_txi = 12_345_678
+      block_index = {567_891, 2}
+      call_txi = 12_345_680
 
-      next_kb_hash = :crypto.strong_rand_bytes(32)
-      next_mb_hash = :crypto.strong_rand_bytes(32)
       account_pk = :crypto.strong_rand_bytes(32)
       amount = Enum.random(1_000_000_000..9_999_999_999)
+      balances = %{{:address, account_pk} => amount}
 
-      with_mocks [
-        {AeMdw.Node.Db, [],
-         [
-           get_key_block_hash: fn
-             ^next_kbi ->
-               next_kb_hash
-           end,
-           get_next_hash: fn ^next_kb_hash, ^mbi -> next_mb_hash end,
-           aex9_balances: fn ^ct_pk, {:micro, ^kbi, ^next_mb_hash} ->
-             balances = %{{:address, account_pk} => amount}
+      Aex9BalancesCache.put(ct_pk, block_index, @next_hash, balances)
 
-             {balances, nil}
-           end
-         ]}
-      ] do
-        state = State.enqueue(State.new(), :update_aex9_state, [ct_pk], [block_index, call_txi])
-        assert %State{} = State.commit_mem(state, [])
+      NullStore.new()
+      |> MemStore.new()
+      |> State.new()
+      |> State.commit_mem([
+        AexnCreateContractMutation.new(
+          :aex9,
+          ct_pk,
+          {"mem_aex9", "mem_aex9", 18},
+          block_index,
+          call_txi,
+          []
+        )
+      ])
 
-        ets_state = State.new(AsyncStore.instance())
-        presence_key = {account_pk, ct_pk}
-        balance_key = {ct_pk, account_pk}
+      assert AeMdw.EtsCache.member(
+               :async_tasks_added,
+               {:update_aex9_state, [ct_pk], [block_index, call_txi]}
+             )
 
-        assert {:ok, Model.aex9_account_presence(index: ^presence_key, txi: ^call_txi)} =
-                 State.get(ets_state, Model.Aex9AccountPresence, presence_key)
+      AsyncTaskTestUtil.wakeup_consumers()
 
-        assert {:ok,
-                Model.aex9_balance(
-                  index: ^balance_key,
-                  block_index: ^block_index,
-                  txi: ^call_txi,
-                  amount: ^amount
-                )} = State.get(ets_state, Model.Aex9Balance, balance_key)
-      end
+      state = State.new(AsyncStore.instance())
+      presence_key = {account_pk, ct_pk}
+
+      assert Enum.any?(1..10, fn _i ->
+               Process.sleep(100)
+
+               match?(
+                 {:ok, Model.aex9_account_presence(index: ^presence_key, txi: ^call_txi)},
+                 State.get(state, Model.Aex9AccountPresence, presence_key)
+               )
+             end)
+
+      balance_key = {ct_pk, account_pk}
+
+      assert {:ok,
+              Model.aex9_balance(
+                index: ^balance_key,
+                block_index: ^block_index,
+                txi: ^call_txi,
+                amount: ^amount
+              )} = State.get(state, Model.Aex9Balance, balance_key)
     end
   end
 end

--- a/test/ae_mdw/db/sync/async_tasks/producer_test.exs
+++ b/test/ae_mdw/db/sync/async_tasks/producer_test.exs
@@ -1,0 +1,51 @@
+defmodule AeMdw.Sync.AsyncTasks.ProducerTest do
+  use ExUnit.Case
+
+  alias AeMdw.Database
+  alias AeMdw.Db.Model
+  alias AeMdw.Sync.AsyncTasks.Producer
+
+  import Mock
+
+  require Model
+
+  test "save_enqueue/0" do
+    args1 = [:crypto.strong_rand_bytes(32)]
+    args2 = [:crypto.strong_rand_bytes(32)]
+
+    {kbi, mbi} = block_index = {543_210, 10}
+    extra_args1 = [block_index, Enum.random(1_000_000..99_000_000)]
+    extra_args2 = [block_index, Enum.random(1_000_000..99_000_000)]
+
+    kb_hash = :crypto.strong_rand_bytes(32)
+    next_mb_hash = :crypto.strong_rand_bytes(32)
+
+    with_mocks [
+      {AeMdw.Node.Db, [],
+       [
+         get_key_block_hash: fn height ->
+           assert height == kbi + 1
+           kb_hash
+         end,
+         get_next_hash: fn ^kb_hash, ^mbi -> next_mb_hash end
+       ]}
+    ] do
+      Producer.enqueue(:update_aex9_state, args1, extra_args1, only_new: false)
+      Producer.enqueue(:update_aex9_state, args2, extra_args2, only_new: false)
+      Producer.save_enqueued()
+
+      all_tasks =
+        Model.AsyncTask
+        |> Database.all_keys()
+        |> Enum.map(&Database.fetch!(Model.AsyncTask, &1))
+
+      assert [Model.async_task(index: task_index1), Model.async_task(index: task_index2)] =
+               Enum.filter(all_tasks, fn Model.async_task(args: args, extra_args: extra_args) ->
+                 {args, extra_args} in [{args1, extra_args1}, {args2, extra_args2}]
+               end)
+
+      Database.dirty_delete(Model.AsyncTask, task_index1)
+      Database.dirty_delete(Model.AsyncTask, task_index2)
+    end
+  end
+end

--- a/test/ae_mdw/sync/async_tasks/stats_test.exs
+++ b/test/ae_mdw/sync/async_tasks/stats_test.exs
@@ -39,12 +39,12 @@ defmodule AeMdw.Sync.AsyncTasks.StatsTest do
         end)
       end)
 
-      pending_count = length(m_tasks)
-
       # setup new to expected pending
       Enum.each(m_tasks, fn m_task ->
         Database.dirty_write(Model.AsyncTask, m_task)
       end)
+
+      pending_count = Database.count(Model.AsyncTask)
 
       assert %{producer_buffer: 0, total_pending: 0} = Stats.counters()
       assert :ok = Stats.update_buffer_len(5, 100)

--- a/test/ae_mdw/sync/async_tasks/store_test.exs
+++ b/test/ae_mdw/sync/async_tasks/store_test.exs
@@ -1,63 +1,187 @@
 defmodule AeMdw.Sync.AsyncTasks.StoreTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
-  alias AeMdw.Db.Model
   alias AeMdw.Database
+  alias AeMdw.Db.Model
   alias AeMdw.Sync.AsyncTasks.Store
 
   require Model
   require Ex2ms
 
   @task_type :update_aex9_state
-  @args1 [<<123_456::256>>]
-  @extra_args1 [{543_211, 11}, 12_345_678]
 
-  @args2 [<<123_457::256>>]
-  @extra_args2 [{543_212, 12}, 12_345_679]
+  describe "add/0" do
+    test "inserts not enqueued task once" do
+      dedup_args = [:crypto.strong_rand_bytes(32)]
 
-  describe "save_new/2 and fetch_unprocessed/1 success" do
-    test "for an unprocessed task" do
       on_exit(fn ->
-        setup_delete_async_task(@args1)
+        :ets.delete(:async_tasks_pending, {@task_type, dedup_args})
       end)
 
-      Store.save_new(@task_type, @args1)
-      Store.save_new(@task_type, @args1, @extra_args1)
-      tasks = Store.fetch_unprocessed(1000)
+      m_task1 =
+        Model.async_task(
+          index: {System.unique_integer(), @task_type},
+          args: dedup_args,
+          extra_args: [{1, 1}, 0]
+        )
 
-      assert 1 == Enum.count(tasks, fn Model.async_task(args: args) -> args == @args1 end)
+      m_task2 =
+        Model.async_task(
+          index: {System.unique_integer(), @task_type},
+          args: dedup_args,
+          extra_args: [{1, 1}, 1]
+        )
+
+      Store.add(m_task1, only_new: false)
+      Store.add(m_task2, only_new: false)
+
+      assert [{{@task_type, dedup_args}, m_task1}] ==
+               :ets.lookup(:async_tasks_pending, {@task_type, dedup_args})
     end
 
-    test "for a task being processed" do
+    test "inserts again a task when not enqueued" do
+      dedup_args = [:crypto.strong_rand_bytes(32)]
+
       on_exit(fn ->
-        setup_delete_async_task(@args2)
+        :ets.delete(:async_tasks_pending, {@task_type, dedup_args})
       end)
 
-      Store.save_new(@task_type, @args2, @extra_args2)
-      tasks_before = Store.fetch_unprocessed(1000)
+      m_task1 =
+        Model.async_task(
+          index: {System.unique_integer(), @task_type},
+          args: dedup_args,
+          extra_args: [{1, 1}, 0]
+        )
 
-      assert Model.async_task(index: task_index) =
-               Enum.find(tasks_before, fn Model.async_task(args: args, extra_args: extra_args) ->
-                 args == @args2 and extra_args == @extra_args2
-               end)
+      m_task2 =
+        Model.async_task(
+          index: {System.unique_integer(), @task_type},
+          args: dedup_args,
+          extra_args: [{1, 1}, 0]
+        )
 
-      Store.set_processing(task_index)
-      tasks_after = Store.fetch_unprocessed(1000)
+      Store.add(m_task1, only_new: false)
 
-      assert nil ==
-               Enum.find(tasks_after, fn Model.async_task(args: args) ->
-                 args == @args2
-               end)
+      assert [{{@task_type, dedup_args}, m_task1}] ==
+               :ets.lookup(:async_tasks_pending, {@task_type, dedup_args})
+
+      :ets.delete(:async_tasks_pending, {@task_type, dedup_args})
+
+      Store.add(m_task2, only_new: false)
+
+      assert [{{@task_type, dedup_args}, m_task2}] ==
+               :ets.lookup(:async_tasks_pending, {@task_type, dedup_args})
+    end
+
+    test "does not insert a task when not enqueued if not new" do
+      dedup_args = [:crypto.strong_rand_bytes(32)]
+
+      m_task1 =
+        Model.async_task(
+          index: {System.unique_integer(), @task_type},
+          args: dedup_args,
+          extra_args: [{1, 1}, 0]
+        )
+
+      m_task2 =
+        Model.async_task(
+          index: {System.unique_integer(), @task_type},
+          args: dedup_args,
+          extra_args: [{1, 1}, 0]
+        )
+
+      Store.add(m_task1, only_new: false)
+
+      assert [{{@task_type, dedup_args}, m_task1}] ==
+               :ets.lookup(:async_tasks_pending, {@task_type, dedup_args})
+
+      :ets.delete(:async_tasks_pending, {@task_type, dedup_args})
+
+      Store.add(m_task2, only_new: true)
+
+      refute [{{@task_type, dedup_args}, m_task2}] ==
+               :ets.lookup(:async_tasks_pending, {@task_type, dedup_args})
     end
   end
 
-  defp setup_delete_async_task(args) do
-    Model.async_task(index: key) =
-      Model.AsyncTask
-      |> Database.all_keys()
-      |> Enum.map(&Database.fetch!(Model.AsyncTask, &1))
-      |> Enum.find(fn m_task -> Model.async_task(m_task, :args) == args end)
+  describe "fetch_unprocessed/0" do
+    test "returns tasks when unprocessed" do
+      args1 = [:crypto.strong_rand_bytes(32)]
+      args2 = [:crypto.strong_rand_bytes(32)]
+      task_index = {System.unique_integer(), @task_type}
 
-    Database.dirty_delete(Model.AsyncTask, key)
+      on_exit(fn ->
+        :ets.delete(:async_tasks_pending, {@task_type, args1})
+        :ets.delete(:async_tasks_pending, {@task_type, args2})
+        Database.dirty_delete(Model.AsyncTask, task_index)
+      end)
+
+      extra_args = [{543_211, 11}, 12_345_678]
+
+      m_task1 = Model.async_task(index: task_index, args: args1, extra_args: extra_args)
+      m_task2 = Model.async_task(index: task_index, args: args2, extra_args: extra_args)
+
+      Store.add(m_task1, only_new: false)
+      Store.add(m_task2, only_new: false)
+      tasks = Store.fetch_unprocessed()
+
+      assert 1 == Enum.count(tasks, fn m_task -> m_task == m_task1 end)
+      assert 1 == Enum.count(tasks, fn m_task -> m_task == m_task2 end)
+    end
+
+    test "does not return a task being processed" do
+      args = [:crypto.strong_rand_bytes(32)]
+      extra_args = [{543_212, 12}, 12_345_679]
+
+      task_index = {System.unique_integer(), @task_type}
+      m_task = Model.async_task(index: task_index, args: args, extra_args: extra_args)
+
+      on_exit(fn ->
+        :ets.delete(:async_tasks_pending, {@task_type, args})
+        :ets.delete(:async_tasks_processing, task_index)
+        Database.dirty_delete(Model.AsyncTask, task_index)
+      end)
+
+      Store.add(m_task, only_new: false)
+      tasks_before = Store.fetch_unprocessed()
+
+      assert 1 == Enum.count(tasks_before, &(&1 == m_task))
+
+      Store.set_processing(task_index)
+      tasks_after = Store.fetch_unprocessed()
+
+      refute Enum.find(tasks_after, &(&1 == m_task))
+    end
+  end
+
+  describe "save/0" do
+    test "succeeds saving not only pending tasks but in processing state as well" do
+      args1 = [:crypto.strong_rand_bytes(32)]
+      args2 = [:crypto.strong_rand_bytes(32)]
+      extra_args = [{543_212, 13}, 12_345_680]
+
+      task_index1 = {System.unique_integer(), @task_type}
+      task_index2 = {System.unique_integer(), @task_type}
+      m_task1 = Model.async_task(index: task_index1, args: args1, extra_args: extra_args)
+      m_task2 = Model.async_task(index: task_index2, args: args2, extra_args: extra_args)
+
+      on_exit(fn ->
+        :ets.delete(:async_tasks_pending, {@task_type, args1})
+        :ets.delete(:async_tasks_pending, {@task_type, args2})
+        :ets.delete(:async_tasks_processing, task_index2)
+        Database.dirty_delete(Model.AsyncTask, task_index1)
+        Database.dirty_delete(Model.AsyncTask, task_index2)
+      end)
+
+      Store.add(m_task1, only_new: false)
+      Store.add(m_task2, only_new: false)
+      Store.set_processing(task_index2)
+      Store.save()
+
+      tasks = Store.fetch_unprocessed()
+
+      assert 1 == Enum.count(tasks, fn m_task -> m_task == m_task1 end)
+      refute Enum.find(tasks, fn m_task -> m_task == m_task2 end)
+    end
   end
 end

--- a/test/ae_mdw_web/controllers/aexn_token_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aexn_token_controller_test.exs
@@ -3,6 +3,7 @@ defmodule AeMdwWeb.AexnTokenControllerTest do
 
   alias AeMdw.Database
   alias AeMdw.Db.AexnCreateContractMutation
+  alias AeMdw.Db.Contract
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
 
@@ -349,15 +350,10 @@ defmodule AeMdwWeb.AexnTokenControllerTest do
       contract_pk = :crypto.strong_rand_bytes(32)
       aexn_meta_info = {:out_of_gas_error, :out_of_gas_error, nil}
 
-      State.commit(State.new(), [
-        AexnCreateContractMutation.new(
-          :aex9,
-          contract_pk,
-          aexn_meta_info,
-          {123, 0},
-          123_456,
-          ["ext1", "ext2"]
-        )
+      State.new()
+      |> Contract.aexn_creation_write(:aex9, aexn_meta_info, contract_pk, 12_345_678, [
+        "ext1",
+        "ext2"
       ])
 
       contract_id = enc_ct(contract_pk)
@@ -403,7 +399,7 @@ defmodule AeMdwWeb.AexnTokenControllerTest do
           contract_pk,
           aexn_meta_info,
           {123, 1},
-          123_456,
+          12_345_679,
           ["ext1", "ext2"]
         )
       ])

--- a/test/support/ae_mdw/async_task_test_util.ex
+++ b/test/support/ae_mdw/async_task_test_util.ex
@@ -1,0 +1,19 @@
+defmodule AeMdw.AsyncTaskTestUtil do
+  @moduledoc """
+  Test helper functions to synchronize with Async Tasks results
+  """
+
+  alias AeMdw.Sync.AsyncTasks
+
+  @spec wakeup_consumers() :: :ok
+  def wakeup_consumers do
+    AsyncTasks.Supervisor
+    |> Supervisor.which_children()
+    |> Enum.filter(fn {id, _pid, _type, _mod} ->
+      is_binary(id) and String.starts_with?(id, "Elixir.AeMdw.Sync.AsyncTasks.Consumer")
+    end)
+    |> Enum.each(fn {_id, consumer_pid, _type, _mod} ->
+      Process.send(consumer_pid, :demand, [:noconnect])
+    end)
+  end
+end


### PR DESCRIPTION
## What

- Runs aex9 tasks asynchronously
- Purges aex9 in-memory and persisted records belonging to invalidated blocks
- Synchronizes the writing of async task result with the main sync database transaction so that if the task finishes later it writes directly to the database.
- Avoid rerunning the tasks for on-db sync (use previous in-memory task result to write to database)

## Why

Refs #749 

## Validation steps

- test/ae_mdw/sync/async_tasks/update_aex9_state_test.exs 
  - validates writing to async (in-memory) store
- test/ae_mdw/sync/async_tasks/store_test.exs
  - validates not to insert a task when it had been added before (if added to on-memory doesn't do for on-db sync)
- test/ae_mdw/db/state_test.exs 
  - validates the synchronization to write to memory or to disk
  - validates that if task was enqueued by on-memory sync it does not run again during on-db sync 
  - validates that commit to database uses previously run task results 
  - validates that pending tasks are only persisted during commit to database
- test/ae_mdw/db/sync/async_tasks/producer_consumer_test.exs
  - validates enqueuing and dequeuing tasks
- test/ae_mdw/db/sync/async_tasks/producer_test.exs
  - validates that pending tasks are persisted after saving in case of server restart

## Notes

Next tasks:
1. Keep the sorting while enqueuing with State
2. Allow enqueuing tasks to rerun if it's in processing state
3. Avoid rerunning the tasks during in-memory sync by detecting invalidations outside of the task
4. After 3, cache next hashes in a way to avoid walking through the blocks repeatedly for every task call. 