### PR TITLE
feat: add /accounts/:id/activities endpoint

### DIFF
--- a/lib/ae_mdw/activities.ex
+++ b/lib/ae_mdw/activities.ex
@@ -1,0 +1,149 @@
+defmodule AeMdw.Activities do
+  @moduledoc """
+  Activities context module.
+  """
+  alias AeMdw.Blocks
+  alias AeMdw.Collection
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Error
+  alias AeMdw.Error.Input, as: ErrInput
+  alias AeMdw.Fields
+  alias AeMdw.Node
+  alias AeMdw.Txs
+  alias AeMdw.Validate
+
+  require Model
+
+  @type activity() :: map()
+
+  @typep state() :: State.t()
+  @typep pagination() :: Collection.direction_limit()
+  @typep range() :: {:gen, Range.t()} | nil
+  @typep query() :: map()
+  @typep cursor() :: binary() | nil
+  @typep txi() :: Txs.txi()
+  @typep activity_key() :: {Blocks.height(), txi(), non_neg_integer()}
+  @typep activity_value() :: {:field, Node.tx_type(), non_neg_integer() | nil}
+  @typep activity_pair() :: {activity_key(), activity_value()}
+
+  @doc """
+  Activities related to an account are those that affect the account in any way.
+
+  The paginated activities returned follow the transactions order, and include the following:
+
+  * Key blocks
+    * Block mined {gen, -1, 0}
+    * Miner rewards {gen, -1, 1..X}
+    * Micro blocks
+      * Block mined {gen, -1, X+1..}
+      * Transactions
+        * If spend_tx, oracle, channels, etc include all senders/recipient's info {gen, A, 0..X}
+        * If contract_create or contract_call include:
+          * All remote calls recusively {gen, A, X+1..Y}
+          * All internal events {gen, A, Y+1..}
+
+  Internally an activity is identified by the tuple {height, txi, local_idx}:
+
+    * `height` - The key block height
+    * `txi` - If the activity belongs to a transaction
+    * `local_idx` - If there's more than one activity per txi, then this index is used, starting from 0.
+
+  These are a few examples of different activities that the build_*_stream functions would return:
+
+  * `{{10, -1, 0}, :block_mined}` - The first activity belonging to the key block 10.
+  * `{{10, 40, 0}, {:field, :spend_tx, 1}}` - The first activity belonging to the transaction with txi 40 (from height 10),
+     where the first field of the spend transaction is the account's being queried.
+
+  """
+  @spec fetch_account_activities(state(), binary(), pagination(), range(), query(), cursor()) ::
+          {:ok, activity() | nil, [activity()], activity() | nil} | {:error, Error.t()}
+  def fetch_account_activities(state, account, pagination, range, _query, cursor) do
+    with {:ok, account_pk} <- Validate.id(account),
+         {:ok, cursor} <- deserialize_cursor(cursor) do
+      {prev_cursor, activities_locators_data, next_cursor} =
+        fn direction ->
+          gens_stream = build_gens_stream(state, direction, account_pk, range, cursor)
+          txs_stream = build_txs_stream(state, direction, account_pk, range, cursor)
+
+          Collection.merge([txs_stream, gens_stream], direction)
+        end
+        |> Collection.paginate(pagination)
+
+      {:ok, serialize_cursor(prev_cursor), Enum.map(activities_locators_data, &render(state, &1)),
+       serialize_cursor(next_cursor)}
+    end
+  end
+
+  defp build_gens_stream(_state, _direction, _account_pk, _range, _cursor) do
+    []
+  end
+
+  defp build_txs_stream(state, direction, account_pk, range, cursor) do
+    {txi_cursor, local_idx_cursor} =
+      case cursor do
+        {_height, txi, local_idx} -> {txi, local_idx}
+        nil -> {nil, nil}
+      end
+
+    stream =
+      state
+      |> Fields.account_fields_stream(account_pk, direction, range, txi_cursor)
+      |> Stream.transform({-1, -1, -1}, fn
+        {txi, tx_type, tx_field_pos}, {txi, height, local_idx} ->
+          {[{height, txi, local_idx + 1, {:field, tx_type, tx_field_pos}}],
+           {txi, height, local_idx + 1}}
+
+        {txi, tx_type, tx_field_pos}, _acc ->
+          Model.tx(block_index: {height, _mbi}) = State.fetch!(state, Model.Tx, txi)
+
+          {[{{height, txi, 0}, {:field, tx_type, tx_field_pos}}], {txi, height, 0}}
+      end)
+
+    if local_idx_cursor do
+      Stream.drop_while(stream, fn
+        {{_height, ^txi_cursor, local_idx}, _data} when direction == :forward ->
+          local_idx < local_idx_cursor
+
+        {{_height, ^txi_cursor, local_idx}, _data} when direction == :backward ->
+          local_idx > local_idx_cursor
+
+        _activity_pair ->
+          false
+      end)
+    else
+      stream
+    end
+  end
+
+  @spec render(state(), activity_pair()) :: map()
+  defp render(state, {{height, txi, _local_idx}, {:field, tx_type, _tx_pos}}) do
+    tx = state |> Txs.fetch!(txi) |> Map.delete("tx_index")
+
+    %{
+      height: height,
+      activity_type: "#{Node.tx_name(tx_type)}Event",
+      activity_payload: %{
+        tx: tx
+      }
+    }
+  end
+
+  defp serialize_cursor(nil), do: nil
+
+  defp serialize_cursor({{{height, txi, local_idx}, _data}, is_reversed?}),
+    do: {"#{height}-#{txi + 1}-#{local_idx}", is_reversed?}
+
+  defp deserialize_cursor(nil), do: {:ok, nil}
+
+  defp deserialize_cursor(cursor) do
+    case Regex.run(~r/\A(\d+)-(\d+)-(\d+)\z/, cursor, capture: :all_but_first) do
+      [height, txi, local_idx] ->
+        {:ok,
+         {String.to_integer(height), String.to_integer(txi) - 1, String.to_integer(local_idx)}}
+
+      nil ->
+        {:error, ErrInput.Cursor.exception(value: cursor)}
+    end
+  end
+end

