### PR TITLE
refactor: allocate smaller tuples for query streams

### DIFF
--- a/lib/ae_mdw/aex141.ex
+++ b/lib/ae_mdw/aex141.ex
@@ -97,11 +97,11 @@ defmodule AeMdw.Aex141 do
         Model.NftOwnership ->
           {
             {pubkey, <<>>, nil},
-            {pubkey, Util.max_256bit_bin(), Util.max_256bit_int()}
+            {pubkey, Util.max_256bit_bin(), Util.max_int()}
           }
 
         Model.NftTokenOwner ->
-          {{pubkey, -Util.max_256bit_int()}, {pubkey, nil}}
+          {{pubkey, Util.min_256bit_int()}, {pubkey, nil}}
       end
 
     fn direction ->

--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -163,9 +163,6 @@ defmodule AeMdw.Application do
       |> Enum.map(fn {k, v} -> {Contract.function_hash(k), v} end)
       |> Enum.into(%{})
 
-    max_int = Util.max_256bit_int()
-    max_blob = :binary.list_to_bin(:lists.duplicate(1024, <<max_int::256>>))
-
     height_proto = :aec_hard_forks.protocols() |> Enum.into([]) |> Enum.sort(&>=/2)
 
     min_block_reward_height =
@@ -202,7 +199,6 @@ defmodule AeMdw.Application do
         aexn_mint_event_hash: [{[], :aec_hash.blake2b_256_hash("Mint")}],
         aexn_transfer_event_hash: [{[], :aec_hash.blake2b_256_hash("Transfer")}],
         aex141_signatures: [{[], aex141_sigs}],
-        max_blob: [{[], max_blob}],
         height_proto: [{[], height_proto}],
         min_block_reward_height: [{[], min_block_reward_height}],
         token_supply_delta:

--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -97,7 +97,7 @@ defmodule AeMdw.Blocks do
           |> Collection.stream(
             Model.Block,
             direction,
-            {{height, 0}, {height, Util.max_256bit_int()}},
+            {{height, 0}, {height, Util.max_int()}},
             cursor
           )
           |> Stream.map(fn {_height, mbi} -> mbi end)
@@ -231,7 +231,7 @@ defmodule AeMdw.Blocks do
     Enum.map(range, fn gen ->
       [key_block | micro_blocks] =
         state
-        |> Collection.stream(@table, :backward, nil, {gen, Util.max_256bit_int()})
+        |> Collection.stream(@table, :backward, nil, {gen, Util.max_int()})
         |> Stream.take_while(&match?({^gen, _mb_index}, &1))
         |> Enum.map(fn key -> State.fetch!(state, @table, key) end)
         |> Enum.reverse()

--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -207,7 +207,7 @@ defmodule AeMdw.Db.Format do
     Model.tx(id: call_tx_hash, block_index: {height, micro_index}) =
       State.fetch!(state, Model.Tx, call_txi)
 
-    block_hash = Model.block(DbUtil.read_block!(state, {height, micro_index}), :hash)
+    Model.block(hash: block_hash) = DbUtil.read_block!(state, {height, micro_index})
 
     {contract_txi, contract_tx_hash} =
       if create_txi == -1 do

--- a/lib/ae_mdw/db/stream/name.ex
+++ b/lib/ae_mdw/db/stream/name.ex
@@ -3,6 +3,7 @@ defmodule AeMdw.Db.Stream.Name do
   alias AeMdw.Db.Stream.Resource.Util, as: RU
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
+  alias AeMdw.Util
 
   ##########
 
@@ -11,7 +12,7 @@ defmodule AeMdw.Db.Stream.Name do
     {init_k, advance} =
       case direction do
         :forward -> {prefix, &State.next(state, &1, &2)}
-        :backward -> {prefix <> AeMdw.Node.max_blob(), &State.prev(state, &1, &2)}
+        :backward -> {prefix <> Util.max_name_bin(), &State.prev(state, &1, &2)}
       end
 
     advance = RU.advance_fn(advance, AeMdwWeb.Util.prefix_checker(prefix))
@@ -23,7 +24,7 @@ defmodule AeMdw.Db.Stream.Name do
     {init_k, advance} =
       case direction do
         :forward -> {prefix, &State.next(state, &1, &2)}
-        :backward -> {prefix <> AeMdw.Node.max_blob(), &State.prev(state, &1, &2)}
+        :backward -> {prefix <> Util.max_name_bin(), &State.prev(state, &1, &2)}
       end
 
     advance = RU.advance_fn(advance, AeMdwWeb.Util.prefix_checker(prefix))

--- a/lib/ae_mdw/db/sync/stats.ex
+++ b/lib/ae_mdw/db/sync/stats.ex
@@ -31,7 +31,7 @@ defmodule AeMdw.Db.Sync.Stats do
     case State.next(
            state,
            Model.NftOwnerToken,
-           {contract_pk, prev_owner_pk, -Util.max_256bit_int()}
+           {contract_pk, prev_owner_pk, Util.min_256bit_int()}
          ) do
       {:ok, {^contract_pk, ^prev_owner_pk, _token}} ->
         state
@@ -44,7 +44,7 @@ defmodule AeMdw.Db.Sync.Stats do
   end
 
   defp increment_collection_owners(state, contract_pk, to_pk) do
-    case State.next(state, Model.NftOwnerToken, {contract_pk, to_pk, -Util.max_256bit_int()}) do
+    case State.next(state, Model.NftOwnerToken, {contract_pk, to_pk, Util.min_256bit_int()}) do
       {:ok, {^contract_pk, ^to_pk, _token}} -> state
       _new_owner -> update_stat_counter(state, Stats.nft_owners_count_key(contract_pk))
     end

--- a/lib/ae_mdw/transfers.ex
+++ b/lib/ae_mdw/transfers.ex
@@ -141,14 +141,13 @@ defmodule AeMdw.Transfers do
 
   defp deserialize_scope(_state, nil) do
     {{{Util.min_int(), Util.min_int()}, Util.min_bin(), Util.min_bin(), Util.min_int()},
-     {{Util.max_256bit_int(), Util.max_256bit_int()}, Util.max_256bit_bin(),
-      Util.max_256bit_bin(), Util.max_256bit_int()}}
+     {{Util.max_int(), Util.max_int()}, Util.max_256bit_bin(), Util.max_256bit_bin(),
+      Util.max_int()}}
   end
 
   defp deserialize_scope(_state, {:gen, %Range{first: first_gen, last: last_gen}}) do
     {{{first_gen, Util.min_int()}, Util.min_bin(), Util.min_bin(), Util.min_int()},
-     {{last_gen, Util.max_256bit_int()}, Util.max_256bit_bin(), Util.max_256bit_bin(),
-      Util.max_256bit_int()}}
+     {{last_gen, Util.max_int()}, Util.max_256bit_bin(), Util.max_256bit_bin(), Util.max_int()}}
   end
 
   defp deserialize_scope(state, {:txi, %Range{first: first_txi, last: last_txi}}) do

