### PR TITLE
fix: add missing origin to oracle created by internal call

### DIFF
--- a/lib/ae_mdw/db/mutations/oracle_extend_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracle_extend_mutation.ex
@@ -6,18 +6,12 @@ defmodule AeMdw.Db.OracleExtendMutation do
   alias :aeser_api_encoder, as: Enc
   alias AeMdw.Blocks
   alias AeMdw.Db.Model
+  alias AeMdw.Db.Oracle
+  alias AeMdw.Db.Sync.Oracle, as: SyncOracle
   alias AeMdw.Db.State
   alias AeMdw.Log
   alias AeMdw.Node.Db
   alias AeMdw.Txs
-
-  import AeMdw.Db.Oracle, only: [cache_through_read: 3]
-
-  import AeMdw.Db.Sync.Oracle,
-    only: [
-      cache_through_delete: 3,
-      cache_through_write: 3
-    ]
 
   require Model
 
@@ -51,7 +45,7 @@ defmodule AeMdw.Db.OracleExtendMutation do
         },
         state
       ) do
-    case cache_through_read(state, Model.ActiveOracle, oracle_pk) do
+    case Oracle.cache_through_read(state, Model.ActiveOracle, oracle_pk) do
       {:ok, Model.oracle(expire: old_expire, extends: extends) = m_oracle} ->
         new_expire = old_expire + delta_ttl
         extends = [{block_index, txi} | extends]
@@ -59,9 +53,9 @@ defmodule AeMdw.Db.OracleExtendMutation do
         m_oracle = Model.oracle(m_oracle, expire: new_expire, extends: extends)
 
         state
-        |> cache_through_delete(Model.ActiveOracleExpiration, {old_expire, oracle_pk})
-        |> cache_through_write(Model.ActiveOracleExpiration, m_exp)
-        |> cache_through_write(Model.ActiveOracle, m_oracle)
+        |> SyncOracle.cache_through_delete(Model.ActiveOracleExpiration, {old_expire, oracle_pk})
+        |> SyncOracle.cache_through_write(Model.ActiveOracleExpiration, m_exp)
+        |> SyncOracle.cache_through_write(Model.ActiveOracle, m_oracle)
 
       nil ->
         Log.warn("[#{height}] invalid extend for oracle #{Enc.encode(:oracle_pubkey, oracle_pk)}")