--- a/lib/ae_mdw/db/util.ex
+++ b/lib/ae_mdw/db/util.ex
@@ -15,6 +15,8 @@ defmodule AeMdw.Db.Util do
   require Model
 
   @typep state() :: State.t()
+  @typep height() :: Blocks.height()
+  @typep direction() :: Collection.direction()
 
   @spec read_tx!(state(), Txs.txi()) :: Model.tx()
   def read_tx!(state, txi), do: State.fetch!(state, Model.Tx, txi)
@@ -81,6 +83,14 @@ defmodule AeMdw.Db.Util do
         end
     end
   end
+
+  @spec first_gen_to_txi(state(), height(), direction()) :: height()
+  def first_gen_to_txi(state, first_gen, :forward), do: gen_to_txi(state, first_gen)
+  def first_gen_to_txi(state, first_gen, :backward), do: gen_to_txi(state, first_gen + 1) - 1
+
+  @spec last_gen_to_txi(state(), height(), direction()) :: height()
+  def last_gen_to_txi(state, last_gen, :forward), do: gen_to_txi(state, last_gen + 1) - 1
+  def last_gen_to_txi(state, last_gen, :backward), do: gen_to_txi(state, last_gen)
 
   @spec txi_to_gen(state(), Txs.txi()) :: Blocks.height()
   def txi_to_gen(state, txi) do

