### PR TITLE
feat: index and fetch nft owners on a collection

### DIFF
--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -327,8 +327,8 @@ defmodule AeMdw.Db.Model do
   ]
   defrecord :aexn_contract_symbol, @aexn_contract_symbol_defaults
 
-  # AEX-141 token owner
-  #     index = {owner pubkey, contract pubkey, token_id},
+  # AEX-141 owner tokens
+  #     index = {owner pubkey, contract pubkey, token_id}
   @nft_ownership_defaults [index: nil, unused: nil]
   defrecord :nft_ownership, @nft_ownership_defaults
 
@@ -336,6 +336,28 @@ defmodule AeMdw.Db.Model do
           record(:nft_ownership,
             index: {pubkey(), pubkey(), AeMdw.Aex141.token_id()},
             unused: nil
+          )
+
+  # AEX-141 collection owners
+  #     index = {contract pubkey, owner pubkey, token_id}
+  @nft_owner_token_defaults [index: nil, unused: nil]
+  defrecord :nft_owner_token, @nft_owner_token_defaults
+
+  @type nft_owner_token() ::
+          record(:nft_owner_token,
+            index: {pubkey(), pubkey(), AeMdw.Aex141.token_id()},
+            unused: nil
+          )
+
+  # AEX-141 token owner
+  #     index = {contract pubkey, token_id}, owner = pubkey
+  @nft_token_owner_defaults [index: {<<>>, -1}, owner: <<>>]
+  defrecord :nft_token_owner, @nft_token_owner_defaults
+
+  @type nft_token_owner() ::
+          record(:nft_token_owner,
+            index: {pubkey(), AeMdw.Aex141.token_id()},
+            owner: pubkey()
           )
 
   # contract call:
@@ -727,7 +749,9 @@ defmodule AeMdw.Db.Model do
       AeMdw.Db.Model.GrpIdIntContractCall,
       AeMdw.Db.Model.IdFnameIntContractCall,
       AeMdw.Db.Model.GrpIdFnameIntContractCall,
-      AeMdw.Db.Model.NftOwnership
+      AeMdw.Db.Model.NftOwnership,
+      AeMdw.Db.Model.NftOwnerToken,
+      AeMdw.Db.Model.NftTokenOwner
     ]
   end
 
@@ -815,6 +839,8 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.IdFnameIntContractCall), do: :id_fname_int_contract_call
   def record(AeMdw.Db.Model.GrpIdFnameIntContractCall), do: :grp_id_fname_int_contract_call
   def record(AeMdw.Db.Model.NftOwnership), do: :nft_ownership
+  def record(AeMdw.Db.Model.NftOwnerToken), do: :nft_owner_token
+  def record(AeMdw.Db.Model.NftTokenOwner), do: :nft_token_owner
   def record(AeMdw.Db.Model.PlainName), do: :plain_name
   def record(AeMdw.Db.Model.AuctionBid), do: :auction_bid
   def record(AeMdw.Db.Model.Pointee), do: :pointee

--- a/lib/ae_mdw_web/controllers/aex141_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex141_controller.ex
@@ -19,6 +19,21 @@ defmodule AeMdwWeb.Aex141Controller do
   plug(PaginatedPlug)
   action_fallback(FallbackController)
 
+  @spec collection_owners(Conn.t(), map()) :: Conn.t()
+  def collection_owners(%Conn{assigns: assigns} = conn, %{"contract_id" => contract_id}) do
+    %{
+      state: state,
+      pagination: pagination,
+      cursor: cursor
+    } = assigns
+
+    with {:ok, contract_pk} <- Validate.id(contract_id, [:contract_pubkey]),
+         {:ok, {prev_cursor, nft_owners, next_cursor}} <-
+           Aex141.fetch_collection_owners(state, contract_pk, cursor, pagination) do
+      WebUtil.paginate(conn, prev_cursor, nft_owners, next_cursor)
+    end
+  end
+
   @spec nft_owner(Conn.t(), map()) :: Conn.t()
   def nft_owner(conn, %{"contract_id" => contract_id, "token_id" => token_id}) do
     with {:ok, contract_pk} <- Validate.id(contract_id, [:contract_pubkey]),

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -14,6 +14,7 @@ defmodule AeMdwWeb.Router do
     {"/aex141", AeMdwWeb.AexnTokenController, :aex141_contracts},
     {"/aex141/:contract_id", AeMdwWeb.AexnTokenController, :aex141_contract},
     {"/aex141/:contract_id/owner/:token_id", AeMdwWeb.Aex141Controller, :nft_owner},