--- a/lib/ae_mdw/util.ex
+++ b/lib/ae_mdw/util.ex
@@ -6,6 +6,8 @@ defmodule AeMdw.Util do
   alias AeMdw.Collection
   alias AeMdw.Db.State
 
+  @max_name_bin String.duplicate("z", 128)
+
   @type opt() :: {:expand?, boolean()} | {:top?, boolean()}
   @type opts() :: [opt()]
 
@@ -188,21 +190,25 @@ defmodule AeMdw.Util do
     )
   end
 
-  @spec max_256bit_int() :: integer()
-  def max_256bit_int(),
-    do: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+  @spec max_int() :: nil
+  def max_int(), do: nil
 
   @spec max_256bit_bin() :: binary()
-  def max_256bit_bin(), do: <<max_256bit_int()::256>>
+  def max_256bit_bin(),
+    do: <<0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF::256>>
 
-  @spec max_name_bin() :: binary
-  def max_name_bin(), do: String.duplicate("z", 128)
-
-  @spec min_int() :: integer()
-  def min_int(), do: -100
+  @spec max_name_bin() :: binary()
+  def max_name_bin(), do: @max_name_bin
 
   @spec min_bin() :: binary()
   def min_bin(), do: <<>>
+
+  # minimum small integer from https://www.erlang.org/doc/efficiency_guide/advanced.html
+  @spec min_int() :: integer()
+  def min_int(), do: -576_460_752_303_423_488
+
+  @spec min_256bit_int() :: integer()
+  def min_256bit_int(), do: -0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
 
   @spec contains_unicode?(binary()) :: boolean()
   def contains_unicode?(string) do