--- a/lib/ae_mdw/fields.ex
+++ b/lib/ae_mdw/fields.ex
@@ -1,0 +1,70 @@
+defmodule AeMdw.Fields do
+  @moduledoc """
+  A simple fields querying API to filter transactions by type and/or ID.
+  """
+
+  alias AeMdw.Collection
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Util, as: DbUtil
+  alias AeMdw.Node
+  alias AeMdw.Node.Db
+  alias AeMdw.Txs
+  alias AeMdw.Util
+
+  @typep state() :: State.t()
+  @typep pubkey() :: Db.pubkey()
+  @typep direction() :: Collection.direction()
+  @typep range() :: {:gen, Range.t()} | nil
+  @typep cursor() :: Txs.tx() | nil
+
+  @create_tx_types ~w(contract_create_tx channel_create_tx oracle_register_tx name_claim_tx ga_attach_tx)a
+
+  @spec account_fields_stream(state(), pubkey(), direction(), range(), cursor()) :: Enumerable.t()
+  def account_fields_stream(state, account_pk, direction, range, cursor) do
+    scope =
+      case range do
+        {:gen, %Range{first: first_gen, last: last_gen}} ->
+          {DbUtil.first_gen_to_txi(state, first_gen, direction),
+           DbUtil.last_gen_to_txi(state, last_gen, direction)}
+
+        nil ->
+          nil
+      end
+
+    Node.tx_types()
+    |> Enum.flat_map(fn tx_type ->
+      types_pos =
+        tx_type
+        |> Node.tx_ids()
+        |> Enum.map(fn {_field, pos} -> {tx_type, pos} end)
+
+      if tx_type in @create_tx_types do
+        [{tx_type, nil} | types_pos]
+      else
+        types_pos
+      end
+    end)
+    |> Enum.map(fn {tx_type, tx_field_pos} ->
+      scope =
+        case scope do
+          {first_txi, last_txi} ->
+            {{tx_type, tx_field_pos, account_pk, first_txi},
+             {tx_type, tx_field_pos, account_pk, last_txi}}
+
+          nil ->
+            {{tx_type, tx_field_pos, account_pk, Util.min_int()},
+             {tx_type, tx_field_pos, account_pk, Util.max_256bit_int()}}
+        end
+
+      cursor = if cursor, do: {tx_type, tx_field_pos, account_pk, cursor}
+
+      state
+      |> Collection.stream(Model.Field, direction, scope, cursor)
+      |> Stream.map(fn {^tx_type, ^tx_field_pos, ^account_pk, txi} ->
+        {txi, tx_type, tx_field_pos}
+      end)
+    end)
+    |> Collection.merge(direction)
+  end
+end

--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -113,8 +113,8 @@ defmodule AeMdw.Txs do
           scope =
             case range do
               {:gen, %Range{first: first_gen, last: last_gen}} ->
-                {first_gen_to_txi(state, first_gen, direction),
-                 last_gen_to_txi(state, last_gen, direction)}
+                {DbUtil.first_gen_to_txi(state, first_gen, direction),
+                 DbUtil.last_gen_to_txi(state, last_gen, direction)}
 
               {:txi, %Range{first: first_txi, last: last_txi}} ->
                 {first_txi, last_txi}
@@ -167,14 +167,6 @@ defmodule AeMdw.Txs do
 
     tx_hash
   end
-
-  defp first_gen_to_txi(state, first_gen, :forward), do: DbUtil.gen_to_txi(state, first_gen)
-
-  defp first_gen_to_txi(state, first_gen, :backward),
-    do: DbUtil.gen_to_txi(state, first_gen + 1) - 1
-
-  defp last_gen_to_txi(state, last_gen, :forward), do: DbUtil.gen_to_txi(state, last_gen + 1) - 1
-  defp last_gen_to_txi(state, last_gen, :backward), do: DbUtil.gen_to_txi(state, last_gen)
 
   # The purpose of this function is to generate the streams that will be then used as input for
   # Collection.merge/2 function. The function is divided into three clauses. There's an explanation

