### PR TITLE
fix: dequeue async tasks non-preemptively

### DIFF
--- a/test/ae_mdw/db/contract_call_mutation_test.exs
+++ b/test/ae_mdw/db/contract_call_mutation_test.exs
@@ -1,12 +1,12 @@
 defmodule AeMdw.Db.ContractCallMutationTest do
   use ExUnit.Case, async: false
 
+  alias AeMdw.AsyncTaskTestUtil
   alias AeMdw.Db.ContractCallMutation
   alias AeMdw.Db.Model
   alias AeMdw.Db.MemStore
   alias AeMdw.Db.NullStore
   alias AeMdw.Db.State
-  alias AeMdw.Sync.AsyncTasks
   alias AeMdw.Validate
 
   import AeMdw.Node.ContractCallFixtures
@@ -34,7 +34,7 @@ defmodule AeMdw.Db.ContractCallMutationTest do
       |> State.cache_put(:ct_create_sync_cache, contract_pk, call_txi - 1)
       |> State.commit_mem([mutation])
 
-      assert AsyncTasks.Store.fetch_unprocessed()
+      assert AsyncTaskTestUtil.list_pending()
              |> Enum.find(fn Model.async_task(args: args, extra_args: extra_args) ->
                args == [contract_pk] and extra_args == [block_index, call_txi]
              end)
@@ -61,7 +61,7 @@ defmodule AeMdw.Db.ContractCallMutationTest do
       |> State.cache_put(:ct_create_sync_cache, contract_pk, call_txi - 1)
       |> State.commit_mem([mutation])
 
-      assert AsyncTasks.Store.fetch_unprocessed()
+      assert AsyncTaskTestUtil.list_pending()
              |> Enum.find(fn Model.async_task(args: args, extra_args: extra_args) ->
                args == [contract_pk] and extra_args == [block_index, call_txi]
              end)
@@ -88,7 +88,7 @@ defmodule AeMdw.Db.ContractCallMutationTest do
       |> State.cache_put(:ct_create_sync_cache, contract_pk, call_txi - 1)
       |> State.commit_mem([mutation])
 
-      assert AsyncTasks.Store.fetch_unprocessed()
+      assert AsyncTaskTestUtil.list_pending()
              |> Enum.find(fn Model.async_task(args: args, extra_args: extra_args) ->
                args == [contract_pk] and extra_args == [block_index, call_txi]
              end)
@@ -110,7 +110,7 @@ defmodule AeMdw.Db.ContractCallMutationTest do
       |> State.cache_put(:ct_create_sync_cache, contract_pk, call_txi - 1)
       |> State.commit_mem([mutation])
 
-      assert AsyncTasks.Store.fetch_unprocessed()
+      assert AsyncTaskTestUtil.list_pending()
              |> Enum.find(fn Model.async_task(args: args, extra_args: extra_args) ->
                args == [contract_pk] and extra_args == [block_index, call_txi]
              end)

--- a/test/ae_mdw/db/contract_create_mutation_test.exs
+++ b/test/ae_mdw/db/contract_create_mutation_test.exs
@@ -4,6 +4,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
   import AeMdw.Node.ContractCallFixtures
   import Mock
 
+  alias AeMdw.AsyncTaskTestUtil
   alias AeMdw.AexnContracts
   alias AeMdw.Db.ContractCreateMutation
   alias AeMdw.Db.MemStore
@@ -12,7 +13,6 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
   alias AeMdw.Db.State
   alias AeMdw.Db.Sync.Contract, as: SyncContract
   alias AeMdw.Db.Sync.Origin
-  alias AeMdw.Sync.AsyncTasks
 
   require Model
 
@@ -52,7 +52,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
             )
           ])
 
-        assert AsyncTasks.Store.fetch_unprocessed()
+        assert AsyncTaskTestUtil.list_pending()
                |> Enum.find(fn Model.async_task(args: args, extra_args: extra_args) ->
                  args == [remote_pk] and extra_args == [block_index, create_txi1]
                end)

