### PR TITLE
test: complement to missing unit tests for AEX-141

### DIFF
--- a/lib/ae_mdw/aexn_tokens.ex
+++ b/lib/ae_mdw/aexn_tokens.ex
@@ -30,9 +30,9 @@ defmodule AeMdw.AexnTokens do
   @aexn_name_table Model.AexnContractName
   @aexn_symbol_table Model.AexnContractSymbol
 
-  @spec fetch_token(State.t(), {aexn_type(), Db.pubkey()}) ::
+  @spec fetch_contract(State.t(), {aexn_type(), Db.pubkey()}) ::
           {:ok, Model.aexn_contract()} | {:error, Error.t()}
-  def fetch_token(state, {aexn_type, contract_pk}) do
+  def fetch_contract(state, {aexn_type, contract_pk}) do
     case State.get(state, Model.AexnContract, {aexn_type, contract_pk}) do
       {:ok, m_aexn} ->
         {:ok, m_aexn}
@@ -42,9 +42,9 @@ defmodule AeMdw.AexnTokens do
     end
   end
 
-  @spec fetch_tokens(State.t(), pagination(), aexn_type(), query(), order_by(), cursor() | nil) ::
+  @spec fetch_contracts(State.t(), pagination(), aexn_type(), query(), order_by(), cursor() | nil) ::
           {:ok, cursor() | nil, [Model.aexn_contract()], cursor() | nil} | {:error, Error.t()}
-  def fetch_tokens(state, pagination, aexn_type, query, order_by, cursor) do
+  def fetch_contracts(state, pagination, aexn_type, query, order_by, cursor) do
     try do
       sorted_table = if order_by == :name, do: @aexn_name_table, else: @aexn_symbol_table
 

--- a/lib/ae_mdw_web/controllers/aex9_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex9_controller.ex
@@ -284,7 +284,7 @@ defmodule AeMdwWeb.Aex9Controller do
 
   defp by_contract_reply(%Conn{assigns: %{state: state}} = conn, contract_id) do
     with {:ok, contract_pk} <- Validate.id(contract_id, [:contract_pubkey]),
-         {:ok, m_aex9} <- AexnTokens.fetch_token(state, {:aex9, contract_pk}) do
+         {:ok, m_aex9} <- AexnTokens.fetch_contract(state, {:aex9, contract_pk}) do
       json(conn, %{data: render_token(m_aex9)})
     end
   end
@@ -293,7 +293,7 @@ defmodule AeMdwWeb.Aex9Controller do
     pagination = {:forward, false, 32_000, false}
 
     with {:ok, _prev_cursor, aex9_tokens, _next_cursor} <-
-           AexnTokens.fetch_tokens(state, pagination, :aex9, params, :name, nil) do
+           AexnTokens.fetch_contracts(state, pagination, :aex9, params, :name, nil) do
       json(conn, render_tokens(aex9_tokens))
     end
   end
@@ -302,7 +302,7 @@ defmodule AeMdwWeb.Aex9Controller do
     pagination = {:forward, false, 32_000, false}
 
     with {:ok, _prev_cursor, aex9_tokens, _next_cursor} <-
-           AexnTokens.fetch_tokens(state, pagination, :aex9, params, :symbol, nil) do
+           AexnTokens.fetch_contracts(state, pagination, :aex9, params, :symbol, nil) do
       json(conn, render_tokens(aex9_tokens))
     end
   end

--- a/lib/ae_mdw_web/controllers/aexn_token_controller.ex
+++ b/lib/ae_mdw_web/controllers/aexn_token_controller.ex
@@ -17,24 +17,24 @@ defmodule AeMdwWeb.AexnTokenController do
 
   action_fallback(FallbackController)
 
-  @spec aex9_tokens(Conn.t(), map()) :: Conn.t()
-  def aex9_tokens(%Conn{assigns: assigns, query_params: query_params} = conn, _params) do
-    aexn_tokens(conn, assigns, query_params, :aex9)
+  @spec aex9_contracts(Conn.t(), map()) :: Conn.t()
+  def aex9_contracts(%Conn{assigns: assigns, query_params: query_params} = conn, _params) do
+    aexn_contracts(conn, assigns, query_params, :aex9)
   end
 
-  @spec aex141_tokens(Conn.t(), map()) :: Conn.t()
-  def aex141_tokens(%Conn{assigns: assigns, query_params: query_params} = conn, _params) do
-    aexn_tokens(conn, assigns, query_params, :aex141)
+  @spec aex141_contracts(Conn.t(), map()) :: Conn.t()
+  def aex141_contracts(%Conn{assigns: assigns, query_params: query_params} = conn, _params) do
+    aexn_contracts(conn, assigns, query_params, :aex141)
   end
 
-  @spec aex9_token(Conn.t(), map()) :: Conn.t()
-  def aex9_token(conn, %{"contract_id" => contract_id}) do
-    aexn_token(conn, contract_id, :aex9)
+  @spec aex9_contract(Conn.t(), map()) :: Conn.t()
+  def aex9_contract(conn, %{"contract_id" => contract_id}) do
+    aexn_contract(conn, contract_id, :aex9)
   end
 
-  @spec aex141_token(Conn.t(), map()) :: Conn.t()
-  def aex141_token(conn, %{"contract_id" => contract_id}) do
-    aexn_token(conn, contract_id, :aex141)
+  @spec aex141_contract(Conn.t(), map()) :: Conn.t()
+  def aex141_contract(conn, %{"contract_id" => contract_id}) do
+    aexn_contract(conn, contract_id, :aex141)
   end
 
   @spec aex9_token_balances(Conn.t(), map()) :: Conn.t()