--- a/priv/migrations/20220721121200_add_type_count_table.ex
+++ b/priv/migrations/20220721121200_add_type_count_table.ex
@@ -23,7 +23,7 @@ defmodule AeMdw.Migrations.AddTypeCountTable do
       |> Database.first_key()
       |> Stream.unfold(fn
         {:ok, {tx_type, _txi}} ->
-          {tx_type, Database.next_key(Model.Type, {tx_type, Util.max_256bit_int()})}
+          {tx_type, Database.next_key(Model.Type, {tx_type, Util.max_int()})}
 
         :none ->
           nil
@@ -33,7 +33,7 @@ defmodule AeMdw.Migrations.AddTypeCountTable do
           RocksDbCF.count_range(
             Model.Type,
             {tx_type, Util.min_int()},
-            {tx_type, Util.max_256bit_int()}
+            {tx_type, Util.max_int()}
           )
 
         {tx_type, count}

--- a/test/ae_mdw/util_test.exs
+++ b/test/ae_mdw/util_test.exs
@@ -3,6 +3,19 @@ defmodule AeMdw.UtilTest do
 
   alias AeMdw.Util
 
+  describe "terms comparision" do
+    test "result in integer asc order" do
+      # min_int is a shorthand for min_nonbigint_integer
+      assert Util.min_256bit_int() < Util.min_int()
+      assert Util.min_int() < 576_460_752_303_423_488 and 576_460_752_303_423_488 < Util.max_int()
+    end
+
+    test "result in binary asc order" do
+      assert Util.min_bin() < Util.max_name_bin()
+      assert Util.max_name_bin() < Util.max_256bit_bin()
+    end
+  end
+
   describe "build_gen_pagination/5" do
     test "when forward and range_first exceeds last_gen, it returns error" do
       assert :error = Util.build_gen_pagination(nil, :forward, {400, 500}, 10, 300)

--- a/test/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/ae_mdw_web/controllers/contract_controller_test.exs
@@ -1,0 +1,1004 @@
+defmodule AeMdwWeb.Controllers.ContractControllerTest do
+  use AeMdwWeb.ConnCase
+  @moduletag skip_store: true
+
+  alias AeMdw.Db.IntCallsMutation
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Store
+  alias AeMdw.Db.MemStore
+  alias AeMdw.Db.NullStore
+  alias AeMdw.Db.Origin
+  alias AeMdw.Txs
+
+  require Model
+
+  @default_limit 10
+
+  @evt1_hash :crypto.strong_rand_bytes(32)
+  @evt2_ctor_name "evt2_hash"
+  @evt2_hash :aec_hash.blake2b_256_hash(@evt2_ctor_name)
+  @event_hashes [Base.hex_encode32(@evt1_hash), Base.hex_encode32(@evt2_hash)]
+
+  @log_kbi 101
+  @log_mbi 1
+  @log_block_hash :crypto.strong_rand_bytes(32)
+  @first_log_txi 1_000_001
+  @evt1_amount 20
+  @mixed_logs_amount 40
+  @contract_logs_amount 20
+  @last_log_txi @first_log_txi + @mixed_logs_amount + @contract_logs_amount - 1
+  @log_txis @first_log_txi..@last_log_txi
+
+  @call_kbi 201
+  @call_mbi 1
+  @call_block_hash :crypto.strong_rand_bytes(32)
+  @first_call_txi 2_000_001
+  @mixed_calls_amount 30
+  @contract_calls_amount 40
+  @last_call_txi @first_call_txi + div(@mixed_calls_amount, 2) + div(@contract_calls_amount, 2)
+  @call_txis @first_call_txi..@last_call_txi
+  @call_function "Chain.spend"
+  @sender_pk <<1::256>>
+
+  setup_all _context do
+    contract_pk = :crypto.strong_rand_bytes(32)
+
+    store =
+      NullStore.new()
+      |> MemStore.new()
+      |> logs_setup(contract_pk)
+      |> calls_setup(contract_pk)
+
+    [store: store, contract_pk: contract_pk]
+  end
+
+  describe "fetch_logs/5" do
+    test "renders all saved contract logs with limit=100", %{
+      conn: conn,
+      store: store,
+      contract_pk: contract_pk
+    } do
+      assert %{"data" => logs, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/logs", limit: 100)
+               |> json_response(200)
+
+      assert @mixed_logs_amount + @contract_logs_amount == length(logs)
+
+      state = State.new(store)
+      contract_create_txi = Origin.tx_index!(state, {:contract, contract_pk})
+
+      Enum.each(logs, fn %{
+                           "contract_txi" => create_txi,
+                           "contract_tx_hash" => contract_tx_hash,
+                           "contract_id" => contract_id,
+                           "ext_caller_contract_txi" => create_txi,
+                           "ext_caller_contract_tx_hash" => contract_tx_hash,
+                           "ext_caller_contract_id" => contract_id,
+                           "parent_contract_id" => nil,
+                           "call_txi" => call_txi,
+                           "call_tx_hash" => call_tx_hash,
+                           "args" => args,
+                           "data" => data,
+                           "event_hash" => event_hash,
+                           "height" => height,
+                           "micro_index" => micro_index,
+                           "block_hash" => block_hash,
+                           "log_idx" => log_idx
+                         } ->
+        assert create_txi == call_txi - 100 or create_txi == contract_create_txi
+        assert contract_tx_hash == encode(:tx_hash, Txs.txi_to_hash(state, create_txi))
+        assert contract_id == enc_ct(Origin.pubkey(state, {:contract, create_txi}))
+        assert call_tx_hash == encode(:tx_hash, Txs.txi_to_hash(state, call_txi))
+        assert args == [to_string(call_txi)]
+        assert data == "0x" <> Integer.to_string(call_txi, 16)
+        assert event_hash in @event_hashes
+        assert height == @log_kbi
+        assert micro_index == @log_mbi
+        assert block_hash == encode(:micro_block_hash, @log_block_hash)
+        assert log_idx == rem(call_txi, 5)
+      end)
+    end
+
+    test "returns paginated contract logs by desc call txi", %{conn: conn, store: store} do
+      assert %{"data" => logs, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/logs")
+               |> json_response(200)
+
+      assert @default_limit = length(logs)
+      assert ^logs = Enum.sort_by(logs, & &1["call_txi"], :desc)
+      assert hd(logs)["call_txi"] == @last_log_txi
+
+      assert Enum.all?(logs, fn %{
+                                  "call_txi" => call_txi,
+                                  "height" => height,
+                                  "micro_index" => micro_index,
+                                  "block_hash" => block_hash
+                                } ->
+               call_txi in @log_txis and height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => next_logs, "prev" => prev_logs} =
+               conn |> with_store(store) |> get(next) |> json_response(200)
+
+      assert @default_limit = length(next_logs)
+      assert ^next_logs = Enum.sort_by(next_logs, & &1["call_txi"], :desc)
+      assert hd(next_logs)["call_txi"] == @last_log_txi - 10
+
+      assert Enum.all?(next_logs, fn %{
+                                       "call_txi" => call_txi,
+                                       "height" => height,
+                                       "micro_index" => micro_index,
+                                       "block_hash" => block_hash
+                                     } ->
+               call_txi in @log_txis and height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => ^logs} =
+               conn |> with_store(store) |> get(prev_logs) |> json_response(200)
+    end
+
+    test "returns paginated contract logs by asc call txi", %{conn: conn, store: store} do
+      assert %{"data" => logs, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/logs", direction: :forward)
+               |> json_response(200)
+
+      assert @default_limit = length(logs)
+      assert ^logs = Enum.sort_by(logs, & &1["call_txi"])
+      assert hd(logs)["call_txi"] == @first_log_txi
+
+      assert Enum.all?(logs, fn %{
+                                  "call_txi" => call_txi,
+                                  "height" => height,
+                                  "micro_index" => micro_index,
+                                  "block_hash" => block_hash
+                                } ->
+               call_txi in @log_txis and height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => next_logs, "prev" => prev_logs} =
+               conn |> with_store(store) |> get(next) |> json_response(200)
+
+      assert @default_limit = length(next_logs)
+      assert ^next_logs = Enum.sort_by(next_logs, & &1["call_txi"])
+      assert hd(next_logs)["call_txi"] == @first_log_txi + 10
+
+      assert Enum.all?(next_logs, fn %{
+                                       "call_txi" => call_txi,
+                                       "height" => height,
+                                       "micro_index" => micro_index,
+                                       "block_hash" => block_hash
+                                     } ->
+               call_txi in @log_txis and height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => ^logs} =
+               conn |> with_store(store) |> get(prev_logs) |> json_response(200)
+    end
+
+    test "returns contract logs filtered by contract", %{
+      conn: conn,
+      store: store,
+      contract_pk: contract_pk
+    } do
+      contract_id = enc_ct(contract_pk)
+
+      assert %{"data" => logs, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/logs", contract: contract_id, direction: :forward)
+               |> json_response(200)
+
+      assert @default_limit = length(logs)
+      assert ^logs = Enum.sort_by(logs, & &1["call_txi"])
+      assert hd(logs)["call_txi"] == @first_log_txi + @mixed_logs_amount
+
+      assert Enum.all?(logs, fn %{
+                                  "contract_id" => ct_id,
+                                  "call_txi" => call_txi,
+                                  "height" => height,
+                                  "micro_index" => micro_index,
+                                  "block_hash" => block_hash
+                                } ->
+               ct_id == contract_id and call_txi in @log_txis and height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => next_logs, "prev" => prev_logs} =
+               conn |> with_store(store) |> get(next) |> json_response(200)
+
+      assert @default_limit = length(next_logs)
+      assert ^next_logs = Enum.sort_by(next_logs, & &1["call_txi"])
+      assert hd(next_logs)["call_txi"] == @first_log_txi + @mixed_logs_amount + 10
+
+      assert Enum.all?(next_logs, fn %{
+                                       "contract_id" => ct_id,
+                                       "call_txi" => call_txi,
+                                       "height" => height,
+                                       "micro_index" => micro_index,
+                                       "block_hash" => block_hash
+                                     } ->
+               ct_id == contract_id and call_txi in @log_txis and height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => ^logs} =
+               conn |> with_store(store) |> get(prev_logs) |> json_response(200)
+    end
+
+    test "returns contract logs filtered by data", %{
+      conn: conn,
+      store: store
+    } do
+      data_prefix = "0x#{Integer.to_string(@first_log_txi, 16)}" |> String.slice(0, 5)
+
+      assert %{"data" => logs, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/logs", data: data_prefix, direction: :forward)
+               |> json_response(200)
+
+      assert @default_limit = length(logs)
+      assert ^logs = Enum.sort_by(logs, & &1["call_txi"])
+      assert hd(logs)["call_txi"] == @first_log_txi
+
+      assert Enum.all?(logs, fn %{
+                                  "data" => data,
+                                  "call_txi" => call_txi,
+                                  "height" => height,
+                                  "micro_index" => micro_index,
+                                  "block_hash" => block_hash
+                                } ->
+               String.starts_with?(data, data_prefix) and call_txi in @log_txis and
+                 height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => next_logs, "prev" => prev_logs} =
+               conn |> with_store(store) |> get(next) |> json_response(200)
+
+      assert @default_limit = length(next_logs)
+      assert ^next_logs = Enum.sort_by(next_logs, & &1["call_txi"])
+      assert hd(next_logs)["call_txi"] == @first_log_txi + 10
+
+      assert Enum.all?(next_logs, fn %{
+                                       "data" => data,
+                                       "call_txi" => call_txi,
+                                       "height" => height,
+                                       "micro_index" => micro_index,
+                                       "block_hash" => block_hash
+                                     } ->
+               String.starts_with?(data, data_prefix) and call_txi in @log_txis and
+                 height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => ^logs} =
+               conn |> with_store(store) |> get(prev_logs) |> json_response(200)
+    end
+
+    test "returns contract logs filtered by data of a contract", %{
+      conn: conn,
+      store: store,
+      contract_pk: contract_pk
+    } do
+      contract_id = enc_ct(contract_pk)
+      # data = "0xF4270"
+      first_txi = @first_log_txi + 47
+      data_prefix = ("0x" <> Integer.to_string(first_txi, 16)) |> String.slice(0, 6)
+      limit = 6
+
+      assert %{"data" => logs, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/logs", data: data_prefix, direction: :forward, limit: 6)
+               |> json_response(200)
+
+      assert length(logs) == limit
+      assert ^logs = Enum.sort_by(logs, & &1["call_txi"])
+      assert hd(logs)["call_txi"] == first_txi
+
+      assert Enum.all?(logs, fn %{
+                                  "data" => data,
+                                  "contract_id" => ct_id,
+                                  "call_txi" => call_txi,
+                                  "height" => height,
+                                  "micro_index" => micro_index,
+                                  "block_hash" => block_hash
+                                } ->
+               String.starts_with?(data, data_prefix) and ct_id == contract_id and
+                 call_txi in @log_txis and height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => next_logs, "prev" => prev_logs} =
+               conn |> with_store(store) |> get(next) |> json_response(200)
+
+      assert length(next_logs) == limit
+      assert ^next_logs = Enum.sort_by(next_logs, & &1["call_txi"])
+      assert hd(next_logs)["call_txi"] == hd(logs)["call_txi"] + limit
+
+      assert Enum.all?(next_logs, fn %{
+                                       "data" => data,
+                                       "call_txi" => call_txi,
+                                       "height" => height,
+                                       "micro_index" => micro_index,
+                                       "block_hash" => block_hash
+                                     } ->
+               String.starts_with?(data, data_prefix) and call_txi in @log_txis and
+                 height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+
+      assert %{"data" => ^logs} =
+               conn |> with_store(store) |> get(prev_logs) |> json_response(200)
+    end
+
+    test "returns contract logs filtered by event", %{
+      conn: conn,
+      store: store
+    } do
+      assert %{"data" => logs, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/logs", event: @evt2_ctor_name, direction: :forward)
+               |> json_response(200)
+
+      assert @default_limit = length(logs)
+      assert ^logs = Enum.sort_by(logs, & &1["call_txi"])
+      assert hd(logs)["call_txi"] == @first_log_txi + @evt1_amount
+
+      assert Enum.all?(logs, fn %{
+                                  "event_hash" => event_hash,
+                                  "call_txi" => call_txi,
+                                  "height" => height,
+                                  "micro_index" => micro_index,
+                                  "block_hash" => block_hash
+                                } ->
+               event_hash == Base.hex_encode32(@evt2_hash) and
+                 call_txi in @log_txis and height == @log_kbi and
+                 micro_index == @log_mbi and
+                 block_hash == encode(:micro_block_hash, @log_block_hash)
+             end)
+    end
+  end
+
+  describe "fetch_calls/5" do
+    test "renders all saved internal calls with limit=100", %{
+      conn: conn,
+      store: store,
+      contract_pk: contract_pk
+    } do
+      assert %{"data" => calls, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/calls", limit: 100)
+               |> json_response(200)
+
+      assert length(calls) == @mixed_calls_amount + @contract_calls_amount + 2
+
+      state = State.new(store)
+      contract_create_txi = Origin.tx_index!(state, {:contract, contract_pk})
+
+      Enum.each(calls, fn %{
+                            "contract_txi" => contract_txi,
+                            "contract_tx_hash" => contract_tx_hash,
+                            "contract_id" => contract_id,
+                            "call_txi" => call_txi,
+                            "call_tx_hash" => call_tx_hash,
+                            "function" => function,
+                            "internal_tx" => internal_tx,
+                            "height" => height,
+                            "micro_index" => micro_index,
+                            "block_hash" => block_hash,
+                            "local_idx" => local_idx
+                          } ->
+        assert contract_txi == call_txi - 100 or contract_txi == contract_create_txi
+        assert contract_tx_hash == encode(:tx_hash, <<contract_txi::256>>)
+        assert contract_id == enc_ct(Origin.pubkey(state, {:contract, contract_txi}))
+        assert call_tx_hash == encode(:tx_hash, <<call_txi::256>>)
+
+        if call_txi == hd(calls)["call_txi"] do
+          assert function == "Call.amount"
+          assert internal_tx["payload"] == "ba_Q2FsbC5hbW91bnTau3mT"
+        else
+          assert function == @call_function
+          assert internal_tx["payload"] == "ba_Q2hhaW4uc3BlbmRFa4Tl"
+        end
+
+        assert Map.delete(internal_tx, "payload") == %{
+                 "amount" => 1_000_000_000_000_000_000,
+                 "fee" => 0,
+                 "nonce" => 0,
+                 "recipient_id" => enc_id(<<call_txi::256>>),
+                 "sender_id" => enc_id(@sender_pk),
+                 "type" => "SpendTx",
+                 "version" => 1
+               }
+
+        assert height == @call_kbi
+        assert micro_index == @call_mbi
+        assert block_hash == encode(:micro_block_hash, @call_block_hash)
+        assert local_idx in 0..1
+      end)
+    end
+
+    test "returns paginated contract calls by desc call txi", %{conn: conn, store: store} do
+      assert %{"data" => calls, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/calls")
+               |> json_response(200)
+
+      assert @default_limit = length(calls)
+      assert ^calls = Enum.sort_by(calls, & &1["call_txi"], :desc)
+      assert hd(calls)["call_txi"] == @last_call_txi
+
+      assert Enum.all?(calls, fn %{
+                                   "call_txi" => call_txi,
+                                   "height" => height,
+                                   "micro_index" => micro_index,
+                                   "block_hash" => block_hash
+                                 } ->
+               call_txi in @call_txis and height == @call_kbi and
+                 micro_index == @call_mbi and
+                 block_hash == encode(:micro_block_hash, @call_block_hash)
+             end)
+
+      assert %{"data" => next_calls, "prev" => prev_calls} =
+               conn |> with_store(store) |> get(next) |> json_response(200)
+
+      assert @default_limit = length(next_calls)
+      assert ^next_calls = Enum.sort_by(next_calls, & &1["call_txi"], :desc)
+      assert hd(next_calls)["call_txi"] == @last_call_txi - 5
+
+      assert Enum.all?(next_calls, fn %{
+                                        "call_txi" => call_txi,
+                                        "height" => height,
+                                        "micro_index" => micro_index,
+                                        "block_hash" => block_hash
+                                      } ->
+               call_txi in @call_txis and height == @call_kbi and
+                 micro_index == @call_mbi and
+                 block_hash == encode(:micro_block_hash, @call_block_hash)
+             end)
+
+      assert %{"data" => ^calls} =
+               conn |> with_store(store) |> get(prev_calls) |> json_response(200)
+    end
+
+    test "returns paginated contract calls by asc call txi", %{conn: conn, store: store} do
+      assert %{"data" => calls, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/calls", direction: :forward)
+               |> json_response(200)
+
+      assert @default_limit = length(calls)
+      assert ^calls = Enum.sort_by(calls, & &1["call_txi"])
+      assert hd(calls)["call_txi"] == @first_call_txi
+
+      assert Enum.all?(calls, fn %{
+                                   "call_txi" => call_txi,
+                                   "height" => height,
+                                   "micro_index" => micro_index,
+                                   "block_hash" => block_hash
+                                 } ->
+               call_txi in @call_txis and height == @call_kbi and
+                 micro_index == @call_mbi and
+                 block_hash == encode(:micro_block_hash, @call_block_hash)
+             end)
+
+      assert %{"data" => next_calls, "prev" => prev_calls} =
+               conn |> with_store(store) |> get(next) |> json_response(200)
+
+      assert @default_limit = length(next_calls)
+      assert ^next_calls = Enum.sort_by(next_calls, & &1["call_txi"])
+      assert hd(next_calls)["call_txi"] == @first_call_txi + 5
+
+      assert Enum.all?(next_calls, fn %{
+                                        "call_txi" => call_txi,
+                                        "height" => height,
+                                        "micro_index" => micro_index,
+                                        "block_hash" => block_hash
+                                      } ->
+               call_txi in @call_txis and height == @call_kbi and
+                 micro_index == @call_mbi and
+                 block_hash == encode(:micro_block_hash, @call_block_hash)
+             end)
+
+      assert %{"data" => ^calls} =
+               conn |> with_store(store) |> get(prev_calls) |> json_response(200)
+    end
+
+    test "returns internal calls filtered by contract", %{
+      conn: conn,
+      store: store,
+      contract_pk: contract_pk
+    } do
+      contract_id = enc_ct(contract_pk)
+
+      assert %{"data" => calls, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/calls", contract: contract_id, direction: :forward)
+               |> json_response(200)
+
+      assert @default_limit == length(calls)
+      assert ^calls = Enum.sort_by(calls, & &1["call_txi"])
+      assert hd(calls)["call_txi"] == @first_call_txi + div(@mixed_calls_amount, 2)
+
+      state = State.new(store)
+      contract_create_txi = Origin.tx_index!(state, {:contract, contract_pk})
+
+      Enum.each(calls, fn %{
+                            "contract_txi" => contract_txi,
+                            "contract_tx_hash" => contract_tx_hash,
+                            "contract_id" => ct_id,
+                            "call_txi" => call_txi,
+                            "call_tx_hash" => call_tx_hash,
+                            "function" => function,
+                            "internal_tx" => internal_tx,
+                            "height" => height,
+                            "micro_index" => micro_index,
+                            "block_hash" => block_hash,
+                            "local_idx" => local_idx
+                          } ->
+        assert contract_txi == contract_create_txi
+        assert contract_tx_hash == encode(:tx_hash, <<contract_txi::256>>)
+        assert ct_id == contract_id
+        assert call_tx_hash == encode(:tx_hash, <<call_txi::256>>)
+        assert function == @call_function
+
+        assert internal_tx == %{
+                 "amount" => 1_000_000_000_000_000_000,
+                 "fee" => 0,
+                 "nonce" => 0,
+                 "payload" => "ba_Q2hhaW4uc3BlbmRFa4Tl",
+                 "recipient_id" => enc_id(<<call_txi::256>>),
+                 "sender_id" => enc_id(@sender_pk),
+                 "type" => "SpendTx",
+                 "version" => 1
+               }
+
+        assert height == @call_kbi
+        assert micro_index == @call_mbi
+        assert block_hash == encode(:micro_block_hash, @call_block_hash)
+        assert local_idx in 0..1
+      end)
+
+      assert %{"data" => next_calls, "prev" => prev_calls} =
+               conn |> with_store(store) |> get(next) |> json_response(200)
+
+      assert @default_limit = length(next_calls)
+      assert ^next_calls = Enum.sort_by(next_calls, & &1["call_txi"])
+      assert hd(next_calls)["call_txi"] == hd(calls)["call_txi"] + 5
+
+      assert Enum.all?(next_calls, fn %{
+                                        "contract_id" => ct_id,
+                                        "call_txi" => call_txi,
+                                        "height" => height,
+                                        "micro_index" => micro_index,
+                                        "block_hash" => block_hash
+                                      } ->
+               ct_id == contract_id and call_txi in @call_txis and height == @call_kbi and
+                 micro_index == @call_mbi and
+                 block_hash == encode(:micro_block_hash, @call_block_hash)
+             end)
+
+      assert %{"data" => ^calls} =
+               conn |> with_store(store) |> get(prev_calls) |> json_response(200)
+    end
+
+    test "returns internal calls filtered by contract and SpendTx recipient_id", %{
+      conn: conn,
+      store: store,
+      contract_pk: contract_pk
+    } do
+      contract_id = enc_ct(contract_pk)
+      expected_call_txi = @first_call_txi + div(@mixed_calls_amount, 2)
+      recipient_id = enc_id(<<expected_call_txi::256>>)
+
+      assert %{"data" => calls, "next" => nil} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/calls", contract: contract_id, recipient_id: recipient_id)
+               |> json_response(200)
+
+      state = State.new(store)
+      contract_create_txi = Origin.tx_index!(state, {:contract, contract_pk})
+
+      Enum.each(calls, fn %{
+                            "contract_txi" => contract_txi,
+                            "contract_tx_hash" => contract_tx_hash,
+                            "contract_id" => ct_id,
+                            "call_txi" => call_txi,
+                            "call_tx_hash" => call_tx_hash,
+                            "function" => function,
+                            "internal_tx" => internal_tx,
+                            "height" => height,
+                            "micro_index" => micro_index,
+                            "block_hash" => block_hash,
+                            "local_idx" => local_idx
+                          } ->
+        assert contract_txi == contract_create_txi
+        assert contract_tx_hash == encode(:tx_hash, <<contract_txi::256>>)
+        assert ct_id == contract_id
+        assert call_txi == expected_call_txi
+        assert call_tx_hash == encode(:tx_hash, <<call_txi::256>>)
+        assert function == @call_function
+
+        assert internal_tx == %{
+                 "amount" => 1_000_000_000_000_000_000,
+                 "fee" => 0,
+                 "nonce" => 0,
+                 "payload" => "ba_Q2hhaW4uc3BlbmRFa4Tl",
+                 "recipient_id" => enc_id(<<call_txi::256>>),
+                 "sender_id" => enc_id(@sender_pk),
+                 "type" => "SpendTx",
+                 "version" => 1
+               }
+
+        assert height == @call_kbi
+        assert micro_index == @call_mbi
+        assert block_hash == encode(:micro_block_hash, @call_block_hash)
+        assert local_idx in 0..1
+      end)
+    end
+
+    test "returns internal calls filtered by SpendTx recipient_id", %{
+      conn: conn,
+      store: store
+    } do
+      expected_call_txi = @first_call_txi + 1
+      recipient_id = enc_id(<<expected_call_txi::256>>)
+
+      assert %{"data" => calls, "next" => nil} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/calls", recipient_id: recipient_id)
+               |> json_response(200)
+
+      state = State.new(store)
+      contract_pk = Origin.pubkey(state, {:contract, expected_call_txi - 100})
+      contract_create_txi = Origin.tx_index!(state, {:contract, contract_pk})
+
+      Enum.each(calls, fn %{
+                            "contract_txi" => contract_txi,
+                            "contract_tx_hash" => contract_tx_hash,
+                            "contract_id" => ct_id,
+                            "call_txi" => call_txi,
+                            "call_tx_hash" => call_tx_hash,
+                            "function" => function,
+                            "internal_tx" => internal_tx,
+                            "height" => height,
+                            "micro_index" => micro_index,
+                            "block_hash" => block_hash,
+                            "local_idx" => local_idx
+                          } ->
+        assert contract_txi == contract_create_txi
+        assert contract_tx_hash == encode(:tx_hash, <<contract_txi::256>>)
+        assert ct_id == enc_ct(contract_pk)
+        assert call_txi == expected_call_txi
+        assert call_tx_hash == encode(:tx_hash, <<call_txi::256>>)
+        assert function == @call_function
+
+        assert internal_tx == %{
+                 "amount" => 1_000_000_000_000_000_000,
+                 "fee" => 0,
+                 "nonce" => 0,
+                 "payload" => "ba_Q2hhaW4uc3BlbmRFa4Tl",
+                 "recipient_id" => enc_id(<<call_txi::256>>),
+                 "sender_id" => enc_id(@sender_pk),
+                 "type" => "SpendTx",
+                 "version" => 1
+               }
+
+        assert height == @call_kbi
+        assert micro_index == @call_mbi
+        assert block_hash == encode(:micro_block_hash, @call_block_hash)
+        assert local_idx in 0..1
+      end)
+    end
+
+    test "returns internal calls filtered by function", %{
+      conn: conn,
+      store: store
+    } do
+      fname_prefix = "Chain"
+
+      assert %{"data" => calls, "next" => next} =
+               conn
+               |> with_store(store)
+               |> get("/v2/contracts/calls", function: fname_prefix)
+               |> json_response(200)
+
+      assert Enum.all?(calls, fn %{
+                                   "function" => function,
+                                   "call_txi" => call_txi,
+                                   "height" => height,
+                                   "micro_index" => micro_index,
+                                   "block_hash" => block_hash
+                                 } ->
+               String.starts_with?(function, fname_prefix) and call_txi in @call_txis and
+                 height == @call_kbi and
+                 micro_index == @call_mbi and
+                 block_hash == encode(:micro_block_hash, @call_block_hash)
+             end)
+
+      assert %{"data" => next_calls, "prev" => prev_calls} =
+               conn |> with_store(store) |> get(next) |> json_response(200)
+
+      assert Enum.all?(next_calls, fn %{
+                                        "function" => function,
+                                        "call_txi" => call_txi,
+                                        "height" => height,
+                                        "micro_index" => micro_index,
+                                        "block_hash" => block_hash
+                                      } ->
+               String.starts_with?(function, fname_prefix) and call_txi in @call_txis and
+                 height == @call_kbi and
+                 micro_index == @call_mbi and
+                 block_hash == encode(:micro_block_hash, @call_block_hash)
+             end)
+
+      assert %{"data" => ^calls} =
+               conn |> with_store(store) |> get(prev_calls) |> json_response(200)
+    end
+  end
+
+  defp enc_ct(pk), do: :aeser_api_encoder.encode(:contract_pubkey, pk)
+  defp enc_id(pk), do: :aeser_api_encoder.encode(:account_pubkey, pk)
+  defp encode(type, pk), do: :aeser_api_encoder.encode(type, pk)
+
+  defp logs_setup(store, contract_pk) do
+    block_index1 = {100, 1}
+    block_index2 = {@log_kbi, @log_mbi}
+
+    store =
+      store
+      |> Store.put(
+        Model.Block,
+        Model.block(index: block_index1, hash: :crypto.strong_rand_bytes(32))
+      )
+      |> Store.put(
+        Model.Block,
+        Model.block(index: block_index2, hash: @log_block_hash)
+      )
+
+    last_log_txi = @first_log_txi + @mixed_logs_amount - 1
+
+    store =
+      Enum.reduce(@first_log_txi..last_log_txi, store, fn txi, store ->
+        create_txi = txi - 100
+        evt_hash = if txi < @first_log_txi + @evt1_amount, do: @evt1_hash, else: @evt2_hash
+        data = "0x" <> Integer.to_string(txi, 16)
+        idx = rem(txi, 5)
+        contract_pk = :crypto.strong_rand_bytes(32)
+
+        m_log =
+          Model.contract_log(
+            index: {create_txi, txi, evt_hash, idx},
+            ext_contract: contract_pk,
+            args: [<<txi::256>>],
+            data: data
+          )
+
+        m_data_log = Model.data_contract_log(index: {data, txi, create_txi, evt_hash, idx})
+        m_evt_log = Model.evt_contract_log(index: {evt_hash, txi, create_txi, idx})
+        m_idx_log = Model.idx_contract_log(index: {txi, create_txi, evt_hash, idx})
+
+        store
+        |> Store.put(
+          Model.Tx,
+          Model.tx(index: create_txi, id: <<create_txi::256>>, block_index: block_index1)
+        )
+        |> Store.put(Model.Tx, Model.tx(index: txi, id: <<txi::256>>, block_index: block_index2))
+        |> Store.put(
+          Model.Field,
+          Model.field(index: {:contract_create_tx, nil, contract_pk, create_txi})
+        )
+        |> Store.put(
+          Model.RevOrigin,
+          Model.rev_origin(index: {create_txi, :contract_create_tx, contract_pk})
+        )
+        |> Store.put(Model.ContractLog, m_log)
+        |> Store.put(Model.DataContractLog, m_data_log)
+        |> Store.put(Model.EvtContractLog, m_evt_log)
+        |> Store.put(Model.IdxContractLog, m_idx_log)
+      end)
+
+    create_txi = last_log_txi + 1 - 100
+
+    store =
+      Enum.reduce((last_log_txi + 1)..(last_log_txi + @contract_logs_amount), store, fn txi,
+                                                                                        store ->
+        evt_hash = @evt1_hash
+        data = "0x" <> Integer.to_string(txi, 16)
+        idx = rem(txi, 5)
+
+        m_log =
+          Model.contract_log(
+            index: {create_txi, txi, evt_hash, idx},
+            ext_contract: contract_pk,
+            args: [<<txi::256>>],
+            data: data
+          )
+
+        m_data_log = Model.data_contract_log(index: {data, txi, create_txi, evt_hash, idx})
+        m_evt_log = Model.evt_contract_log(index: {evt_hash, txi, create_txi, idx})
+        m_idx_log = Model.idx_contract_log(index: {txi, create_txi, evt_hash, idx})
+
+        store
+        |> Store.put(
+          Model.Tx,
+          Model.tx(index: create_txi, id: <<create_txi::256>>, block_index: block_index1)
+        )
+        |> Store.put(Model.Tx, Model.tx(index: txi, id: <<txi::256>>, block_index: block_index2))
+        |> Store.put(Model.ContractLog, m_log)
+        |> Store.put(Model.DataContractLog, m_data_log)
+        |> Store.put(Model.EvtContractLog, m_evt_log)
+        |> Store.put(Model.IdxContractLog, m_idx_log)
+      end)
+
+    store
+    |> Store.put(
+      Model.Field,
+      Model.field(index: {:contract_create_tx, nil, contract_pk, create_txi})
+    )
+    |> Store.put(
+      Model.RevOrigin,
+      Model.rev_origin(index: {create_txi, :contract_create_tx, contract_pk})
+    )
+  end
+
+  defp calls_setup(store, contract_pk) do
+    block_index1 = {200, 1}
+    block_index2 = {@call_kbi, @call_mbi}
+
+    store =
+      store
+      |> Store.put(
+        Model.Block,
+        Model.block(index: block_index1, hash: :crypto.strong_rand_bytes(32))
+      )
+      |> Store.put(
+        Model.Block,
+        Model.block(index: block_index2, hash: @call_block_hash)
+      )
+
+    last_call_txi = @first_call_txi + div(@mixed_calls_amount, 2) - 1
+
+    {mixed_ct_mutations, store} =
+      Enum.map_reduce(@first_call_txi..last_call_txi, store, fn call_txi, store ->
+        int_calls =
+          Enum.map(0..1, fn i ->
+            tx =
+              {:aetx, :spend_tx, :aec_spend_tx, i,
+               {:spend_tx, {:id, :account, @sender_pk}, {:id, :account, <<call_txi::256>>},
+                1_000_000_000_000_000_000, 0, 0, 0, @call_function}}
+
+            {tx_type, raw_tx} = :aetx.specialize_type(tx)
+
+            {@call_function, tx_type, tx, raw_tx}
+          end)
+
+        contract_pk = :crypto.strong_rand_bytes(32)
+        create_txi = call_txi - 100
+
+        store =
+          store
+          |> Store.put(
+            Model.Field,
+            Model.field(index: {:contract_create_tx, nil, contract_pk, create_txi})
+          )
+          |> Store.put(
+            Model.RevOrigin,
+            Model.rev_origin(index: {create_txi, :contract_create_tx, contract_pk})
+          )
+          |> Store.put(
+            Model.Tx,
+            Model.tx(index: call_txi, id: <<call_txi::256>>, block_index: block_index2)
+          )
+          |> Store.put(
+            Model.Tx,
+            Model.tx(index: create_txi, id: <<create_txi::256>>, block_index: block_index2)
+          )
+
+        {IntCallsMutation.new(contract_pk, call_txi, int_calls), store}
+      end)
+
+    first_txi = last_call_txi + 1
+    last_txi = first_txi + div(@contract_calls_amount, 2) - 1
+
+    {contract_mutations, store} =
+      Enum.map_reduce(first_txi..last_txi, store, fn call_txi, store ->
+        int_calls =
+          Enum.map(0..1, fn i ->
+            tx =
+              {:aetx, :spend_tx, :aec_spend_tx, i,
+               {:spend_tx, {:id, :account, @sender_pk}, {:id, :account, <<call_txi::256>>},
+                1_000_000_000_000_000_000, 0, 0, 0, @call_function}}
+
+            {tx_type, raw_tx} = :aetx.specialize_type(tx)
+
+            {@call_function, tx_type, tx, raw_tx}
+          end)
+
+        store =
+          Store.put(
+            store,
+            Model.Tx,
+            Model.tx(index: call_txi, id: <<call_txi::256>>, block_index: block_index2)
+          )
+
+        {IntCallsMutation.new(contract_pk, call_txi, int_calls), store}
+      end)
+
+    not_spend_txi = last_txi + 1
+
+    not_spend_int_calls =
+      Enum.map(0..1, fn i ->
+        tx =
+          {:aetx, :spend_tx, :aec_spend_tx, i,
+           {:spend_tx, {:id, :account, @sender_pk}, {:id, :account, <<not_spend_txi::256>>},
+            1_000_000_000_000_000_000, 0, 0, 0, "Call.amount"}}
+
+        {tx_type, raw_tx} = :aetx.specialize_type(tx)
+
+        {"Call.amount", tx_type, tx, raw_tx}
+      end)
+
+    extra_ct_pk = :crypto.strong_rand_bytes(32)
+    create_txi = not_spend_txi - 100
+
+    store =
+      store
+      |> Store.put(
+        Model.Field,
+        Model.field(index: {:contract_create_tx, nil, extra_ct_pk, create_txi})
+      )
+      |> Store.put(
+        Model.RevOrigin,
+        Model.rev_origin(index: {create_txi, :contract_create_tx, extra_ct_pk})
+      )
+      |> Store.put(
+        Model.Tx,
+        Model.tx(index: create_txi, id: <<create_txi::256>>, block_index: block_index2)
+      )
+      |> Store.put(
+        Model.Tx,
+        Model.tx(index: not_spend_txi, id: <<not_spend_txi::256>>, block_index: block_index2)
+      )
+
+    extra_mutation = IntCallsMutation.new(extra_ct_pk, not_spend_txi, not_spend_int_calls)
+
+    %{store: store2} =
+      State.commit_mem(
+        State.new(store),
+        mixed_ct_mutations ++ contract_mutations ++ [extra_mutation]
+      )
+
+    store2
+  end
+end

--- a/test/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/ae_mdw_web/controllers/contract_controller_test.exs
@@ -993,12 +993,6 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
 
     extra_mutation = IntCallsMutation.new(extra_ct_pk, not_spend_txi, not_spend_int_calls)
 
-    %{store: store2} =
-      State.commit_mem(
-        State.new(store),
-        mixed_ct_mutations ++ contract_mutations ++ [extra_mutation]
-      )
-
-    store2
+    change_store(store, mixed_ct_mutations ++ contract_mutations ++ [extra_mutation])
   end
 end

--- a/test/support/test_util.ex
+++ b/test/support/test_util.ex
@@ -4,6 +4,7 @@ defmodule AeMdwWeb.TestUtil do
   """
 
   alias AeMdw.Error.Input, as: ErrInput
+  alias AeMdw.Db.Mutation
   alias AeMdw.Db.State
   alias Plug.Conn
 
@@ -20,5 +21,15 @@ defmodule AeMdwWeb.TestUtil do
   @spec with_store(Conn.t(), Store.t()) :: Conn.t()
   def with_store(conn, store) do
     Conn.assign(conn, :state, State.new(store))
+  end
+
+  @spec change_store(Store.t(), [Mutation.t()]) :: Store.t()
+  def change_store(store, mutations) do
+    %{store: store2} =
+      Enum.reduce(mutations, State.new(store), fn mutation, state ->
+        Mutation.execute(mutation, state)
+      end)
+
+    store2
   end
 end


### PR DESCRIPTION
## What

- Unify scope deserialization by separating key boundary from the gen or txi scope
- Remove use of `max_blob` for all `/v2/contract/calls` and `/v2/contract/logs` except for data log filtered one
- Remove use of `max_blob` for name and auction prefixing 
- Leverage Erlang term comparison to allocate less memory on query key boundaries
- Adds unit test coverage for `/v2/contract/calls` and `/v2/contract/logs`

## Why

- Allocate less memory by replacing `max_256bit_int` with `nil`
- max_blob is a 256KB

## Notes

- Gladly the BEAM doesn't reallocate every time the `max_blob` 
- Analysis of NFT token id with negative values will be done in a separte PR 