--- a/lib/ae_mdw/db/mutations/oracles_expiration_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracles_expiration_mutation.ex
@@ -6,11 +6,22 @@ defmodule AeMdw.Db.OraclesExpirationMutation do
    or `extend` operation.
   """
 
+  alias :aeser_api_encoder, as: Enc
   alias AeMdw.Blocks
   alias AeMdw.Collection
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Oracle
   alias AeMdw.Db.State
+  alias AeMdw.Log
+
+  import AeMdw.Db.Oracle, only: [cache_through_read: 3]
+
+  import AeMdw.Db.Sync.Oracle,
+    only: [
+      cache_through_delete: 3,
+      cache_through_write: 3
+    ]
+
+  require Model
 
   @derive AeMdw.Db.Mutation
   defstruct [:height]
@@ -29,7 +40,34 @@ defmodule AeMdw.Db.OraclesExpirationMutation do
     |> Stream.take_while(&match?({^height, _pk}, &1))
     |> Enum.to_list()
     |> Enum.reduce(state, fn {^height, pubkey}, state ->
-      Oracle.expire_oracle(state, height, pubkey)
+      expire_oracle(state, height, pubkey)
     end)
+  end
+
+  defp expire_oracle(state, height, pubkey) do
+    oracle_id = Enc.encode(:oracle_pubkey, pubkey)
+    state2 = cache_through_delete(state, Model.ActiveOracleExpiration, {height, pubkey})
+
+    case cache_through_read(state2, Model.ActiveOracle, pubkey) do
+      {:ok, m_oracle} ->
+        if height == Model.oracle(m_oracle, :expire) do
+          m_exp = Model.expiration(index: {height, pubkey})
+
+          Log.info("[#{height}] inactivated oracle #{oracle_id}")
+
+          state2
+          |> cache_through_write(Model.InactiveOracle, m_oracle)
+          |> cache_through_write(Model.InactiveOracleExpiration, m_exp)
+          |> cache_through_delete(Model.ActiveOracle, pubkey)
+          |> State.inc_stat(:oracles_expired)
+        else
+          Log.warn("[#{height}] ignored old oracle expiration for #{oracle_id}")
+          state2
+        end
+
+      nil ->
+        Log.warn("[#{height}] ignored oracle expiration for #{oracle_id}")
+        state2
+    end
   end
 end

--- a/lib/ae_mdw/db/mutations/stats_mutation.ex
+++ b/lib/ae_mdw/db/mutations/stats_mutation.ex
@@ -10,9 +10,9 @@ defmodule AeMdw.Db.StatsMutation do
   alias AeMdw.Db.IntTransfer
   alias AeMdw.Db.Model
   alias AeMdw.Db.Name
-  alias AeMdw.Db.Oracle
   alias AeMdw.Db.Origin
   alias AeMdw.Db.State
+  alias AeMdw.Db.Sync.Oracle
   alias AeMdw.Stats
   alias AeMdw.Txs
   alias AeMdw.Util
@@ -133,7 +133,6 @@ defmodule AeMdw.Db.StatsMutation do
     oracles_expired_count =
       state
       |> Oracle.list_expired_at(height)
-      |> Enum.uniq()
       |> Enum.count()
 
     current_block_reward = IntTransfer.read_block_reward(state, height)

--- a/lib/ae_mdw/db/oracle.ex
+++ b/lib/ae_mdw/db/oracle.ex
@@ -2,32 +2,18 @@ defmodule AeMdw.Db.Oracle do
   @moduledoc """
   Cache through operations for active and inactive oracles.
   """
-  alias :aeser_api_encoder, as: Enc
   alias AeMdw.Blocks
-  alias AeMdw.Collection
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Oracle
-  alias AeMdw.Db.OracleResponseMutation
   alias AeMdw.Db.State
-  alias AeMdw.Log
-  alias AeMdw.Node
   alias AeMdw.Node.Db
-  alias AeMdw.Txs
 
-  require Ex2ms
   require Model
-  require Logger
 
   import AeMdw.Util
 
   @typep pubkey :: Db.pubkey()
   @typep cache_key :: pubkey() | {pos_integer(), pubkey()}
   @typep state :: State.t()
-
-  @spec source(atom(), :expiration) ::
-          Model.ActiveOracleExpiration | Model.InactiveOracleExpiration
-  def source(Model.ActiveName, :expiration), do: Model.ActiveOracleExpiration
-  def source(Model.InactiveName, :expiration), do: Model.InactiveOracleExpiration
 
   @spec locate(state(), pubkey()) ::
           {Model.oracle(), Model.ActiveOracle | Model.InactiveOracle} | nil
@@ -37,6 +23,13 @@ defmodule AeMdw.Db.Oracle do
         cache_through_read(state, Model.InactiveOracle, pubkey),
         &{&1, Model.InactiveOracle}
       )
+  end
+
+  @spec oracle_tree!(Blocks.block_hash()) :: tuple()
+  def oracle_tree!(block_hash) do
+    block_hash
+    |> :aec_db.get_block_state()
+    |> :aec_trees.oracles()
   end
 
   @spec cache_through_read(state(), atom(), cache_key()) :: {:ok, Model.oracle()} | nil
@@ -51,106 +44,5 @@ defmodule AeMdw.Db.Oracle do
           :not_found -> nil
         end
     end
-  end
-
-  @spec cache_through_write(state(), atom(), tuple()) :: state()
-  def cache_through_write(state, table, record) do
-    state
-    |> State.cache_put(:oracle_sync_cache, {table, elem(record, 1)}, record)
-    |> State.put(table, record)
-  end
-
-  @spec cache_through_delete(state(), atom(), cache_key()) :: state()
-  def cache_through_delete(state, table, key) do
-    state
-    |> State.cache_delete(:oracle_sync_cache, {table, key})
-    |> State.delete(table, key)
-  end
-
-  @spec cache_through_delete_inactive(state(), nil | Model.oracle()) :: state()
-  def cache_through_delete_inactive(state, nil), do: state
-
-  def cache_through_delete_inactive(state, m_oracle) do
-    pubkey = Model.oracle(m_oracle, :index)
-    expire = Model.oracle(m_oracle, :expire)
-
-    state
-    |> cache_through_delete(Model.InactiveOracle, pubkey)
-    |> cache_through_delete(Model.InactiveOracleExpiration, {expire, pubkey})
-  end
-
-  @spec oracle_tree!(Blocks.block_hash()) :: tuple()
-  def oracle_tree!(block_hash) do
-    block_hash
-    |> :aec_db.get_block_state()
-    |> :aec_trees.oracles()
-  end
-
-  @spec expire_oracle(state(), Blocks.height(), pubkey()) :: state()
-  def expire_oracle(state, height, pubkey) do
-    oracle_id = Enc.encode(:oracle_pubkey, pubkey)
-    state2 = cache_through_delete(state, Model.ActiveOracleExpiration, {height, pubkey})
-
-    case cache_through_read(state2, Model.ActiveOracle, pubkey) do
-      {:ok, m_oracle} ->
-        if height == Model.oracle(m_oracle, :expire) do
-          m_exp = Model.expiration(index: {height, pubkey})
-
-          Log.info("[#{height}] inactivated oracle #{oracle_id}")
-
-          state2
-          |> cache_through_write(Model.InactiveOracle, m_oracle)
-          |> cache_through_write(Model.InactiveOracleExpiration, m_exp)
-          |> cache_through_delete(Model.ActiveOracle, pubkey)
-          |> State.inc_stat(:oracles_expired)
-        else
-          Log.warn("[#{height}] ignored old oracle expiration for #{oracle_id}")
-          state2
-        end
-
-      nil ->
-        Log.warn("[#{height}] ignored oracle expiration for #{oracle_id}")
-        state2
-    end
-  end
-
-  @spec response_mutation(Node.tx(), Blocks.block_index(), Blocks.block_hash(), Txs.txi()) ::
-          OracleResponseMutation.t()
-  def response_mutation(tx, block_index, block_hash, txi) do
-    oracle_pk = :aeo_response_tx.oracle_pubkey(tx)
-    query_id = :aeo_response_tx.query_id(tx)
-    o_tree = Oracle.oracle_tree!(block_hash)
-
-    try do
-      fee =
-        oracle_pk
-        |> :aeo_state_tree.get_query(query_id, o_tree)
-        |> :aeo_query.fee()
-
-      OracleResponseMutation.new(block_index, txi, oracle_pk, fee)
-    rescue
-      # TreeId = <<OracleId/binary, QId/binary>>,
-      # Serialized = aeu_mtrees:get(TreeId, Tree#oracle_tree.otree)
-      # raises error on unexisting tree_id
-      error ->
-        Log.error(error)
-        []
-    end
-  end
-
-  @doc """
-  Returns stream of oracle pubkey() that expired at a certain height.
-  """
-  @spec list_expired_at(State.t(), Blocks.height()) :: Enumerable.t()
-  def list_expired_at(state, height) do
-    state
-    |> Collection.stream(
-      Model.InactiveOracleExpiration,
-      :forward,
-      {{height, <<>>}, {height + 1, <<>>}},
-      nil
-    )
-    |> Stream.map(fn {_height, pubkey} -> pubkey end)
-    |> Stream.uniq()
   end
 end

--- a/lib/ae_mdw/db/oracle.ex
+++ b/lib/ae_mdw/db/oracle.ex
@@ -25,13 +25,6 @@ defmodule AeMdw.Db.Oracle do
       )
   end
 
-  @spec oracle_tree!(Blocks.block_hash()) :: tuple()
-  def oracle_tree!(block_hash) do
-    block_hash
-    |> :aec_db.get_block_state()
-    |> :aec_trees.oracles()
-  end
-
   @spec cache_through_read(state(), atom(), cache_key()) :: {:ok, Model.oracle()} | nil
   def cache_through_read(state, table, key) do
     case State.cache_get(state, table, key) do
@@ -44,5 +37,12 @@ defmodule AeMdw.Db.Oracle do
           :not_found -> nil
         end
     end
+  end
+
+  @spec oracle_tree!(Blocks.block_hash()) :: tuple()
+  def oracle_tree!(block_hash) do
+    block_hash
+    |> :aec_db.get_block_state()
+    |> :aec_trees.oracles()
   end
 end

--- a/lib/ae_mdw/db/sync/oracle.ex
+++ b/lib/ae_mdw/db/sync/oracle.ex
@@ -1,0 +1,110 @@
+defmodule AeMdw.Db.Sync.Oracle do
+  @moduledoc """
+  Synchronize mdw database with oracle chain state.
+  """
+
+  alias AeMdw.Blocks
+  alias AeMdw.Collection
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Mutation
+  alias AeMdw.Db.OracleRegisterMutation
+  alias AeMdw.Db.OracleResponseMutation
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Sync.Origin
+  alias AeMdw.Log
+  alias AeMdw.Node
+  alias AeMdw.Node.Db
+  alias AeMdw.Txs
+
+  require Model
+
+  @typep pubkey :: Db.pubkey()
+  @typep cache_key :: pubkey() | {pos_integer(), pubkey()}
+  @typep state :: State.t()
+
+  @spec register_mutations(Node.tx(), Txs.tx_hash(), Blocks.block_index(), Txs.txi()) :: [
+          Mutation.t()
+        ]
+  def register_mutations(tx, tx_hash, {height, _mbi} = block_index, txi) do
+    oracle_pk = :aeo_register_tx.account_pubkey(tx)
+    delta_ttl = :aeo_utils.ttl_delta(height, :aeo_register_tx.oracle_ttl(tx))
+    expire = height + delta_ttl
+
+    [
+      Origin.origin_mutations(:oracle_register_tx, nil, oracle_pk, txi, tx_hash),
+      OracleRegisterMutation.new(oracle_pk, block_index, expire, txi)
+    ]
+  end
+
+  @spec response_mutation(Node.tx(), Blocks.block_index(), Blocks.block_hash(), Txs.txi()) ::
+          OracleResponseMutation.t() | nil
+  def response_mutation(tx, block_index, block_hash, txi) do
+    oracle_pk = :aeo_response_tx.oracle_pubkey(tx)
+    query_id = :aeo_response_tx.query_id(tx)
+    o_tree = oracle_tree!(block_hash)
+
+    try do
+      fee =
+        oracle_pk
+        |> :aeo_state_tree.get_query(query_id, o_tree)
+        |> :aeo_query.fee()
+
+      OracleResponseMutation.new(block_index, txi, oracle_pk, fee)
+    rescue
+      # TreeId = <<OracleId/binary, QId/binary>>,
+      # Serialized = aeu_mtrees:get(TreeId, Tree#oracle_tree.otree)
+      # raises error on unexisting tree_id
+      error ->
+        Log.error(error)
+        nil
+    end
+  end
+
+  @spec cache_through_write(state(), atom(), tuple()) :: state()
+  def cache_through_write(state, table, record) do
+    state
+    |> State.cache_put(:oracle_sync_cache, {table, elem(record, 1)}, record)
+    |> State.put(table, record)
+  end
+
+  @spec cache_through_delete(state(), atom(), cache_key()) :: state()
+  def cache_through_delete(state, table, key) do
+    state
+    |> State.cache_delete(:oracle_sync_cache, {table, key})
+    |> State.delete(table, key)
+  end
+
+  @spec cache_through_delete_inactive(state(), nil | Model.oracle()) :: state()
+  def cache_through_delete_inactive(state, nil), do: state
+
+  def cache_through_delete_inactive(state, m_oracle) do
+    pubkey = Model.oracle(m_oracle, :index)
+    expire = Model.oracle(m_oracle, :expire)
+
+    state
+    |> cache_through_delete(Model.InactiveOracle, pubkey)
+    |> cache_through_delete(Model.InactiveOracleExpiration, {expire, pubkey})
+  end
+
+  @doc """
+  Returns stream of oracle pubkey() that expired at a certain height.
+  """
+  @spec list_expired_at(State.t(), Blocks.height()) :: Enumerable.t()
+  def list_expired_at(state, height) do
+    state
+    |> Collection.stream(
+      Model.InactiveOracleExpiration,
+      :forward,
+      {{height, <<>>}, {height + 1, <<>>}},
+      nil
+    )
+    |> Stream.map(fn {_height, pubkey} -> pubkey end)
+    |> Stream.uniq()
+  end
+
+  defp oracle_tree!(block_hash) do
+    block_hash
+    |> :aec_db.get_block_state()
+    |> :aec_trees.oracles()
+  end
+end

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -14,12 +14,11 @@ defmodule AeMdw.Db.Sync.Transaction do
   alias AeMdw.Db.Model
   alias AeMdw.Db.NameRevokeMutation
   alias AeMdw.Db.NameTransferMutation
-  alias AeMdw.Db.Oracle
   alias AeMdw.Db.OracleExtendMutation
-  alias AeMdw.Db.OracleRegisterMutation
   alias AeMdw.Db.Sync.Contract, as: SyncContract
   alias AeMdw.Db.Sync.InnerTx
   alias AeMdw.Db.Sync.Name, as: SyncName
+  alias AeMdw.Db.Sync.Oracle
   alias AeMdw.Db.Sync.Origin
   alias AeMdw.Db.WriteFieldsMutation
   alias AeMdw.Db.WriteMutation
@@ -293,16 +292,9 @@ defmodule AeMdw.Db.Sync.Transaction do
          tx: tx,
          txi: txi,
          tx_hash: tx_hash,
-         block_index: {height, _mbi} = block_index
+         block_index: block_index
        }) do
-    oracle_pk = :aeo_register_tx.account_pubkey(tx)
-    delta_ttl = :aeo_utils.ttl_delta(height, :aeo_register_tx.oracle_ttl(tx))
-    expire = height + delta_ttl
-
-    [
-      Origin.origin_mutations(:oracle_register_tx, nil, oracle_pk, txi, tx_hash),
-      OracleRegisterMutation.new(oracle_pk, block_index, expire, txi)
-    ]
+    Oracle.register_mutations(tx, tx_hash, block_index, txi)
   end
 
   defp tx_mutations(%TxContext{

--- a/test/ae_mdw/db/oracle_expire_mutation_test.exs
+++ b/test/ae_mdw/db/oracle_expire_mutation_test.exs
@@ -1,0 +1,102 @@
+defmodule AeMdw.Db.OraclesExpirationMutationTest do
+  use AeMdw.Db.MutationCase
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.OraclesExpirationMutation
+  alias AeMdw.Db.Store
+
+  require Model
+
+  describe "execute" do
+    test "inactivates an oracle that has just expired", %{store: store} do
+      pubkey = <<123_451::256>>
+      sync_height = 10_000
+
+      m_oracle =
+        Model.oracle(
+          index: pubkey,
+          expire: sync_height,
+          register: {{sync_height - 5_000, 0}, 1_234},
+          extends: nil,
+          previous: nil
+        )
+
+      store =
+        store
+        |> Store.put(Model.ActiveOracle, m_oracle)
+        |> Store.put(Model.ActiveOracleExpiration, Model.expiration(index: {sync_height, pubkey}))
+
+      mutation = OraclesExpirationMutation.new(sync_height)
+      store = change_store(store, [mutation])
+
+      assert :not_found = Store.get(store, Model.ActiveOracleExpiration, {sync_height, pubkey})
+
+      assert {:ok, ^m_oracle} = Store.get(store, Model.InactiveOracle, pubkey)
+
+      assert {:ok, Model.expiration(index: {^sync_height, ^pubkey})} =
+               Store.get(store, Model.InactiveOracleExpiration, {sync_height, pubkey})
+    end
+
+    test "does nothing when oracle has not expired yet",
+         %{store: store} do
+      pubkey = <<123_452::256>>
+      sync_height = 10_000
+      expire = sync_height + 1
+
+      m_oracle =
+        Model.oracle(
+          index: pubkey,
+          expire: expire,
+          register: {{expire - 5_000, 0}, 1_234},
+          extends: nil,
+          previous: nil
+        )
+
+      store =
+        store
+        |> Store.put(Model.ActiveOracle, m_oracle)
+        |> Store.put(Model.ActiveOracleExpiration, Model.expiration(index: {expire, pubkey}))
+
+      mutation = OraclesExpirationMutation.new(sync_height)
+      store = change_store(store, [mutation])
+
+      assert :not_found = Store.get(store, Model.InactiveOracle, pubkey)
+      assert :not_found = Store.get(store, Model.InactiveOracleExpiration, {sync_height, pubkey})
+
+      assert {:ok, ^m_oracle} = Store.get(store, Model.ActiveOracle, pubkey)
+
+      assert {:ok, Model.expiration(index: {^expire, ^pubkey})} =
+               Store.get(store, Model.ActiveOracleExpiration, {expire, pubkey})
+    end
+
+    test "does nothing when oracle is already inactive", %{store: store} do
+      pubkey = <<123_453::256>>
+      sync_height = 10_000
+      expire = sync_height - 1
+
+      m_oracle =
+        Model.oracle(
+          index: pubkey,
+          expire: expire,
+          register: {{expire - 5_000, 0}, 1_234},
+          extends: nil,
+          previous: nil
+        )
+
+      store =
+        store
+        |> Store.put(Model.InactiveOracle, m_oracle)
+        |> Store.put(Model.InactiveOracleExpiration, Model.expiration(index: {expire, pubkey}))
+
+      mutation = OraclesExpirationMutation.new(sync_height)
+      store = change_store(store, [mutation])
+
+      assert :not_found = Store.get(store, Model.ActiveOracle, pubkey)
+
+      assert {:ok, ^m_oracle} = Store.get(store, Model.InactiveOracle, pubkey)
+
+      assert {:ok, Model.expiration(index: {^expire, ^pubkey})} =
+               Store.get(store, Model.InactiveOracleExpiration, {expire, pubkey})
+    end
+  end
+end

--- a/test/ae_mdw/db/oracle_extend_mutation_test.exs
+++ b/test/ae_mdw/db/oracle_extend_mutation_test.exs
@@ -1,0 +1,75 @@
+defmodule AeMdw.Db.OracleExtendMutationTest do
+  use AeMdw.Db.MutationCase
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Store
+  alias AeMdw.Db.OracleExtendMutation
+
+  require Model
+
+  describe "execute" do
+    test "succeeds when oracle is active", %{store: store} do
+      height = Enum.random(1_000..500_000)
+      ttl = 5_000
+      pubkey = <<1::256>>
+      old_expire = height - 1
+      new_expire = height + ttl - 1
+
+      mutation =
+        OracleExtendMutation.new(
+          {height, 0},
+          height * 1000,
+          pubkey,
+          ttl
+        )
+
+      store =
+        store
+        |> Store.put(Model.ActiveOracle, Model.oracle(index: pubkey, expire: old_expire))
+        |> Store.put(
+          Model.ActiveOracleExpiration,
+          Model.expiration(index: {old_expire, pubkey})
+        )
+        |> change_store([mutation])
+
+      assert {:ok, Model.oracle(index: ^pubkey, expire: ^new_expire)} =
+               Store.get(store, Model.ActiveOracle, pubkey)
+
+      assert {:ok, Model.expiration(index: {^new_expire, ^pubkey})} =
+               Store.get(store, Model.ActiveOracleExpiration, {new_expire, pubkey})
+
+      assert :not_found = Store.get(store, Model.ActiveOracleExpiration, {old_expire, pubkey})
+    end
+
+    test "do nothing when oracle is inactive", %{store: store} do
+      height = Enum.random(1_000..500_000)
+      ttl = 5_000
+      pubkey = <<2::256>>
+      old_expire = height - 1
+
+      mutation =
+        OracleExtendMutation.new(
+          {height, 0},
+          height * 1000,
+          pubkey,
+          ttl
+        )
+
+      store =
+        store
+        |> Store.put(Model.InactiveOracle, Model.oracle(index: pubkey, expire: old_expire))
+        |> Store.put(
+          Model.InactiveOracleExpiration,
+          Model.expiration(index: {old_expire, pubkey})
+        )
+        |> change_store([mutation])
+
+      assert :not_found = Store.get(store, Model.ActiveOracle, pubkey)
+
+      assert {:ok, Model.oracle(index: ^pubkey)} = Store.get(store, Model.InactiveOracle, pubkey)
+
+      assert {:ok, Model.expiration(index: {^old_expire, ^pubkey})} =
+               Store.get(store, Model.InactiveOracleExpiration, {old_expire, pubkey})
+    end
+  end
+end

--- a/test/ae_mdw/sync/oracle_test.exs
+++ b/test/ae_mdw/sync/oracle_test.exs
@@ -1,205 +1,46 @@
 defmodule AeMdw.Db.Sync.OracleTest do
-  use ExUnit.Case, async: false
+  use AeMdw.Db.MutationCase
 
   alias AeMdw.Db.Model
-  alias AeMdw.Db.OracleExtendMutation
-  alias AeMdw.Db.OraclesExpirationMutation
-  alias AeMdw.Db.State
-  alias AeMdw.Database
+  alias AeMdw.Db.Store
+  alias AeMdw.Db.Sync.Oracle
+  alias AeMdw.Validate
 
   require Model
 
-  @pubkey1 <<123_451::256>>
-  @pubkey2 <<123_452::256>>
-  @pubkey3 <<123_453::256>>
-  @pubkey4 <<123_454::256>>
-  @pubkey5 <<123_455::256>>
+  describe "register_mutations/4" do
+    test "registers an oracle on :oracle_register_tx putting its origin", %{store: store} do
+      pubkey =
+        <<11, 180, 237, 121, 39, 249, 123, 81, 225, 188, 181, 225, 52, 13, 18, 51, 91, 42, 43, 18,
+          200, 188, 82, 33, 214, 60, 75, 203, 57, 212, 30, 97>>
 
-  @sync_height 1000
-  @expire1 999
-  @expire2 1000
-  @expire3 1001
-  @expire4 1001
-  @expire5 1001
+      sync_height = 50_000
+      ttl = 10_000
+      expire = sync_height + ttl
+      txi = sync_height * 1000
 
-  setup_all %{} do
-    last_txi = 1234
+      tx_hash = Validate.id!("th_WQ9yMkEFe45drDzGEnhnYanH5Rov2ewAkjzbwcPzX32krZRyG")
 
-    [
-      Model.oracle(
-        index: @pubkey1,
-        expire: @expire1,
-        register: {{898, 0}, last_txi},
-        extends: nil,
-        previous: nil
-      )
-    ]
-    |> Enum.each(&Database.dirty_write(Model.InactiveOracle, &1))
+      tx =
+        {:oracle_register_tx, {:id, :account, pubkey}, 8904, "{\"bla\": str}", "{\"bla\": str}",
+         ttl, {:delta, ttl}, 2_000_000_000_000_000_000, 0, 0}
 
-    [
-      Model.expiration(index: {@expire1, @pubkey1})
-    ]
-    |> Enum.each(&Database.dirty_write(Model.InactiveOracleExpiration, &1))
+      store = change_store(store, Oracle.register_mutations(tx, tx_hash, {sync_height, 0}, txi))
 
-    [
-      Model.oracle(
-        index: @pubkey3,
-        expire: @expire3,
-        register: {{900, 0}, last_txi + 2},
-        extends: nil,
-        previous: nil
-      ),
-      Model.oracle(
-        index: @pubkey4,
-        expire: @expire4,
-        register: {{900, 0}, last_txi + 3},
-        extends: nil,
-        previous: nil
-      ),
-      Model.oracle(
-        index: @pubkey5,
-        expire: @expire5,
-        register: {{999, 0}, last_txi + 4},
-        extends: nil,
-        previous: nil
-      )
-    ]
-    |> Enum.each(&Database.dirty_write(Model.ActiveOracle, &1))
+      assert {:ok, Model.oracle(index: ^pubkey, expire: ^expire)} =
+               Store.get(store, Model.ActiveOracle, pubkey)
 
-    [
-      Model.expiration(index: {@expire3, @pubkey3}),
-      Model.expiration(index: {@expire4, @pubkey4}),
-      Model.expiration(index: {@sync_height - 1, @pubkey4}),
-      Model.expiration(index: {@expire5, @pubkey5})
-    ]
-    |> Enum.each(&Database.dirty_write(Model.ActiveOracleExpiration, &1))
+      assert {:ok, Model.expiration(index: {^expire, ^pubkey})} =
+               Store.get(store, Model.ActiveOracleExpiration, {expire, pubkey})
 
-    :ok
-  end
+      assert {:ok, Model.origin(index: {:oracle_register_tx, ^pubkey, ^txi}, tx_id: ^tx_hash)} =
+               Store.get(store, Model.Origin, {:oracle_register_tx, pubkey, txi})
 
-  describe "extend" do
-    test "fails when oracle is not active" do
-      mutation =
-        OracleExtendMutation.new(
-          {@sync_height, 0},
-          1234,
-          @pubkey1,
-          123
-        )
+      assert {:ok, Model.rev_origin(index: {^txi, :oracle_register_tx, ^pubkey})} =
+               Store.get(store, Model.RevOrigin, {txi, :oracle_register_tx, pubkey})
 
-      Database.commit([mutation])
-
-      assert :not_found = Database.fetch(Model.ActiveOracle, @pubkey1)
-
-      pubkey = @pubkey1
-      expire = @expire1
-
-      assert Model.oracle(index: ^pubkey, expire: ^expire) =
-               Database.fetch!(Model.InactiveOracle, @pubkey1)
-
-      assert Model.expiration(index: {^expire, ^pubkey}) =
-               Database.fetch!(Model.InactiveOracleExpiration, {expire, pubkey})
-    end
-
-    test "succeeds when oracle is active" do
-      ttl = 123
-      pubkey = @pubkey3
-      new_expiration = @expire3 + ttl
-
-      mutation =
-        OracleExtendMutation.new(
-          {@sync_height, 0},
-          1234,
-          pubkey,
-          ttl
-        )
-
-      Database.commit([mutation])
-
-      assert Model.oracle(index: ^pubkey, expire: ^new_expiration) =
-               Database.fetch!(Model.ActiveOracle, pubkey)
-
-      assert Model.expiration(index: {^new_expiration, ^pubkey}) =
-               Database.fetch!(Model.ActiveOracleExpiration, {new_expiration, pubkey})
-
-      assert :not_found = Database.fetch(Model.ActiveOracleExpiration, {@expire3, pubkey})
-    end
-  end
-
-  describe "expire/1" do
-    test "inactivates an oracle that has just expired" do
-      assert @expire2 == @sync_height
-      m_exp = Model.expiration(index: {@expire2, @pubkey2})
-      Database.dirty_write(Model.ActiveOracleExpiration, m_exp)
-
-      m_oracle =
-        Model.oracle(
-          index: @pubkey2,
-          expire: @expire2,
-          register: {{899, 0}, 1234},
-          extends: nil,
-          previous: nil
-        )
-
-      Database.dirty_write(Model.ActiveOracle, m_oracle)
-
-      pubkey = @pubkey2
-      sync_height = @sync_height
-      mutation = OraclesExpirationMutation.new(sync_height)
-      Database.commit([mutation])
-
-      assert :not_found = Database.fetch(Model.ActiveOracleExpiration, {sync_height, pubkey})
-
-      assert Model.expiration(index: {^sync_height, ^pubkey}) =
-               Database.fetch!(Model.InactiveOracleExpiration, {sync_height, pubkey})
-    end
-
-    test "does nothing when oracle has multiple expirations and last one is greater than height" do
-      pubkey = @pubkey4
-      state = State.new()
-      m_oracle = State.fetch!(state, Model.ActiveOracle, pubkey)
-
-      mutation = OraclesExpirationMutation.new(@sync_height)
-      Database.commit([mutation])
-
-      assert Model.expiration(index: {@expire4, pubkey}) ==
-               Database.fetch!(Model.ActiveOracleExpiration, {@expire4, pubkey})
-
-      assert m_oracle == State.fetch!(state, Model.ActiveOracle, pubkey)
-    end
-
-    test "does nothing when oracle has not yet expired" do
-      pubkey = @pubkey5
-      state = State.new()
-
-      assert Model.oracle(expire: expire) =
-               m_oracle = State.fetch!(state, Model.ActiveOracle, pubkey)
-
-      assert expire == @expire5
-      assert expire > @sync_height
-
-      mutation = OraclesExpirationMutation.new(@sync_height)
-      Database.commit([mutation])
-
-      assert Model.expiration(index: {@expire5, pubkey}) ==
-               State.fetch!(state, Model.ActiveOracleExpiration, {@expire5, pubkey})
-
-      assert m_oracle == State.fetch!(state, Model.ActiveOracle, pubkey)
-    end
-
-    test "does nothing when oracle is already inactive" do
-      pubkey = @pubkey1
-      state = State.new()
-      assert :not_found = Database.fetch(Model.ActiveOracle, @pubkey1)
-      assert m_oracle = State.fetch!(state, Model.InactiveOracle, pubkey)
-
-      mutation = OraclesExpirationMutation.new(@sync_height)
-      Database.commit([mutation])
-
-      assert Model.expiration(index: {@expire1, pubkey}) ==
-               State.fetch!(state, Model.InactiveOracleExpiration, {@expire1, pubkey})
-
-      assert m_oracle == State.fetch!(state, Model.InactiveOracle, pubkey)
+      assert :not_found = Store.get(store, Model.InactiveOracle, pubkey)
+      assert :not_found = Store.get(store, Model.InactiveOracleExpiration, {expire, pubkey})
     end
   end
 end

--- a/test/integration/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/block_controller_test.exs
@@ -7,7 +7,7 @@ defmodule Integration.AeMdwWeb.BlockControllerTest do
   alias AeMdw.Db.State
   alias AeMdw.Db.Util, as: DbUtil
   alias AeMdw.Node.Db
-  alias AeMdwWeb.TestUtil
+  alias AeMdw.TestUtil
   alias AeMdw.Error.Input, as: ErrInput
 
   require Model

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -10,7 +10,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
   alias AeMdw.Db.Util
   alias AeMdw.Error.Input, as: ErrInput
   alias AeMdw.Validate
-  alias AeMdwWeb.TestUtil
+  alias AeMdw.TestUtil
 
   require Model
 

--- a/test/support/ae_mdw/db/mutation_case.ex
+++ b/test/support/ae_mdw/db/mutation_case.ex
@@ -1,0 +1,24 @@
+defmodule AeMdw.Db.MutationCase do
+  @moduledoc """
+  Test case setup providing an empty memory store.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      import AeMdw.TestUtil
+    end
+  end
+
+  setup tags do
+    alias AeMdw.Db.MemStore
+    alias AeMdw.Db.NullStore
+
+    if Map.get(tags, :integration, false) or Map.get(tags, :skip_store, false) do
+      :ok
+    else
+      {:ok, store: MemStore.new(NullStore.new())}
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -24,7 +24,7 @@ defmodule AeMdwWeb.ConnCase do
       # Import conveniences for testing with connections
       import Plug.Conn
       import Phoenix.ConnTest
