### PR TITLE
fix: return proper error when aex141 token is a partial int

### DIFF
--- a/lib/ae_mdw_web/controllers/aex141_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex141_controller.ex
@@ -37,15 +37,18 @@ defmodule AeMdwWeb.Aex141Controller do
   @spec nft_owner(Conn.t(), map()) :: Conn.t()
   def nft_owner(conn, %{"contract_id" => contract_id, "token_id" => token_id}) do
     with {:ok, contract_pk} <- Validate.id(contract_id, [:contract_pubkey]),
-         {token_id, ""} <- Integer.parse(token_id),
+         {:int, {token_id, ""}} <- {:int, Integer.parse(token_id)},
          {:ok, account_pk} <- Aex141.fetch_nft_owner(contract_pk, token_id) do
       json(conn, %{data: enc_id(account_pk)})
     else
       :error ->
         {:error, ErrInput.NotFound.exception(value: token_id)}
 
-      error ->
-        error
+      {:int, _invalid_int} ->
+        {:error, ErrInput.NotFound.exception(value: token_id)}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/test/ae_mdw_web/controllers/aex141_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex141_controller_test.exs
@@ -274,6 +274,15 @@ defmodule AeMdwWeb.Aex141ControllerTest do
                  conn |> get("/aex141/#{contract_id}/owner/#{234}") |> json_response(400)
       end
     end
+
+    test "when token is invalid, it returns an error", %{conn: conn} do
+      contract_id = "ct_y7gojSY8rXW6tztE9Ftqe3kmNrqEXsREiPwGCeG3MJL38jkFo"
+      token_id = "123abc"
+      error_msg = "not found: #{token_id}"
+
+      assert %{"error" => ^error_msg} =
+               conn |> get("/aex141/#{contract_id}/owner/#{token_id}") |> json_response(404)
+    end
   end
 
   describe "owned-nfts" do


### PR DESCRIPTION
Since `Integer.parse("123abc")` returns `{123, "abc"}` it was causing owner path to return 500 error.