### PR TITLE
fix: handle dry-run error when contract is not present

### DIFF
--- a/lib/ae_mdw/dry_run/contract.ex
+++ b/lib/ae_mdw/dry_run/contract.ex
@@ -6,7 +6,6 @@ defmodule AeMdw.DryRun.Contract do
   alias AeMdw.Util
 
   @typep pubkey() :: <<_::256>>
-  @typep block_hash() :: <<_::256>>
 
   @abi_fate_sophia_1 3
   @gas 10_000_000_000_000_000_000_000
@@ -14,19 +13,12 @@ defmodule AeMdw.DryRun.Contract do
   @spec new_call_tx(
           pubkey(),
           pubkey(),
-          block_hash(),
           AeMdw.Contract.method_name(),
           AeMdw.Contract.method_args(),
           pos_integer()
         ) :: AeMdw.Node.aetx()
-  def new_call_tx(caller_pk, contract_pk, block_hash, function_name, args, gas \\ @gas) do
-    {_tx_env, trees} = :aetx_env.tx_env_and_trees_from_hash(:aetx_contract, block_hash)
-    contracts = :aec_trees.contracts(trees)
-
-    contract_id =
-      contract_pk
-      |> :aect_state_tree.get_contract(contracts)
-      |> :aect_contracts.id()
+  def new_call_tx(caller_pk, contract_pk, function_name, args, gas \\ @gas) do
+    contract_id = :aeser_id.create(:contract, contract_pk)
 
     call_data =
       function_name

--- a/test/ae_mdw/db/contract_call_mutation_test.exs
+++ b/test/ae_mdw/db/contract_call_mutation_test.exs
@@ -187,7 +187,7 @@ defmodule AeMdw.Db.ContractCallMutationTest do
          [
            get_key_block_hash: fn 231_735 -> kb_hash end,
            get_next_hash: fn ^kb_hash, 54 -> next_mb_hash end,
-           aex9_balances: fn ^contract_pk, _next -> {%{}, nil} end
+           aex9_balances: fn ^contract_pk, _next -> {:ok, %{}} end
          ]}
       ] do
         state =

--- a/test/ae_mdw/db/contract_test.exs
+++ b/test/ae_mdw/db/contract_test.exs
@@ -69,8 +69,8 @@ defmodule AeMdw.Db.ContractTest do
            kb_hash
          end,
          get_next_hash: fn ^kb_hash, ^mbi -> next_mb_hash end,
-         aex9_balances: fn _ct_pk, {:micro, ^kbi, ^next_mb_hash} = block_tuple ->
-           {%{{:address, :crypto.strong_rand_bytes(32)} => <<>>}, block_tuple}
+         aex9_balances: fn _ct_pk, {:micro, ^kbi, ^next_mb_hash} ->
+           {:ok, %{{:address, :crypto.strong_rand_bytes(32)} => <<>>}}
          end
        ]}
     ] do

--- a/test/ae_mdw/db/state_test.exs
+++ b/test/ae_mdw/db/state_test.exs
@@ -77,6 +77,13 @@ defmodule AeMdw.Db.StateTest do
                  Database.fetch(Model.Aex9AccountPresence, {account_pk, ct_pk})
                )
              end)
+
+      task_index =
+        Enum.find_value(tasks, fn Model.async_task(index: index, args: args) ->
+          if args == [ct_pk], do: index
+        end)
+
+      refute Database.exists?(Model.AsyncTask, task_index)
     end
 
     test "doesn't enqueue aex9 task again after enqueued by on-memory sync" do

--- a/test/ae_mdw/dry_run/runner_test.exs
+++ b/test/ae_mdw/dry_run/runner_test.exs
@@ -1,0 +1,13 @@
+defmodule AeMdw.DryRun.RunnerTest do
+  use ExUnit.Case
+
+  alias AeMdw.Node.Db, as: DBN
+  alias AeMdw.DryRun.Runner
+
+  describe "call_contract/4" do
+    test "returs error when contract does not exist" do
+      assert {:error, :contract_does_not_exist} =
+               Runner.call_contract(<<123_456::256>>, DBN.top_height_hash(false), "balances", [])
+    end
+  end
+end


### PR DESCRIPTION
## What

- Replaces unnecessary use of banging `:aect_state_tree.get_contract(pubkey, contracts)`
- Discards the async task when dry-run fails due to `:contract_does_not_exist` or other error like insufficient funds. 

## Why

A contract may not exist anymore on a microblock referenced by block_index, which might happen syncing the last microblocks. 