### PR TITLE
chore: accept contract param besides contract_id

### DIFF
--- a/lib/ae_mdw/aexn_transfers.ex
+++ b/lib/ae_mdw/aexn_transfers.ex
@@ -60,25 +60,6 @@ defmodule AeMdw.AexnTransfers do
     )
   end
 
-  @spec fetch_contract_recipient_transfers(
-          State.t(),
-          AeMdw.Txs.txi(),
-          pubkey() | nil,
-          pagination(),
-          cursor() | nil
-        ) ::
-          contract_paginated_transfers()
-  def fetch_contract_recipient_transfers(state, contract_txi, recipient_pk, pagination, cursor) do
-    paginate_transfers(
-      state,
-      contract_txi,
-      pagination,
-      Model.AexnContractToTransfer,
-      cursor,
-      recipient_pk
-    )
-  end
-
   @spec fetch_sender_transfers(State.t(), aexn_type(), pubkey(), pagination(), cursor() | nil) ::
           account_paginated_transfers()
   def fetch_sender_transfers(state, aexn_type, sender_pk, pagination, cursor) do
@@ -137,7 +118,7 @@ defmodule AeMdw.AexnTransfers do
   #
   defp paginate_transfers(
          state,
-         aexn_type,
+         aexn_type_or_txi,
          pagination,
          table,
          cursor,
@@ -145,25 +126,7 @@ defmodule AeMdw.AexnTransfers do
        ) do
     cursor_key = deserialize_cursor(cursor)
 
-    do_paginate_transfers(
-      state,
-      aexn_type,
-      pagination,
-      table,
-      cursor_key,
-      account_pk_or_pair_pks
-    )
-  end
-
-  defp do_paginate_transfers(
-         state,
-         aexn_type_or_txi,
-         pagination,
-         table,
-         cursor_key,
-         params
-       ) do
-    key_boundary = key_boundary(aexn_type_or_txi, params)
+    key_boundary = key_boundary(aexn_type_or_txi, account_pk_or_pair_pks)
 
     {prev_cursor_key, transfer_keys, next_cursor_key} =
       state
@@ -219,15 +182,15 @@ defmodule AeMdw.AexnTransfers do
 
   defp key_boundary(type_or_txi, nil) do
     {
-      {type_or_txi, nil, 0, nil, 0, 0},
-      {type_or_txi, Util.max_256bit_bin(), nil, nil, 0, 0}
+      {type_or_txi, <<>>, 0, <<>>, 0, 0},
+      {type_or_txi, Util.max_256bit_bin(), nil, <<>>, 0, 0}
     }
   end
 
   defp key_boundary(type_or_txi, account_pk) do
     {
-      {type_or_txi, account_pk, 0, nil, 0, 0},
-      {type_or_txi, account_pk, nil, nil, 0, 0}
+      {type_or_txi, account_pk, 0, <<>>, 0, 0},
+      {type_or_txi, account_pk, nil, <<>>, 0, 0}
     }
   end
 end

--- a/lib/ae_mdw/contracts.ex
+++ b/lib/ae_mdw/contracts.ex
@@ -384,6 +384,9 @@ defmodule AeMdw.Contracts do
   defp convert_param(state, {"contract_id", contract_id}),
     do: {:create_txi, create_txi!(state, contract_id)}
 
+  defp convert_param(state, {"contract", contract_id}),
+    do: {:create_txi, create_txi!(state, contract_id)}
+
   defp convert_param(_state, {"data", data}), do: {:data_prefix, URI.decode(data)}
 
   defp convert_param(_state, {"event", ctor_name}),

--- a/lib/ae_mdw_web/controllers/aexn_transfer_controller.ex
+++ b/lib/ae_mdw_web/controllers/aexn_transfer_controller.ex
@@ -88,6 +88,10 @@ defmodule AeMdwWeb.AexnTransferController do
     end
   end
 
+  def aex141_transfers_from(conn, %{"contract" => contract_id} = params) do
+    aex141_transfers_from(conn, Map.put(params, "contract_id", contract_id))
+  end
+
   def aex141_transfers_from(conn, %{"sender" => sender_id}) do
     transfers_from_reply(conn, :aex141, sender_id)
   end
@@ -97,6 +101,10 @@ defmodule AeMdwWeb.AexnTransferController do
     with {:ok, recipient_pk} <- Validate.id(recipient_id, [:account_pubkey]) do
       contract_transfers_reply(conn, contract_id, {:to, recipient_pk})
     end
+  end
+
+  def aex141_transfers_to(conn, %{"contract" => contract_id} = params) do
+    aex141_transfers_to(conn, Map.put(params, "contract_id", contract_id))
   end
 
   def aex141_transfers_to(conn, %{"recipient" => recipient_id}) do


### PR DESCRIPTION
## What / Why
Accept `contract` param besides `contract_id` on nft transfer filter because some endpoints work or are documented with `contract` (while contract logs and calls expect `contract_id`).

Refs #629 

## Notes
- Changes also `/contract/calls` and `/contract/logs` to accept `contract`
- #902 was opened to discuss unifying these params on `/v3` 