### PR TITLE
fix: map recipient record when filtering by nft collection

### DIFF
--- a/lib/ae_mdw_web/controllers/aexn_transfer_controller.ex
+++ b/lib/ae_mdw_web/controllers/aexn_transfer_controller.ex
@@ -120,7 +120,11 @@ defmodule AeMdwWeb.AexnTransferController do
     json(conn, transfers)
   end
 
-  defp contract_transfers_reply(%Conn{assigns: assigns} = conn, contract_id, tagged_account_pk) do
+  defp contract_transfers_reply(
+         %Conn{assigns: assigns} = conn,
+         contract_id,
+         {filter_by, _pk} = tagged_account_pk
+       ) do
     %{pagination: pagination, cursor: cursor, state: state} = assigns
 
     with {:ok, contract_pk} <- Validate.id(contract_id, [:contract_pubkey]),
@@ -134,7 +138,7 @@ defmodule AeMdwWeb.AexnTransferController do
           cursor
         )
 
-      data = Enum.map(transfers_keys, &contract_transfer_to_map(state, &1))
+      data = Enum.map(transfers_keys, &contract_transfer_to_map(state, filter_by, &1))
 
       paginate(conn, prev_cursor, data, next_cursor)
     else

--- a/lib/ae_mdw_web/views/aexn_view.ex
+++ b/lib/ae_mdw_web/views/aexn_view.ex
@@ -96,10 +96,19 @@ defmodule AeMdwWeb.AexnView do
   def pair_transfer_to_map(state, {type, sender_pk, recipient_pk, call_txi, amount, log_idx}),
     do: do_transfer_to_map(state, {type, sender_pk, call_txi, recipient_pk, amount, log_idx})
 
-  @spec contract_transfer_to_map(State.t(), contract_transfer_key()) :: map()
+  @spec contract_transfer_to_map(State.t(), :from | :to, contract_transfer_key()) :: map()
   def contract_transfer_to_map(
         state,
+        :from,
         {_create_txi, sender_pk, call_txi, recipient_pk, token_id, log_idx}
+      ) do
+    do_transfer_to_map(state, {:aex141, sender_pk, call_txi, recipient_pk, token_id, log_idx})
+  end
+
+  def contract_transfer_to_map(
+        state,
+        :to,
+        {_create_txi, recipient_pk, call_txi, sender_pk, token_id, log_idx}
       ) do
     do_transfer_to_map(state, {:aex141, sender_pk, call_txi, recipient_pk, token_id, log_idx})
   end


### PR DESCRIPTION
Maps nft recipient record when filtering transfer by collection as 
`/v2/aex141/transfers/to/ak_QVSUoGrJ31CVxWpvgvwQ7PUPFgnvWQouUgsDBVoGjuT7hjQYW?contract_id=ct_Fv9d66QTjr4yon9GEuMRc2B5y7Afy4to1ATaoYmpUTbN6DYiP`