### PR TITLE
fix: include ga_attach_tx when counting contracts

### DIFF
--- a/lib/ae_mdw/db/origin.ex
+++ b/lib/ae_mdw/db/origin.ex
@@ -107,7 +107,8 @@ defmodule AeMdw.Db.Origin do
 
   @spec count_contracts(State.t()) :: non_neg_integer()
   def count_contracts(state) do
-    count_by_tx_type(state, :contract_create_tx) + count_by_tx_type(state, :contract_call_tx)
+    count_by_tx_type(state, :contract_create_tx) + count_by_tx_type(state, :contract_call_tx) +
+      count_by_tx_type(state, :ga_attach_tx)
   end
 
   #

--- a/test/ae_mdw/db/origin_test.exs
+++ b/test/ae_mdw/db/origin_test.exs
@@ -1,0 +1,35 @@
+defmodule AeMdw.Db.OriginTest do
+  use ExUnit.Case, async: false
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.MemStore
+  alias AeMdw.Db.NullStore
+  alias AeMdw.Db.Origin
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Store
+  alias AeMdw.TestSamples, as: TS
+
+  require Model
+
+  describe "count_contracts/1" do
+    test "it counts spend_tx, contract_call_tx and ga_attach_tx contract origins" do
+      contract_pk1 = TS.contract_pk(0)
+      contract_pk2 = TS.contract_pk(1)
+      contract_pk3 = TS.contract_pk(2)
+      contract_pk4 = TS.contract_pk(3)
+      contract_pk5 = TS.contract_pk(4)
+
+      state =
+        NullStore.new()
+        |> MemStore.new()
+        |> Store.put(Model.Origin, Model.origin(index: {:contract_create_tx, contract_pk1, 123}))
+        |> Store.put(Model.Origin, Model.origin(index: {:contract_create_tx, contract_pk2, 123}))
+        |> Store.put(Model.Origin, Model.origin(index: {:contract_create_tx, contract_pk3, 123}))
+        |> Store.put(Model.Origin, Model.origin(index: {:contract_call_tx, contract_pk4, 123}))
+        |> Store.put(Model.Origin, Model.origin(index: {:ga_attach_tx, contract_pk5, 123}))
+        |> State.new()
+
+      assert 5 = Origin.count_contracts(state)
+    end
+  end
+end

--- a/test/support/test_sample.ex
+++ b/test/support/test_sample.ex
@@ -116,4 +116,21 @@ defmodule AeMdw.TestSamples do
     end)
     |> Enum.at(n)
   end
+
+  @spec contract_pk(non_neg_integer()) :: Db.pubkey()
+  def contract_pk(n) do
+    ~w(
+      ct_y7gojSY8rXW6tztE9Ftqe3kmNrqEXsREiPwGCeG3MJL38jkFo
+      ct_azbNZ1XrPjXfqBqbAh1ffLNTQ1sbnuUDFvJrXjYz7JQA1saQ3
+      ct_eJhrbPPS4V97VLKEVbSCJFpdA4uyXiZujQyLqMFoYV88TzDe6
+      ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z
+      ct_jmRkfpzmn7KZbXbkEL9wueJkb1vaFzMnVFJMFjAnJgj1CTtQe
+    )
+    |> Enum.map(fn hash ->
+      {:ok, decoded_hash} = :aeser_api_encoder.safe_decode(:contract_pubkey, hash)
+
+      decoded_hash
+    end)
+    |> Enum.at(n)
+  end
 end


### PR DESCRIPTION
In order to update the stats we're going to need to run a full-sync, this bug has been always present, even in production.