### PR TITLE
refactor: decrease consumer async server wait and sleep

### DIFF
--- a/lib/ae_mdw/sync/async_tasks/producer.ex
+++ b/lib/ae_mdw/sync/async_tasks/producer.ex
@@ -13,7 +13,7 @@ defmodule AeMdw.Sync.AsyncTasks.Producer do
   require Model
   require Logger
 
-  @max_buffer_size 100
+  @long_timeout_ms 10_000
 
   @spec start_link(any()) :: GenServer.on_start()
   def start_link(_args) do
@@ -41,7 +41,7 @@ defmodule AeMdw.Sync.AsyncTasks.Producer do
 
   @spec dequeue() :: nil | Model.async_task_record()
   def dequeue() do
-    GenServer.call(__MODULE__, :dequeue)
+    GenServer.call(__MODULE__, :dequeue, @long_timeout_ms)
   end
 
   @spec notify_consumed(Model.async_task_index(), Model.async_task_args(), boolean()) :: :ok
@@ -74,7 +74,7 @@ defmodule AeMdw.Sync.AsyncTasks.Producer do
 
     new_buffer
     |> length()
-    |> Stats.update_buffer_len(@max_buffer_size)
+    |> Stats.update_buffer_len()
 
     {:reply, m_task, new_state}
   end

--- a/lib/ae_mdw/sync/async_tasks/stats.ex
+++ b/lib/ae_mdw/sync/async_tasks/stats.ex
@@ -23,15 +23,11 @@ defmodule AeMdw.Sync.AsyncTasks.Stats do
     :ok
   end
 
-  @spec update_buffer_len(pos_integer(), pos_integer()) :: :ok
-  def update_buffer_len(producer_buffer_len, max_len) do
+  @spec update_buffer_len(pos_integer()) :: :ok
+  def update_buffer_len(producer_buffer_len) do
     :ets.update_element(@tab, @stats_key, {@buffer_len_pos, producer_buffer_len})
 
-    cond do
-      producer_buffer_len == 0 -> reset_db_count()
-      rem(max_len, @max_db_count_times) == 0 -> update_db_count()
-      true -> :noop
-    end
+    if rem(producer_buffer_len, @max_db_count_times) == 0, do: update_db_count()
 
     :ok
   end
@@ -76,9 +72,5 @@ defmodule AeMdw.Sync.AsyncTasks.Stats do
   defp update_db_count() do
     db_pending_count = Database.count(Model.AsyncTask)
     :ets.update_element(@tab, @stats_key, {@db_count_pos, db_pending_count})
-  end
-
-  defp reset_db_count() do
-    :ets.update_element(@tab, @stats_key, {@db_count_pos, 0})
   end
 end

--- a/lib/ae_mdw/sync/async_tasks/update_aex9_state.ex
+++ b/lib/ae_mdw/sync/async_tasks/update_aex9_state.ex
@@ -19,16 +19,20 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9State do
 
   @microsecs 1_000_000
 
-  @spec process(args :: list()) :: :ok
-  def process([contract_pk, block_index, _call_txi] = args) do
+  @spec process(args :: list(), done_fn :: fun()) :: :ok
+  def process([contract_pk, block_index, _call_txi] = args, done_fn) do
     {time_delta, {write_mutation, delete_mutation}} = :timer.tc(fn -> mutations(args) end)
 
     Log.info("[update_aex9_state] #{enc_ct(contract_pk)} after #{time_delta / @microsecs}s")
 
-    AsyncStoreServer.write_mutations(block_index, [
-      delete_mutation,
-      write_mutation
-    ])
+    AsyncStoreServer.write_mutations(
+      block_index,
+      [
+        delete_mutation,
+        write_mutation
+      ],
+      done_fn
+    )
 
     :ok
   end

--- a/lib/ae_mdw/sync/async_tasks/work.ex
+++ b/lib/ae_mdw/sync/async_tasks/work.ex
@@ -3,5 +3,5 @@ defmodule AeMdw.Sync.AsyncTasks.Work do
   The interface for actual processing modules.
   """
 
-  @callback process(args :: list()) :: :ok
+  @callback process(args :: list(), done_fn :: fun()) :: :ok
 end

--- a/test/ae_mdw/sync/async_tasks/stats_test.exs
+++ b/test/ae_mdw/sync/async_tasks/stats_test.exs
@@ -14,7 +14,7 @@ defmodule AeMdw.Sync.AsyncTasks.StatsTest do
 
   describe "update_buffer_len/2 and counter/0 success" do
     test "without pending db records" do
-      assert :ok = Stats.update_buffer_len(15, 100)
+      assert :ok = Stats.update_buffer_len(15)
       assert %{producer_buffer: 15} = Stats.counters()
     end
 
@@ -47,14 +47,14 @@ defmodule AeMdw.Sync.AsyncTasks.StatsTest do
       pending_count = Database.count(Model.AsyncTask)
 
       assert %{producer_buffer: 0, total_pending: 0} = Stats.counters()
-      assert :ok = Stats.update_buffer_len(5, 100)
-      assert %{producer_buffer: 5, total_pending: ^pending_count} = Stats.counters()
+      assert :ok = Stats.update_buffer_len(10)
+      assert %{producer_buffer: 10, total_pending: ^pending_count} = Stats.counters()
     end
   end
 
   describe "update_consumed/2 and counter/0 success" do
     test "without pending db records" do
-      assert :ok = Stats.update_buffer_len(15, 100)
+      assert :ok = Stats.update_buffer_len(15)
       assert :ok = Stats.inc_long_tasks_count()
       assert :ok = Stats.inc_long_tasks_count()
       assert %{producer_buffer: 15, long_tasks: 2} = Stats.counters()

--- a/test/ae_mdw/sync/async_tasks/update_aex9_state_test.exs
+++ b/test/ae_mdw/sync/async_tasks/update_aex9_state_test.exs
@@ -65,7 +65,7 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9StateTest do
       amount1 = @amount1
       amount2 = @amount2
 
-      UpdateAex9State.process([@contract_pk1, block_index, call_txi])
+      UpdateAex9State.process([@contract_pk1, block_index, call_txi], fn -> :ok end)
 
       state = State.new(AsyncStore.instance())
 
@@ -90,7 +90,7 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9StateTest do
       block_index = {@kbi, @mbi}
       call_txi = 12_345_680
 
-      UpdateAex9State.process([@contract_pk2, block_index, call_txi])
+      UpdateAex9State.process([@contract_pk2, block_index, call_txi], fn -> :ok end)
 
       state = State.new(AsyncStore.instance())
 
@@ -115,7 +115,7 @@ defmodule AeMdw.Sync.AsyncTasks.UpdateAex9StateTest do
         {:address, account_pk2} => amount2
       })
 
-      UpdateAex9State.process([@contract_pk3, {@kbi, @mbi}, call_txi])
+      UpdateAex9State.process([@contract_pk3, {@kbi, @mbi}, call_txi], fn -> :ok end)
       state = State.new(AsyncStore.instance())
 
       Enum.any?(1..10, fn _i ->


### PR DESCRIPTION
Decreases the number of soft real time preemption on `AsyncStoreServer` by delegating the signaling of async task done.