### PR TITLE
fix: rerun failed task and fix processing state

### DIFF
--- a/lib/ae_mdw/sync/async_tasks/consumer.ex
+++ b/lib/ae_mdw/sync/async_tasks/consumer.ex
@@ -68,12 +68,11 @@ defmodule AeMdw.Sync.AsyncTasks.Consumer do
         {:DOWN, ref, :process, _pid, _reason},
         %State{task: task, m_task: m_task} = state
       ) do
-    schedule_demand()
-
-    if ref == task.ref do
+    if task != nil and task.ref == ref do
       new_task = run_supervised(m_task)
       {:noreply, %State{task: new_task, m_task: m_task}}
     else
+      schedule_demand()
       Producer.notify_error(m_task)
       {:noreply, state}
     end

--- a/lib/ae_mdw/sync/async_tasks/producer.ex
+++ b/lib/ae_mdw/sync/async_tasks/producer.ex
@@ -19,7 +19,7 @@ defmodule AeMdw.Sync.AsyncTasks.Producer do
   @impl GenServer
   def init(:ok) do
     Store.reset()
-    {:ok, %{dequeue_buffer: []}}
+    {:ok, :no_state}
   end
 
   @spec enqueue(atom(), list(), list(), only_new: boolean()) :: :ok
@@ -51,6 +51,16 @@ defmodule AeMdw.Sync.AsyncTasks.Producer do
   def notify_consumed(task_index, task_args) do
     Store.set_done(task_index, task_args)
     Stats.update_consumed()
+
+    :ok
+  end
+
+  @spec notify_error(Model.async_task_index()) :: :ok
+  def notify_error(task_index) do
+    Store.set_unprocessed(task_index)
+
+    Store.count_unprocessed()
+    |> Stats.update_buffer_len()
 
     :ok
   end

--- a/lib/ae_mdw/sync/async_tasks/store.ex
+++ b/lib/ae_mdw/sync/async_tasks/store.ex
@@ -99,10 +99,16 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
     end
   end
 
+  @spec set_unprocessed(Model.async_task_index()) :: :ok
+  def set_unprocessed(task_index) do
+    :ets.delete(@processing_tab, task_index)
+    :ok
+  end
+
   @spec set_done(Model.async_task_index(), Model.async_task_args()) :: :ok
   def set_done({_ts, task_type} = task_index, args) do
     Database.dirty_delete(Model.AsyncTask, task_index)
-    :ets.delete_object(@processing_tab, task_index)
+    :ets.delete(@processing_tab, task_index)
     :ets.delete(@pending_tab, {task_type, args})
 
     :ok

--- a/test/ae_mdw/sync/async_tasks/store_test.exs
+++ b/test/ae_mdw/sync/async_tasks/store_test.exs
@@ -182,6 +182,7 @@ defmodule AeMdw.Sync.AsyncTasks.StoreTest do
 
       refute Enum.find(tasks, &(&1 == m_task1))
       refute Database.exists?(Model.AsyncTask, task_index1)
+      refute :ets.member(:async_tasks_processing, task_index1)
       assert Enum.find(tasks, &(&1 == m_task2))
     end
   end

--- a/test/support/ae_mdw/async_task_test_util.ex
+++ b/test/support/ae_mdw/async_task_test_util.ex
@@ -23,6 +23,23 @@ defmodule AeMdw.AsyncTaskTestUtil do
     end)
   end
 
+  @spec wakeup_consumer() :: pid()
+  def wakeup_consumer do
+    AsyncTasks.Supervisor.start_link([])
+    Process.sleep(100)
+
+    {_id, consumer_pid, _type, _mod} =
+      AsyncTasks.Supervisor
+      |> Supervisor.which_children()
+      |> Enum.find(fn {id, _pid, _type, _mod} ->
+        is_binary(id) and String.starts_with?(id, "Elixir.AeMdw.Sync.AsyncTasks.Consumer")
+      end)
+
+    Process.send(consumer_pid, :demand, [:noconnect])
+
+    consumer_pid
+  end
+
   @spec list_pending() :: [Model.async_task_record()]
   def list_pending do
     :async_tasks_pending


### PR DESCRIPTION
Fix for `total_pending` stat related to consumption of task stuck on processing state.