--- a/test/ae_mdw/db/contract_test.exs
+++ b/test/ae_mdw/db/contract_test.exs
@@ -2,12 +2,12 @@ defmodule AeMdw.Db.ContractTest do
   use ExUnit.Case, async: false
 
   alias AeMdw.AexnContracts
+  alias AeMdw.AsyncTaskTestUtil
   alias AeMdw.Db.Contract
   alias AeMdw.Db.MemStore
   alias AeMdw.Db.Model
   alias AeMdw.Db.NullStore
   alias AeMdw.Db.State
-  alias AeMdw.Sync.AsyncTasks
 
   import AeMdw.Node.ContractCallFixtures, only: [call_rec: 1]
   import Mock
@@ -95,7 +95,7 @@ defmodule AeMdw.Db.ContractTest do
       |> State.commit_mem([])
 
       tasks =
-        AsyncTasks.Store.fetch_unprocessed()
+        AsyncTaskTestUtil.list_pending()
         |> Enum.map(fn Model.async_task(index: {_ts, type}, args: args, extra_args: extra_args) ->
           {type, args, extra_args}
         end)

--- a/test/ae_mdw/db/state_test.exs
+++ b/test/ae_mdw/db/state_test.exs
@@ -11,7 +11,6 @@ defmodule AeMdw.Db.StateTest do
   alias AeMdw.Db.NullStore
   alias AeMdw.Db.State
   alias AeMdw.Db.WriteMutation
-  alias AeMdw.Sync.AsyncTasks.Store
 
   require Model
 
@@ -116,7 +115,8 @@ defmodule AeMdw.Db.StateTest do
                Process.sleep(100)
 
                nil ==
-                 Enum.find(Store.fetch_unprocessed(), fn Model.async_task(args: args) ->
+                 AsyncTaskTestUtil.list_pending()
+                 |> Enum.find(fn Model.async_task(args: args) ->
                    args == dedup_args
                  end)
              end)

--- a/test/ae_mdw/sync/async_tasks/stats_test.exs
+++ b/test/ae_mdw/sync/async_tasks/stats_test.exs
@@ -55,11 +55,9 @@ defmodule AeMdw.Sync.AsyncTasks.StatsTest do
   describe "update_consumed/2 and counter/0 success" do
     test "without pending db records" do
       assert :ok = Stats.update_buffer_len(15)
-      assert :ok = Stats.inc_long_tasks_count()
-      assert :ok = Stats.inc_long_tasks_count()
-      assert %{producer_buffer: 15, long_tasks: 2} = Stats.counters()
-      assert :ok = Stats.update_consumed(true)
-      assert %{producer_buffer: 15, long_tasks: 1} = Stats.counters()
+      assert %{producer_buffer: 15, long_tasks: 0} = Stats.counters()
+      assert :ok = Stats.update_consumed()
+      assert %{producer_buffer: 15, long_tasks: 0} = Stats.counters()
     end
   end
 end

--- a/test/support/ae_mdw/async_task_test_util.ex
+++ b/test/support/ae_mdw/async_task_test_util.ex
@@ -4,6 +4,9 @@ defmodule AeMdw.AsyncTaskTestUtil do
   """
 
   alias AeMdw.Sync.AsyncTasks
+  alias AeMdw.Db.Model
+
+  require Model
 
   @spec wakeup_consumers() :: :ok
   def wakeup_consumers do
@@ -18,5 +21,13 @@ defmodule AeMdw.AsyncTaskTestUtil do
     |> Enum.each(fn {_id, consumer_pid, _type, _mod} ->
       Process.send(consumer_pid, :demand, [:noconnect])
     end)
+  end
+
+  @spec list_pending() :: [Model.async_task_record()]
+  def list_pending do
+    :async_tasks_pending
+    |> :ets.tab2list()
+    |> Enum.map(fn {_key, m_task} -> m_task end)
+    |> Enum.sort_by(fn Model.async_task(index: index) -> index end)
   end
 end


### PR DESCRIPTION
## What

Dequeue async task by multiple consumers without waiting for the Producer

## Why

Avoids timeout or increasing it and speeds up the sync.

## Notes

Synced on mainnet until 413430 and keeps going without timeout.