### PR TITLE
fix: handle out_of_gas_error on aex141 cleanup

### DIFF
--- a/lib/ae_mdw_web/helpers/aexn_helper.ex
+++ b/lib/ae_mdw_web/helpers/aexn_helper.ex
@@ -25,7 +25,9 @@ defmodule AeMdwWeb.Helpers.AexnHelper do
   @spec enc_id(pubkey()) :: String.t()
   def enc_id(pk), do: :aeser_api_encoder.encode(:account_pubkey, pk)
 
-  @spec sort_field_truncate(String.t()) :: String.t()
+  @spec sort_field_truncate(String.t() | :atom) :: String.t()
+  def sort_field_truncate(field_value) when is_atom(field_value), do: field_value
+
   def sort_field_truncate(field_value) do
     if String.length(field_value) <= @max_sort_field_length do
       field_value

--- a/lib/ae_mdw_web/helpers/aexn_helper.ex
+++ b/lib/ae_mdw_web/helpers/aexn_helper.ex
@@ -25,7 +25,7 @@ defmodule AeMdwWeb.Helpers.AexnHelper do
   @spec enc_id(pubkey()) :: String.t()
   def enc_id(pk), do: :aeser_api_encoder.encode(:account_pubkey, pk)
 
-  @spec sort_field_truncate(String.t() | :atom) :: String.t()
+  @spec sort_field_truncate(String.t() | atom()) :: String.t()
   def sort_field_truncate(field_value) when is_atom(field_value), do: field_value
 
   def sort_field_truncate(field_value) do

--- a/priv/migrations/20220826152500_aex141_cleanup.ex
+++ b/priv/migrations/20220826152500_aex141_cleanup.ex
@@ -31,15 +31,19 @@ defmodule AeMdw.Migrations.Aex141Cleanup do
         else
           Database.dirty_delete(Model.AexnContract, {:aex141, ct_pk})
 
-          Database.dirty_delete(
-            Model.AexnContractName,
-            {:aex141, sort_field_truncate(name), ct_pk}
-          )
+          if not is_atom(name) do
+            Database.dirty_delete(
+              Model.AexnContractName,
+              {:aex141, sort_field_truncate(name), ct_pk}
+            )
+          end
 
-          Database.dirty_delete(
-            Model.AexnContractSymbol,
-            {:aex141, sort_field_truncate(symbol), ct_pk}
-          )
+          if not is_atom(symbol) do
+            Database.dirty_delete(
+              Model.AexnContractSymbol,
+              {:aex141, sort_field_truncate(symbol), ct_pk}
+            )
+          end
 
           1
         end


### PR DESCRIPTION
Avoid deleting aex141 contract indexed by metadata covering some mainnet cases.