### PR TITLE
chore: improve dialyzer warnings to catch unmatched results

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -102,6 +102,6 @@ jobs:
         if: steps.plt-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p priv/plts
-          mix dialyzer --plt
+          mix dialyzer --plt --format github
 
-      - run: mix dialyzer
+      - run: mix dialyzer --format github

--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -59,9 +59,9 @@ defmodule AeMdw.Application do
 
   defp init(:aecore_services) do
     # need to be started after app_ctrl_server
-    Application.ensure_all_started(:aehttp)
-    Application.ensure_all_started(:aestratum)
-    Application.ensure_all_started(:aemon)
+    {:ok, _apps1} = Application.ensure_all_started(:aehttp)
+    {:ok, _apps2} = Application.ensure_all_started(:aestratum)
+    {:ok, _apps3} = Application.ensure_all_started(:aemon)
   end
 
   # def init(:aesophia) do
@@ -77,8 +77,12 @@ defmodule AeMdw.Application do
     oracle_fields = NodeHelper.record_keys(aeo_oracles_code, :oracle)
     query_fields = NodeHelper.record_keys(aeo_query_code, :query)
 
-    SmartRecord.new(AeMdw.Node, :oracle, Enum.zip(oracle_fields, Stream.cycle([nil])))
-    SmartRecord.new(AeMdw.Node, :oracle_query, Enum.zip(query_fields, Stream.cycle([nil])))
+    {:ok, _oracle_mod} =
+      SmartRecord.new(AeMdw.Node, :oracle, Enum.zip(oracle_fields, Stream.cycle([nil])))
+
+    {:ok, _oracle_query_mod} =
+      SmartRecord.new(AeMdw.Node, :oracle_query, Enum.zip(query_fields, Stream.cycle([nil])))
+
     :ok
   end
 
@@ -215,7 +219,7 @@ defmodule AeMdw.Application do
   defp init(:aesync), do: Application.ensure_all_started(:aesync)
 
   defp init(:tables) do
-    :ets.new(:tx_sync_cache, [:named_table, :ordered_set, :public])
+    :tx_sync_cache = :ets.new(:tx_sync_cache, [:named_table, :ordered_set, :public])
 
     {ets_table, ets_expiration} = Broadcaster.ets_config()
     EtsCache.new(ets_table, ets_expiration)
@@ -238,7 +242,7 @@ defmodule AeMdw.Application do
 
   @impl Application
   def start_phase(:migrate_db, _start_type, []) do
-    Mix.Tasks.MigrateDb.run(true)
+    {:ok, _applied_count} = Mix.Tasks.MigrateDb.run(true)
     :ok
   end
 