--- a/lib/ae_mdw_web/controllers/activity_controller.ex
+++ b/lib/ae_mdw_web/controllers/activity_controller.ex
@@ -1,0 +1,29 @@
+defmodule AeMdwWeb.ActivityController do
+  use AeMdwWeb, :controller
+
+  alias AeMdw.Activities
+  alias AeMdwWeb.FallbackController
+  alias AeMdwWeb.Plugs.PaginatedPlug
+  alias AeMdwWeb.Util
+  alias Plug.Conn
+
+  plug(PaginatedPlug)
+  action_fallback(FallbackController)
+
+  @spec account_activities(Conn.t(), map()) :: Conn.t()
+  def account_activities(%Conn{assigns: assigns} = conn, %{"id" => account}) do
+    %{state: state, pagination: pagination, cursor: cursor, query: query, scope: scope} = assigns
+
+    with {:ok, prev_cursor, activities, next_cursor} <-
+           Activities.fetch_account_activities(
+             state,
+             account,
+             pagination,
+             scope,
+             query,
+             cursor
+           ) do
+      Util.paginate(conn, prev_cursor, activities, next_cursor)
+    end
+  end
+end

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -97,6 +97,8 @@ defmodule AeMdwWeb.Router do
 
       get "/channels", ChannelController, :channels
 
+      get "/accounts/:id/activities", ActivityController, :account_activities
+
       get "/deltastats", StatsController, :delta_stats
       get "/stats", StatsController, :stats
       get "/minerstats", StatsController, :miners

--- a/test/integration/ae_mdw_web/controllers/activity_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/activity_controller_test.exs
@@ -1,0 +1,76 @@
+defmodule Integration.AeMdwWeb.ActivityControllerTest do
+  use AeMdwWeb.ConnCase, async: false
+
+  @moduletag :integration
+
+  describe "account_activities" do
+    test "by default, it gets all account events backwards", %{conn: conn} do
+      account = "ak_2nVdbZTBVTbAet8j2hQhLmfNm1N2WKoAGyL7abTAHF1wGMPjzx"
+
+      assert %{"data" => events, "next" => next_url} =
+               conn
+               |> get("/v2/accounts/#{account}/activities")
+               |> json_response(200)
+
+      heights = events |> Enum.map(&Map.fetch(&1, "height")) |> Enum.reverse()
+
+      assert ^heights = Enum.sort(heights)
+
+      assert %{"data" => next_events} =
+               conn
+               |> get(next_url)
+               |> json_response(200)
+
+      next_heights = next_events |> Enum.map(&Map.fetch(&1, "height")) |> Enum.reverse()
+
+      assert List.last(heights) >= Enum.at(next_heights, 0)
+    end
+
+    test "when direction=forward it gets all account events forwards", %{conn: conn} do
+      account = "ak_2nVdbZTBVTbAet8j2hQhLmfNm1N2WKoAGyL7abTAHF1wGMPjzx"
+      from_height = 18_061
+      to_height = 1_000_000
+
+      assert %{"data" => events, "next" => next_url} =
+               conn
+               |> get("/v2/accounts/#{account}/activities",
+                 direction: "forward",
+                 scope: "gen:#{from_height}-#{to_height}"
+               )
+               |> json_response(200)
+
+      assert Enum.all?(
+               events,
+               &match?(
+                 %{"height" => height} when height >= from_height and height <= to_height,
+                 &1
+               )
+             )
+
+      assert %{"prev" => prev_url, "data" => next_events} =
+               conn
+               |> get(next_url)
+               |> json_response(200)
+
+      assert Enum.all?(
+               next_events,
+               &match?(
+                 %{"height" => height} when height >= from_height and height <= to_height,
+                 &1
+               )
+             )
+
+      assert %{"data" => ^events} = conn |> get(prev_url) |> json_response(200)
+    end
+
+    test "when account is invalid", %{conn: conn} do
+      invalid_account = "ak_foooo"
+      error_msg = "invalid id: #{invalid_account}"
+
+      assert %{"error" => ^error_msg} =
+               conn
+               |> get("/v2/accounts/#{invalid_account}/activities")
+               |> json_response(400)
+    end
+  end
+end


### PR DESCRIPTION
Initial approach for dealing with account activities.

This endpoint contains exclusively events generated by direct transactions (no internal transactions generated by contract calls).

The next steps are:
  * Including contract call events.
  * Including key-block and micro-block events (e.g. block_mined, dev_reward).
  * Including AEx9 and AEx141 events.
  * Refactor AeMdw.Txs so that it uses the Field module as well.

refs #725 