### PR TITLE
chore: set dry run gas upper limit

### DIFF
--- a/lib/ae_mdw/dry_run/contract.ex
+++ b/lib/ae_mdw/dry_run/contract.ex
@@ -8,7 +8,8 @@ defmodule AeMdw.DryRun.Contract do
   @typep pubkey() :: <<_::256>>
 
   @abi_fate_sophia_1 3
-  @gas 10_000_000_000_000_000_000_000
+  # allows 10 times the gas used for a contract with balance for aprox 50k accounts.
+  @gas 910_000_000 * 10
 
   @spec new_call_tx(
           pubkey(),


### PR DESCRIPTION
## What

Set maximum gas using a contract with maximum number of accounts as a reference (current max).

## Why

AEX-9 balances dry-run gas consumption turned out to be linear and previous value is too high.
Refs #713 #839