### PR TITLE
chore: sorts aex9 account balances from last to first (v1)

### DIFF
--- a/lib/ae_mdw_web/controllers/aex9_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex9_controller.ex
@@ -366,6 +366,7 @@ defmodule AeMdwWeb.Aex9Controller do
             []
         end
       end)
+      |> Enum.sort_by(fn {_amount, call_txi, _contract_pk} -> call_txi end, :desc)
       |> Enum.map(&balance_to_map(state, &1))
 
     json(conn, balances)


### PR DESCRIPTION
This behavior is not expected for v1 but for v2. However it's an enhancement for v1 while v2 index is refactored.