--- a/lib/ae_mdw/database.ex
+++ b/lib/ae_mdw/database.ex
@@ -11,10 +11,8 @@ defmodule AeMdw.Database do
   returned instead.
   """
 
-  alias AeMdw.Db.Mutation
   alias AeMdw.Db.RocksDb
   alias AeMdw.Db.RocksDbCF
-  alias AeMdw.Db.State
 
   @type table() :: atom()
   @type record() :: tuple()
@@ -160,18 +158,6 @@ defmodule AeMdw.Database do
     end
 
     :ok = RocksDbCF.delete(txn, table, key)
-  end
-
-  @doc """
-  Creates a transaction and commits the changes of a mutation list.
-
-  Left for backwards compat to deal with invalidations.
-  """
-  @spec commit([Mutation.t()]) :: :ok
-  def commit(mutations) do
-    State.commit(State.new(), mutations)
-
-    :ok
   end
 
   @spec transaction_new() :: transaction()

--- a/lib/ae_mdw/db/hardfork_presets.ex
+++ b/lib/ae_mdw/db/hardfork_presets.ex
@@ -17,7 +17,9 @@ defmodule AeMdw.Db.HardforkPresets do
         :ok
 
       _missing ->
-        do_import_account_presets()
+        _state = do_import_account_presets()
+
+        :ok
     end
   end
 

--- a/lib/ae_mdw/db/rocksdb_cf.ex
+++ b/lib/ae_mdw/db/rocksdb_cf.ex
@@ -22,8 +22,9 @@ defmodule AeMdw.Db.RocksDbCF do
 
   @spec init_tables() :: :ok
   def init_tables() do
-    :ets.new(@block_tab, [:named_table, :public, :ordered_set])
-    :ets.new(@tx_tab, [:named_table, :public, :ordered_set])
+    @block_tab = :ets.new(@block_tab, [:named_table, :public, :ordered_set])
+    @tx_tab = :ets.new(@tx_tab, [:named_table, :public, :ordered_set])
+    :ok
   end
 
   @spec read_block(Blocks.block_index_txi_pos()) :: {:ok, Model.block()} | :not_found

--- a/lib/ae_mdw/ets_cache.ex
+++ b/lib/ae_mdw/ets_cache.ex
@@ -87,5 +87,6 @@ defmodule AeMdw.EtsCache do
   defp init_gc(table, exp) when is_integer(exp) and exp > 0 do
     gc_period = :timer.minutes(exp)
     {:ok, _ref} = :timer.apply_interval(gc_period, __MODULE__, :purge, [table, gc_period])
+    :ok
   end
 end

--- a/lib/ae_mdw/sync/async_tasks/stats.ex
+++ b/lib/ae_mdw/sync/async_tasks/stats.ex
@@ -17,7 +17,7 @@ defmodule AeMdw.Sync.AsyncTasks.Stats do
 
   @spec init() :: :ok
   def init do
-    :ets.new(@tab, [:named_table, :set, :public])
+    @tab = :ets.new(@tab, [:named_table, :set, :public])
     :ets.insert(@tab, {@stats_key, 0, 0, 0})
     :ok
   end

--- a/lib/ae_mdw/sync/async_tasks/store.ex
+++ b/lib/ae_mdw/sync/async_tasks/store.ex
@@ -21,8 +21,8 @@ defmodule AeMdw.Sync.AsyncTasks.Store do
   @spec init() :: :ok
   def init do
     EtsCache.new(@added_tab, @minutes_expire)
-    :ets.new(@pending_tab, [:named_table, :ordered_set, :public])
-    :ets.new(@processing_tab, [:named_table, :set, :public])
+    @pending_tab = :ets.new(@pending_tab, [:named_table, :ordered_set, :public])
+    @processing_tab = :ets.new(@processing_tab, [:named_table, :set, :public])
     :ok
   end
 

--- a/lib/ae_mdw/sync/server.ex
+++ b/lib/ae_mdw/sync/server.ex
@@ -231,7 +231,7 @@ defmodule AeMdw.Sync.Server do
   def handle_event(:info, {:DOWN, _ref, :process, _pid, reason}, _state, state_data) do
     Log.info("Sync.Server error: #{inspect(reason)}. Stopping...")
 
-    :timer.apply_after(@retry_time, __MODULE__, :restart_sync, [])
+    {:ok, _ref} = :timer.apply_after(@retry_time, __MODULE__, :restart_sync, [])
 
     {:next_state, :stopped, state_data}
   end

--- a/lib/ae_mdw_web/controllers/aex9_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex9_controller.ex
@@ -358,9 +358,9 @@ defmodule AeMdwWeb.Aex9Controller do
         if last - first + 1 > @max_range_length do
           {:error,
            ErrInput.RangeTooBig.exception(value: "max range length is #{@max_range_length}")}
+        else
+          {:ok, first..last}
         end
-
-        {:ok, first..last}
 
       {:error, _detail} ->
         {:error, ErrInput.NotAex9.exception(value: range)}

--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -127,7 +127,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
           :ok
 
         :error ->
-          {:error, :block_not_found}
+          :ok
       end
     end
   end
@@ -149,7 +149,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
         :ok
 
       :error ->
-        {:error, :block_not_found}
+        :ok
     end
   end
 

--- a/lib/ae_mdw_web/websocket/supervisor.ex
+++ b/lib/ae_mdw_web/websocket/supervisor.ex
@@ -6,10 +6,10 @@ defmodule AeMdwWeb.Websocket.Supervisor do
 
   @impl true
   def init([]) do
-    :ets.new(:subs_pids, [:public, :ordered_set, :named_table])
-    :ets.new(:subs_main, [:public, :ordered_set, :named_table])
-    :ets.new(:subs_channel_targets, [:public, :ordered_set, :named_table])
-    :ets.new(:subs_target_channels, [:public, :ordered_set, :named_table])
+    :subs_pids = :ets.new(:subs_pids, [:public, :ordered_set, :named_table])
+    :subs_main = :ets.new(:subs_main, [:public, :ordered_set, :named_table])
+    :subs_channel_targets = :ets.new(:subs_channel_targets, [:public, :ordered_set, :named_table])
+    :subs_target_channels = :ets.new(:subs_target_channels, [:public, :ordered_set, :named_table])
 
     children = [
       AeMdwWeb.Websocket.Broadcaster,

--- a/lib/mix/tasks/migrate_db.ex
+++ b/lib/mix/tasks/migrate_db.ex
@@ -27,8 +27,8 @@ defmodule Mix.Tasks.MigrateDb do
     from_startup? = (List.first(args) || "false") |> String.to_existing_atom()
 
     if not from_startup? do
-      :net_kernel.start([:aeternity@localhost, :shortnames])
-      :ae_plugin_utils.start_aecore()
+      {:ok, _pid} = :net_kernel.start([:aeternity@localhost, :shortnames])
+      {:ok, _started_apps} = :ae_plugin_utils.start_aecore()
       :lager.set_loglevel(:epoch_sync_lager_event, :lager_console_backend, :undefined, :error)
       :lager.set_loglevel(:lager_console_backend, :error)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -172,7 +172,11 @@ defmodule AeMdw.MixProject do
       ignore_warnings: ".dialyzer_ignore.exs",
       plt_add_apps: [:mix],
       plt_core_path: "priv/plts",
-      plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
+      plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
+      flags: [
+        :unmatched_returns,
+        :race_conditions
+      ]
     ]
   end
 end

--- a/priv/migrations/20220721121200_add_type_count_table.ex
+++ b/priv/migrations/20220721121200_add_type_count_table.ex
@@ -43,7 +43,7 @@ defmodule AeMdw.Migrations.AddTypeCountTable do
          acc + count}
       end)
 
-    State.commit(state, mutations)
+    _state = State.commit(state, mutations)
 
     duration = DateTime.diff(DateTime.utc_now(), begin)
 

--- a/priv/migrations/20220803120000_add_name_fees_to_stats.ex
+++ b/priv/migrations/20220803120000_add_name_fees_to_stats.ex
@@ -66,7 +66,7 @@ defmodule AeMdw.Migrations.AddNameFeesToStats do
         }
       end)
 
-    State.commit(state, mutations)
+    _state = State.commit(state, mutations)
 
     duration = DateTime.diff(DateTime.utc_now(), begin)
 

--- a/priv/migrations/20220815120000_add_channels_stats.ex
+++ b/priv/migrations/20220815120000_add_channels_stats.ex
@@ -140,13 +140,14 @@ defmodule AeMdw.Migrations.AddChannelsStats do
             locked_in_channels: new_locked
           )
 
-        State.commit(
-          state,
-          [
-            WriteMutation.new(Model.DeltaStat, new_delta_stat),
-            WriteMutation.new(Model.TotalStat, new_total_stat)
-          ]
-        )
+        _state =
+          State.commit(
+            state,
+            [
+              WriteMutation.new(Model.DeltaStat, new_delta_stat),
+              WriteMutation.new(Model.TotalStat, new_total_stat)
+            ]
+          )
 
         if rem(height, @log_freq) == 0, do: IO.puts("Processed #{height} of #{total_gens}")
 

--- a/priv/migrations/20220816120000_add_miners.ex
+++ b/priv/migrations/20220816120000_add_miners.ex
@@ -60,7 +60,7 @@ defmodule AeMdw.Migrations.AddMiners do
         Model.stat(index: Stats.miners_count_key(), payload: length(mutations))
       )
 
-    State.commit(state, [stat_mutation | mutations])
+    _state = State.commit(state, [stat_mutation | mutations])
 
     IO.puts("DONE")
 

--- a/priv/migrations/20220824120000_reprocess_aens_update_calls.ex
+++ b/priv/migrations/20220824120000_reprocess_aens_update_calls.ex
@@ -69,7 +69,7 @@ defmodule AeMdw.Migrations.ReprocessAENSUpdateCalls do
       DeleteKeysMutation.new(%{Model.ActiveNameExpiration => expire_deletion_keys}) | mutations
     ]
 
-    State.commit(state, mutations)
+    _state = State.commit(state, mutations)
 
     duration = DateTime.diff(DateTime.utc_now(), begin)
 

--- a/priv/migrations/20220830144500_aex9_to_aexn_transfers.ex
+++ b/priv/migrations/20220830144500_aex9_to_aexn_transfers.ex
@@ -42,7 +42,7 @@ defmodule AeMdw.Migrations.Aex9toAexnTransfer do
       end)
       |> Enum.to_list()
 
-    State.commit_db(state, write_mutations, false)
+    _state = State.commit(state, write_mutations)
     duration = DateTime.diff(DateTime.utc_now(), begin)
 
     {:ok, {div(length(write_mutations), 3), duration}}

--- a/priv/migrations/20220901120000_add_active_channels.ex
+++ b/priv/migrations/20220901120000_add_active_channels.ex
@@ -158,7 +158,7 @@ defmodule AeMdw.Migrations.AddActiveChannels do
 
     mutations = active_mutations ++ inactive_mutations
 
-    State.commit(state, mutations)
+    _state = State.commit(state, mutations)
 
     {:ok, {div(length(active_mutations), 2) + length(inactive_mutations), duration}}
   end

--- a/priv/migrations/20220908150000_aex141_owners.ex
+++ b/priv/migrations/20220908150000_aex141_owners.ex
@@ -35,7 +35,7 @@ defmodule AeMdw.Migrations.Aex141Owners do
           State.fetch!(state, Model.ContractLog, {create_txi, txi, evt_hash, i})
 
         contract_pk = Origin.pubkey(state, {:contract, create_txi})
-        Contract.write_aex141_ownership(state, contract_pk, args)
+        _state = Contract.write_aex141_ownership(state, contract_pk, args)
         :ok
       end)
       |> Enum.count()
@@ -50,7 +50,7 @@ defmodule AeMdw.Migrations.Aex141Owners do
                          contract_pk: contract_pk
                        ) ->
         args = [from_pk, to_pk, <<token_id::256>>]
-        Contract.write_aex141_ownership(state, contract_pk, args)
+        _state = Contract.write_aex141_ownership(state, contract_pk, args)
         :ok
       end)
       |> Enum.count()

--- a/priv/migrations/20220912195001_aex141_stats.ex
+++ b/priv/migrations/20220912195001_aex141_stats.ex
@@ -39,7 +39,7 @@ defmodule AeMdw.Migrations.Aex141Stats do
       end)
 
     mutations = token_count_mutations ++ owners_count_mutations
-    State.commit_db(State.new(), mutations)
+    _state = State.commit(state, mutations)
     duration = DateTime.diff(DateTime.utc_now(), begin)
 
     {:ok, {length(mutations), duration}}

--- a/test/ae_mdw/db/name_claim_mutation_test.exs
+++ b/test/ae_mdw/db/name_claim_mutation_test.exs
@@ -56,15 +56,15 @@ defmodule AeMdw.Db.NameClaimMutationTest do
       Model.owner(index: {owner_pk, plain_name})
     )
 
+    state = State.new()
+
     with_mocks [
       {AeMdw.Node.Db, [], [proto_vsn: fn _height -> 3 end]}
     ] do
-      tx
-      |> Sync.Name.name_claim_mutations(tx_hash, block_index, txi)
-      |> Database.commit()
-    end
+      mutations = Sync.Name.name_claim_mutations(tx, tx_hash, block_index, txi)
 
-    state = State.new()
+      State.commit(state, mutations)
+    end
 
     assert {:ok,
             Model.name(
@@ -90,8 +90,9 @@ defmodule AeMdw.Db.NameClaimMutationTest do
     block_index = {claim_height, 0}
     timeout = 54
     txi = 1234
+    state = State.new()
 
-    Database.commit([
+    State.commit(state, [
       NameClaimMutation.new(
         plain_name,
         name_hash,
@@ -103,8 +104,6 @@ defmodule AeMdw.Db.NameClaimMutationTest do
         timeout
       )
     ])
-
-    state = State.new()
 
     refute State.exists?(state, Model.ActiveName, plain_name)
     refute State.exists?(state, Model.ActiveNameActivation, {claim_height, plain_name})

--- a/test/ae_mdw/db/sync/transaction_test.exs
+++ b/test/ae_mdw/db/sync/transaction_test.exs
@@ -10,6 +10,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
   alias AeMdw.Db.AexnCreateContractMutation
   alias AeMdw.Db.Sync.Transaction
   alias AeMdw.Db.Model
+  alias AeMdw.Db.State
   alias AeMdw.EtsCache
   alias AeMdw.Validate
 
@@ -30,6 +31,8 @@ defmodule AeMdw.Db.Sync.TransactionTest do
 
   describe "sync_transaction spend_tx" do
     test "when receiver and sender ids are different" do
+      state = State.new()
+
       with_blockchain %{alice: 10_000, bob: 20_000},
         mb1: [
           t1: spend_tx(:alice, :bob, 5_000)
@@ -47,7 +50,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
             false
           )
 
-        Database.commit(txn_mutations)
+        State.commit(state, txn_mutations)
 
         {sender_pk, recipient_pk} = pubkeys_from_tx(signed_tx)
         assert sender_pk != recipient_pk
@@ -61,6 +64,8 @@ defmodule AeMdw.Db.Sync.TransactionTest do
     end
 
     test "when receiver and sender ids are the same" do
+      state = State.new()
+
       with_blockchain %{alice: 10_000},
         mb1: [
           t1: spend_tx(:alice, :alice, 5_000)
@@ -78,7 +83,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
             false
           )
 
-        Database.commit(txn_mutations)
+        State.commit(state, txn_mutations)
 
         {sender_pk, recipient_pk} = pubkeys_from_tx(signed_tx)
         assert sender_pk == recipient_pk

--- a/test/ae_mdw_web/controllers/aex9_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex9_controller_test.exs
@@ -104,6 +104,20 @@ defmodule AeMdwWeb.Aex9ControllerTest do
     end
   end
 
+  describe "balance_range" do
+    test "it validates the range", %{conn: conn} do
+      contract_id = enc_ct(:crypto.strong_rand_bytes(32))
+      account_id = enc_id(:crypto.strong_rand_bytes(32))
+      last_range = 1_000_000
+      error_msg = "invalid range: max range length is 10"
+
+      assert %{"error" => ^error_msg} =
+               conn
+               |> get("/aex9/balance/gen/1-#{last_range}/#{contract_id}/#{account_id}")
+               |> json_response(400)
+    end
+  end
+
   describe "balance" do
     test "returns 400 when contract is unknown", %{conn: conn, store: store} do
       contract_id = enc_ct(:crypto.strong_rand_bytes(32))


### PR DESCRIPTION
Also fixes some minor bug regarding validating aex9 ranges on the aex9 `balance_range` endpoint which was found when enabling these warnings