### PR TITLE
revert: undo change unused by activities

### DIFF
--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -295,15 +295,21 @@ defmodule AeMdw.Txs do
     initial_tx_types =
       initial_fields |> Enum.map(fn {tx_type, _pos} -> tx_type end) |> MapSet.new()
 
-    ids_fields_rest
-    |> Enum.map(fn {_id, fields} ->
-      fields
-      |> Enum.map(fn {tx_type, _pos} -> tx_type end)
-      |> MapSet.new()
-    end)
-    |> Enum.reduce(initial_tx_types, &MapSet.intersection/2)
-    |> MapSet.intersection(MapSet.new(types))
-    |> Enum.flat_map(fn tx_type ->
+    intersection_of_tx_types =
+      Enum.reduce(ids_fields_rest, initial_tx_types, fn {_id, fields}, acc ->
+        fields
+        |> Enum.map(fn {tx_type, _pos} -> tx_type end)
+        |> MapSet.new()
+        |> MapSet.intersection(acc)
+      end)
+
+    intersection_of_tx_types =
+      case types do
+        [] -> intersection_of_tx_types
+        _types -> MapSet.intersection(intersection_of_tx_types, MapSet.new(types))
+      end
+
+    Enum.flat_map(intersection_of_tx_types, fn tx_type ->
       {min_account_id, min_fields} =
         Enum.min_by(ids_fields, fn {id, fields} ->
           count_txs_for_account(state, id, fields, tx_type)


### PR DESCRIPTION
## What/Why

Reverts a refactor on `/txs` that introduces a bug when filtering transactions by fields like `sender_id` or `oracle`.

It can be reverted because it was added by 5ab2cb2d but is not used by `/activities` endpoint.