+    {"/aex141/:contract_id/owners", AeMdwWeb.Aex141Controller, :collection_owners},
     {"/aex141/owned-nfts/:account_id", AeMdwWeb.Aex141Controller, :owned_nfts}
   ]
 

--- a/priv/migrations/20220906173000_aex141_owners.ex
+++ b/priv/migrations/20220906173000_aex141_owners.ex
@@ -1,0 +1,37 @@
+defmodule AeMdw.Migrations.Aex141Owners do
+  @moduledoc """
+  Indexes nft owners by collection.
+  """
+
+  alias AeMdw.Collection
+  alias AeMdw.Db.Contract
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+
+  require Model
+
+  @spec run(boolean()) :: {:ok, {non_neg_integer(), non_neg_integer()}}
+  def run(_from_start?) do
+    state = State.new()
+    begin = DateTime.utc_now()
+
+    count =
+      state
+      |> Collection.stream(Model.AexnTransfer, nil)
+      |> Stream.take_while(fn key -> elem(key, 0) == :aex141 end)
+      |> Stream.map(&State.fetch!(state, Model.AexnTransfer, &1))
+      |> Stream.map(fn Model.aexn_transfer(
+                         index: {:aex141, from_pk, txi, to_pk, token_id, i},
+                         contract_pk: contract_pk
+                       ) ->
+        args = [from_pk, to_pk, <<token_id::256>>]
+        Contract.write_aex141_records(state, contract_pk, txi, i, args)
+        :ok
+      end)
+      |> Enum.count()
+
+    duration = DateTime.diff(DateTime.utc_now(), begin)
+
+    {:ok, {count, duration}}
+  end
+end

--- a/test/ae_mdw/db/contract_call_mutation_test.exs
+++ b/test/ae_mdw/db/contract_call_mutation_test.exs
@@ -273,11 +273,25 @@ defmodule AeMdw.Db.ContractCallMutationTest do
           Model.NftOwnership,
           Model.nft_ownership(index: {from_pk, contract_pk, token_id})
         )
+        |> State.put(
+          Model.NftOwnerToken,
+          Model.nft_owner_token(index: {contract_pk, from_pk, token_id})
+        )
+        |> State.put(
+          Model.NftTokenOwner,
+          Model.nft_token_owner(index: {contract_pk, token_id}, owner: from_pk)
+        )
         |> State.cache_put(:ct_create_sync_cache, contract_pk, call_txi - 1)
         |> State.commit_mem([mutation])
 
       assert State.exists?(state, Model.NftOwnership, {to_pk, contract_pk, token_id})
+
+      assert {:ok, Model.nft_token_owner(owner: ^to_pk)} =
+               State.get(state, Model.NftTokenOwner, {contract_pk, token_id})
+
+      assert State.exists?(state, Model.NftOwnerToken, {contract_pk, to_pk, token_id})
       refute State.exists?(state, Model.NftOwnership, {from_pk, contract_pk, token_id})
+      refute State.exists?(state, Model.NftOwnerToken, {contract_pk, from_pk, token_id})
 
       key = {:aex141, from_pk, call_txi, to_pk, token_id, 0}
 


### PR DESCRIPTION
## What

- Index owners of a collection based on nft transfers  
- Add `/aex141/:contract_id/owners` endpoint for querying

## Why

Refs #629  

## Notes

- Includes handling delegated approvals
- An additional PR gonna provide docs for all aex141 endpoints
- New minting and burning gonna be handled by a separated PR (for transfer refactoring)