@@ -89,7 +89,7 @@ defmodule AeMdwWeb.AexnTokenController do
     end
   end
 
-  defp aexn_tokens(
+  defp aexn_contracts(
          %Conn{assigns: %{state: state}} = conn,
          %{
            pagination: pagination,
@@ -99,7 +99,7 @@ defmodule AeMdwWeb.AexnTokenController do
          query_params,
          aexn_type
        ) do
-    case AexnTokens.fetch_tokens(state, pagination, aexn_type, query_params, order_by, cursor) do
+    case AexnTokens.fetch_contracts(state, pagination, aexn_type, query_params, order_by, cursor) do
       {:ok, prev_cursor, aexn_tokens, next_cursor} ->
         Util.paginate(conn, prev_cursor, render_tokens(aexn_tokens), next_cursor)
 
@@ -108,9 +108,9 @@ defmodule AeMdwWeb.AexnTokenController do
     end
   end
 
-  defp aexn_token(%Conn{assigns: %{state: state}} = conn, contract_id, aexn_type) do
+  defp aexn_contract(%Conn{assigns: %{state: state}} = conn, contract_id, aexn_type) do
     with {:ok, contract_pk} <- Validate.id(contract_id, [:contract_pubkey]),
-         {:ok, m_aexn} <- AexnTokens.fetch_token(state, {aexn_type, contract_pk}) do
+         {:ok, m_aexn} <- AexnTokens.fetch_contract(state, {aexn_type, contract_pk}) do
       json(conn, render_token(m_aexn))
     end
   end

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -11,8 +11,8 @@ defmodule AeMdwWeb.Router do
     {"/contracts/calls", AeMdwWeb.ContractController, :calls},
     {"/totalstats/", AeMdwWeb.StatsController, :total_stats},
     {"/status", AeMdwWeb.UtilController, :status},
-    {"/aex141", AeMdwWeb.AexnTokenController, :aex141_tokens},
-    {"/aex141/:contract_id", AeMdwWeb.AexnTokenController, :aex141_token},
+    {"/aex141", AeMdwWeb.AexnTokenController, :aex141_contracts},
+    {"/aex141/:contract_id", AeMdwWeb.AexnTokenController, :aex141_contract},
     {"/aex141/:contract_id/owner/:token_id", AeMdwWeb.Aex141Controller, :nft_owner},
     {"/aex141/owned-nfts/:account_id", AeMdwWeb.Aex141Controller, :owned_nfts}
   ]
@@ -61,8 +61,8 @@ defmodule AeMdwWeb.Router do
       get "/names", NameController, :names
       get "/names/:id", NameController, :name
 
-      get "/aex9", AexnTokenController, :aex9_tokens
-      get "/aex9/:contract_id", AexnTokenController, :aex9_token
+      get "/aex9", AexnTokenController, :aex9_contracts
+      get "/aex9/:contract_id", AexnTokenController, :aex9_contract
       get "/aex9/:contract_id/balances", AexnTokenController, :aex9_token_balances
       get "/aex9/:contract_id/balances/:account_id", AexnTokenController, :aex9_token_balance
       get "/aex9/account-balances/:account_id", AexnTokenController, :aex9_account_balances

--- a/test/ae_mdw/aexn_tokens_test.exs
+++ b/test/ae_mdw/aexn_tokens_test.exs
@@ -13,7 +13,7 @@ defmodule AeMdw.AexnTokensTest do
 
   require Model
 
-  describe "fetch_token/1" do
+  describe "fetch_contract/1" do
     test "returns an AEX-9 contract meta info" do
       contract_pk = <<9_123_456::256>>
       aex9_meta_info = {name, symbol, decimals} = {"Token1", "TK1", 18}
@@ -33,7 +33,7 @@ defmodule AeMdw.AexnTokensTest do
 
       contract_id = enc_ct(contract_pk)
 
-      assert {:ok, m_aex9} = AexnTokens.fetch_token(state, {:aex9, contract_pk})
+      assert {:ok, m_aex9} = AexnTokens.fetch_contract(state, {:aex9, contract_pk})
 
       assert %{
                name: ^name,
@@ -67,7 +67,7 @@ defmodule AeMdw.AexnTokensTest do
 
       contract_id = enc_ct(contract_pk)
 
-      assert {:ok, m_aex141} = AexnTokens.fetch_token(state, {:aex141, contract_pk})
+      assert {:ok, m_aex141} = AexnTokens.fetch_contract(state, {:aex141, contract_pk})
 
       assert %{
                name: ^name,
@@ -85,7 +85,7 @@ defmodule AeMdw.AexnTokensTest do
       contract_pk = Validate.id!(contract_id)
 
       assert {:error, %ErrInput{reason: ErrInput.NotFound}} =
-               AexnTokens.fetch_token(State.new(), {:aex9, contract_pk})
+               AexnTokens.fetch_contract(State.new(), {:aex9, contract_pk})
     end
 
     test "returns input error AEX141 not found" do
@@ -93,7 +93,7 @@ defmodule AeMdw.AexnTokensTest do
       contract_pk = Validate.id!(contract_id)
 
       assert {:error, %ErrInput{reason: ErrInput.NotFound}} =
-               AexnTokens.fetch_token(State.new(), {:aex141, contract_pk})
+               AexnTokens.fetch_contract(State.new(), {:aex141, contract_pk})
     end
   end
 end


### PR DESCRIPTION
Adds missing unit tests for AEX-141 endpoints and additionally renames "token" routes to "contract" to avoid ambiguity with the token belonging to an NFT contract.