### PR TITLE
feat: add txs per second stat on /stats

### DIFF
--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -594,6 +594,11 @@ defmodule AeMdw.Db.Model do
             burned_in_auctions: non_neg_integer()
           )
 
+  @stat_defaults [:index, :payload]
+  defrecord :stat, @stat_defaults
+
+  @type stat() :: record(:stat, index: atom(), payload: term())
+
   ################################################################################
 
   # starts with only chain_tables and add them progressively by groups
@@ -684,7 +689,8 @@ defmodule AeMdw.Db.Model do
   defp stat_tables() do
     [
       AeMdw.Db.Model.DeltaStat,
-      AeMdw.Db.Model.TotalStat
+      AeMdw.Db.Model.TotalStat,
+      AeMdw.Db.Model.Stat
     ]
   end
 
@@ -754,4 +760,5 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.TargetKindIntTransferTx), do: :target_kind_int_transfer_tx
   def record(AeMdw.Db.Model.DeltaStat), do: :delta_stat
   def record(AeMdw.Db.Model.TotalStat), do: :total_stat
+  def record(AeMdw.Db.Model.Stat), do: :stat
 end

--- a/lib/ae_mdw/db/state.ex
+++ b/lib/ae_mdw/db/state.ex
@@ -138,6 +138,14 @@ defmodule AeMdw.Db.State do
 
   def next(state, table, :forward, cursor), do: next(state, table, cursor)
 
+  @spec update(t(), table(), key(), (record() -> record()), term() | nil) :: t()
+  def update(state, table, key, update_fn, default \\ nil) do
+    case get(state, table, key) do
+      {:ok, record} -> put(state, table, update_fn.(record))
+      :not_found -> put(state, table, update_fn.(default))
+    end
+  end
+
   @spec inc_stat(t(), stat_name(), integer()) :: t()
   def inc_stat(state, name, delta \\ 1)
 

--- a/lib/ae_mdw/db/sync/block.ex
+++ b/lib/ae_mdw/db/sync/block.ex
@@ -22,13 +22,13 @@ defmodule AeMdw.Db.Sync.Block do
   alias AeMdw.Db.NamesExpirationMutation
   alias AeMdw.Db.OraclesExpirationMutation
   alias AeMdw.Db.State
-  alias AeMdw.Db.StatsMutation
   alias AeMdw.Db.Sync.Transaction
   alias AeMdw.Db.WriteMutation
   alias AeMdw.Db.Mutation
   alias AeMdw.Log
   alias AeMdw.Node, as: AE
   alias AeMdw.Node.Db
+  alias AeMdw.Stats
   alias AeMdw.Txs
 
   require Model
@@ -99,7 +99,7 @@ defmodule AeMdw.Db.Sync.Block do
         block_rewards_mutation,
         NamesExpirationMutation.new(height),
         OraclesExpirationMutation.new(height),
-        StatsMutation.new(height, starting_from_mb0?),
+        Stats.mutation(height, key_block, micro_blocks, starting_from_mb0?),
         next_kb_mutation
       ]
 

--- a/lib/ae_mdw_web/controllers/stats_controller.ex
+++ b/lib/ae_mdw_web/controllers/stats_controller.ex
@@ -3,13 +3,15 @@ defmodule AeMdwWeb.StatsController do
 
   alias AeMdw.Stats
   alias AeMdwWeb.Plugs.PaginatedPlug
+  alias AeMdwWeb.FallbackController
   alias AeMdwWeb.Util
   alias Plug.Conn
 
   plug(PaginatedPlug)
+  action_fallback(FallbackController)
 
-  @spec stats(Conn.t(), map()) :: Conn.t()
-  def stats(%Conn{assigns: assigns} = conn, _params) do
+  @spec stats_v1(Conn.t(), map()) :: Conn.t()
+  def stats_v1(%Conn{assigns: assigns} = conn, _params) do
     %{
       state: state,
       pagination: {direction, _is_reversed?, limit, _has_cursor?},
@@ -51,5 +53,13 @@ defmodule AeMdwWeb.StatsController do
       Stats.fetch_total_stats(state, direction, scope, cursor, limit)
 
     Util.paginate(conn, prev_cursor, stats, next_cursor)
+  end
+
+  @spec stats(Conn.t(), map()) :: Conn.t()
+  def stats(%Conn{assigns: %{state: state}} = conn, _params) do
+    case Stats.fetch_stats(state) do
+      {:ok, stats} -> json(conn, stats)
+      {:error, reason} -> {:error, reason}
+    end
   end
 end

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -78,6 +78,7 @@ defmodule AeMdwWeb.Router do
       get "/oracles", OracleController, :oracles
 
       get "/deltastats", StatsController, :delta_stats
+      get "/stats", StatsController, :stats
 
       scope "/swagger" do
         forward "/", SwaggerForwardV2,
@@ -155,7 +156,7 @@ defmodule AeMdwWeb.Router do
     get "/aex9/balances/hash/:blockhash/:contract_id", Aex9Controller, :balances_for_hash
     get "/aex9/balances/:contract_id", Aex9Controller, :balances
 
-    get "/stats", StatsController, :stats
+    get "/stats", StatsController, :stats_v1
     get "/stats/:direction", StatsController, :stats
     get "/stats/:scope_type/:range", StatsController, :stats
     get "/totalstats/:direction", StatsController, :total_stats


### PR DESCRIPTION
TPS is calculated by grabbing the microblocks from a single gen and using the total transactions from that gen

refs #821
