### PR TITLE
fix: remove rocksdb wrapping code that created DB inconsistencies

### DIFF
--- a/lib/ae_mdw/db/rocksdb.ex
+++ b/lib/ae_mdw/db/rocksdb.ex
@@ -160,32 +160,19 @@ defmodule AeMdw.Db.RocksDb do
   @spec dirty_get(transaction(), table(), binary()) ::
           {:ok, binary()} | :not_found | {:error, {:corruption, charlist()}} | {:error, any()}
   def dirty_get(t_ref, table, key) do
-    {db_ref, cf_ref} = cf_refs(table)
+    {_db_ref, cf_ref} = cf_refs(table)
 
-    case :rocksdb.transaction_get(t_ref, cf_ref, key, []) do
-      {:ok, value} -> {:ok, value}
-      :not_found -> :rocksdb.get(db_ref, cf_ref, key, [])
-      error -> error
-    end
+    :rocksdb.transaction_get(t_ref, cf_ref, key, [])
   end
 
   @doc """
   Delete a key-value from a column family.
   """
-  @spec delete(transaction(), table(), binary()) :: :ok | {:error, any()}
+  @spec delete(transaction(), table(), binary()) :: :ok
   def delete(t_ref, table, key) do
-    {db_ref, cf_ref} = cf_refs(table)
+    {_db_ref, cf_ref} = cf_refs(table)
 
-    case :rocksdb.transaction_get(t_ref, cf_ref, key, []) do
-      {:ok, _value} ->
-        :ok = :rocksdb.transaction_delete(t_ref, cf_ref, key)
-
-      :not_found ->
-        :rocksdb.delete(db_ref, cf_ref, key, [])
-
-      error ->
-        error
-    end
+    :ok = :rocksdb.transaction_delete(t_ref, cf_ref, key)
   end
 
   @doc """

--- a/test/ae_mdw/db/rocksdb_test.exs
+++ b/test/ae_mdw/db/rocksdb_test.exs
@@ -34,6 +34,26 @@ defmodule AeMdw.Db.RocksDbTest do
       assert :ok = RocksDb.delete(txn, Model.Block, key)
       assert :not_found = RocksDb.dirty_get(txn, Model.Block, key)
     end
+
+    test "it deletes a key-value not from the transaction" do
+      key = :erlang.term_to_binary({new_kbi(), -1})
+      value = new_block() |> :erlang.term_to_binary()
+
+      assert :ok = RocksDb.dirty_put(Model.Block, key, value)
+
+      {:ok, txn} = RocksDb.transaction_new()
+      assert :ok = RocksDb.delete(txn, Model.Block, key)
+      assert :not_found = RocksDb.dirty_get(txn, Model.Block, key)
+      :ok = RocksDb.transaction_commit(txn)
+    end
+
+    test "it doesn't fail when deleting a non-existent key" do
+      key = "non-existent-key"
+
+      {:ok, txn} = RocksDb.transaction_new()
+      assert :ok = RocksDb.delete(txn, Model.Block, key)
+      :ok = RocksDb.transaction_commit(txn)
+    end
   end
 
   describe "commit/4 and get/2" do


### PR DESCRIPTION
This will allow deleting records created inside the transaction and
non-existent values.