### PR TITLE
fix: filter contracts after account balance dry-run on blockhash

### DIFF
--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -199,7 +199,8 @@ defmodule AeMdw.Aex9 do
 
         account_presences =
           Enum.map(account_presence_keys, fn {^account_pk, contract_pk} ->
-            {amount, _height_hash} = Db.aex9_balance(contract_pk, account_pk, type_height_hash)
+            {:ok, {amount, _height_hash}} =
+              Db.aex9_balance(contract_pk, account_pk, type_height_hash)
 
             Model.aexn_contract(meta_info: {name, symbol, _dec}) =
               State.fetch!(state, Model.AexnContract, {:aex9, contract_pk})
@@ -360,7 +361,8 @@ defmodule AeMdw.Aex9 do
   defp render_balance_history_item(contract_pk, account_pk, gen) do
     type_height_hash = {:key, gen, DbUtil.height_hash(gen)}
 
-    {amount_or_nil, _height_hash} = Db.aex9_balance(contract_pk, account_pk, type_height_hash)
+    {:ok, {amount_or_nil, _height_hash}} =
+      Db.aex9_balance(contract_pk, account_pk, type_height_hash)
 
     balance = render_balance(contract_pk, {:address, account_pk}, amount_or_nil)
 

--- a/lib/ae_mdw/error.ex
+++ b/lib/ae_mdw/error.ex
@@ -25,7 +25,7 @@ defmodule AeMdw.Error do
   def to_string(Input.NotAex9, x), do: concat("not AEX9 contract", x)
   def to_string(Input.NotAex141, x), do: concat("not AEX141 contract", x)
   def to_string(Input.ContractReturn, x), do: concat("invalid return of contract", x)
-  def to_string(Input.Aex9BalanceNotAvailable, x), do: concat("balance is not yet available", x)
+  def to_string(Input.Aex9BalanceNotAvailable, x), do: concat("balance is not available", x)
   def to_string(Input.Base64, x), do: concat("invalid base64 encoding", x)
   def to_string(Input.Hex32, x), do: concat("invalid hex32 encoding", x)
   def to_string(Input.RangeTooBig, x), do: concat("invalid range", x)

--- a/lib/ae_mdw_web/controllers/aex9_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex9_controller.ex
@@ -315,8 +315,8 @@ defmodule AeMdwWeb.Aex9Controller do
           {:ok, account_balance} ->
             account_balance
 
-          {:error, unavailable_error} ->
-            raise unavailable_error
+          {:error, reason} ->
+            {:error, ErrInput.Aex9BalanceNotAvailable.exception(value: reason)}
         end
       else
         case Aex9.fetch_amount_and_keyblock(state, contract_pk, account_pk) do
@@ -384,7 +384,7 @@ defmodule AeMdwWeb.Aex9Controller do
          account_pk,
          {kbi, mbi} = block_index
        ) do
-    {:ok, Model.block(hash: block_hash)} = State.get(state, Model.Block, block_index)
+    Model.block(hash: block_hash) = State.fetch!(state, Model.Block, block_index)
 
     type = if mbi == -1, do: :key, else: :micro
 

--- a/lib/ae_mdw_web/views/aexn_view.ex
+++ b/lib/ae_mdw_web/views/aexn_view.ex
@@ -23,7 +23,7 @@ defmodule AeMdwWeb.AexnView do
   @spec balance_to_map(State.t(), {non_neg_integer(), non_neg_integer(), pubkey()}) ::
           map()
   def balance_to_map(state, {amount, call_txi, contract_pk}) do
-    Model.tx(id: tx_hash, block_index: {height, _mbi}) = Util.read_tx!(state, call_txi)
+    Model.tx(id: tx_hash, block_index: {height, _mbi}) = State.fetch!(state, Model.Tx, call_txi)
 
     {block_hash, tx_type, _signed_tx, _tx_rec} = NodeDb.get_tx_data(tx_hash)
 

--- a/test/ae_mdw_web/controllers/aex9_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex9_controller_test.exs
@@ -104,6 +104,19 @@ defmodule AeMdwWeb.Aex9ControllerTest do
     end
   end
 
+  describe "balance" do
+    test "returns 400 when contract is unknown", %{conn: conn, store: store} do
+      contract_id = enc_ct(:crypto.strong_rand_bytes(32))
+      account_id = enc_id(:crypto.strong_rand_bytes(32))
+
+      assert %{"error" => <<"not AEX9 contract: ", ^contract_id::binary>>} =
+               conn
+               |> with_store(store)
+               |> get("/aex9/balance/#{contract_id}/#{account_id}")
+               |> json_response(400)
+    end
+  end
+
   describe "balances" do
     test "returns all account balances", %{conn: conn, store: store} do
       account_pk = :crypto.strong_rand_bytes(32)


### PR DESCRIPTION
Contracts filtering needs to be performed after the dry-run since the presence is updated with last call.

Balances are consistent with expected 10 integration entries.
