### PR TITLE
fix: handle variant owner return

### DIFF
--- a/lib/ae_mdw/aex141.ex
+++ b/lib/ae_mdw/aex141.ex
@@ -26,7 +26,7 @@ defmodule AeMdw.Aex141 do
   @spec fetch_nft_owner(pubkey(), token_id()) :: {:ok, pubkey()} | {:error, Error.t()}
   def fetch_nft_owner(contract_pk, token_id) do
     with :ok <- validate_aex141(contract_pk),
-         {:ok, {:address, account_pk}} <-
+         {:ok, {:variant, [0, 1], 1, {{:address, account_pk}}}} <-
            AexnContracts.call_contract(contract_pk, "owner", [token_id]) do
       {:ok, account_pk}
     else

--- a/test/ae_mdw_web/controllers/aex141_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex141_controller_test.exs
@@ -178,7 +178,9 @@ defmodule AeMdwWeb.Aex141ControllerTest do
         {AexnContracts, [],
          [
            is_aex141?: fn pk -> pk == <<1_411::256>> end,
-           call_contract: fn _pk, "owner", [_token_id] -> {:ok, {:address, account_pk}} end
+           call_contract: fn _pk, "owner", [_token_id] ->
+             {:ok, {:variant, [0, 1], 1, {{:address, account_pk}}}}
+           end
          ]}
       ] do
         assert %{"data" => account_id} =


### PR DESCRIPTION
Handles variant `owner` NFT contract call after successful mint/transfer.