-      import AeMdwWeb.TestUtil
+      import AeMdw.TestUtil
       alias AeMdwWeb.Router.Helpers, as: Routes
 
       # The default endpoint for testing

--- a/test/support/test_util.ex
+++ b/test/support/test_util.ex
@@ -1,6 +1,6 @@
-defmodule AeMdwWeb.TestUtil do
+defmodule AeMdw.TestUtil do
   @moduledoc """
-  Test helper funcitons imported by default on all tests.
+  Test helper functions imported by default on all tests.
   """
 
   alias AeMdw.Error.Input, as: ErrInput
@@ -26,7 +26,9 @@ defmodule AeMdwWeb.TestUtil do
   @spec change_store(Store.t(), [Mutation.t()]) :: Store.t()
   def change_store(store, mutations) do
     %{store: store2} =
-      Enum.reduce(mutations, State.new(store), fn mutation, state ->
+      mutations
+      |> List.flatten()
+      |> Enum.reduce(State.new(store), fn mutation, state ->
         Mutation.execute(mutation, state)
       end)
 


### PR DESCRIPTION
## What/Why

- Add `Oracle.register_mutations` to register an oracle after internal call the same way after a `:oracle_register_tx`
- Refactors Oracle to separate methods that are used only for specific syncing purposes
- Add unit tests

## Notes

- Existing oracle response handling (and test case) would need an extra review to analyse if the query exception should be raised/propagated
- This origin was saved from the beginning for oracles with `:oracle_register_tx` and can be used for listing created oracles at a certain height
- Oracle endpoint serialization fails on 1.20 (before `:jason` upgrade)