### PR TITLE
fix: sort event logs by index

### DIFF
--- a/lib/ae_mdw/contracts.ex
+++ b/lib/ae_mdw/contracts.ex
@@ -3,7 +3,6 @@ defmodule AeMdw.Contracts do
   Context module for dealing with Contracts.
   """
 
-  alias :aeser_api_encoder, as: Enc
   alias AeMdw.Collection
   alias AeMdw.Contract
   alias AeMdw.Db.Format
@@ -17,7 +16,7 @@ defmodule AeMdw.Contracts do
   alias AeMdw.Util
   alias AeMdw.Validate
 
-  import AeMdwWeb.Helpers.ViewHelper
+  import AeMdw.Util.Encoding
 
   require Model
 
@@ -482,13 +481,13 @@ defmodule AeMdw.Contracts do
       ext_caller_contract_id: encode_ct(ext_ct_pk),
       parent_contract_id: encode_ct(parent_contract_pk),
       call_txi: call_txi,
-      call_tx_hash: Enc.encode(:tx_hash, call_tx_hash),
+      call_tx_hash: encode(:tx_hash, call_tx_hash),
       args: Enum.map(Model.contract_log(m_log, :args), fn <<topic::256>> -> to_string(topic) end),
       data: Model.contract_log(m_log, :data),
       event_hash: Base.hex_encode32(event_hash),
       height: height,
       micro_index: micro_index,
-      block_hash: Enc.encode(:micro_block_hash, block_hash),
+      block_hash: encode(:micro_block_hash, block_hash),
       log_idx: log_idx
     }
   end

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -430,9 +430,9 @@ defmodule AeMdw.Db.Model do
   defrecord :evt_contract_log, @evt_contract_log_defaults
 
   # idx contract log:
-  #     index: {call txi, create txi, event hash, log idx}
+  #     index: {call txi, log idx, create_txi, event hash}
   @idx_contract_log_defaults [
-    index: {-1, -1, nil, -1},
+    index: {-1, -1, -1, <<>>},
     unused: nil
   ]
   defrecord :idx_contract_log, @idx_contract_log_defaults

--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -25,7 +25,7 @@ defmodule AeMdw.Txs do
 
   @type tx :: map()
   @type txi :: non_neg_integer()
-  @type tx_hash() :: binary()
+  @type tx_hash() :: <<_::256>>
   @type cursor :: binary()
   @type query ::
           %{

--- a/lib/ae_mdw/util/encoding.ex
+++ b/lib/ae_mdw/util/encoding.ex
@@ -1,6 +1,6 @@
-defmodule AeMdwWeb.Helpers.ViewHelper do
+defmodule AeMdw.Util.Encoding do
   @moduledoc """
-  Formats accounts, contracts, hashes to json responses.
+  Encodes and decodes accounts, contracts, hashes and other ids.
   """
 
   alias AeMdw.Db.State

--- a/lib/ae_mdw_web/helpers/view_helper.ex
+++ b/lib/ae_mdw_web/helpers/view_helper.ex
@@ -1,0 +1,25 @@
+defmodule AeMdwWeb.Helpers.ViewHelper do
+  @moduledoc """
+  Formats accounts, contracts, hashes to json responses.
+  """
+
+  alias AeMdw.Db.State
+  alias AeMdw.Txs
+
+  @typep pubkey :: AeMdw.Node.Db.pubkey()
+
+  @spec encode_ct(pubkey() | nil) :: String.t()
+  def encode_ct(nil), do: nil
+  def encode_ct(pk), do: :aeser_api_encoder.encode(:contract_pubkey, pk)
+
+  @spec encode_to_hash(State.t(), AeMdw.Blocks.txi_pos()) :: String.t()
+  def encode_to_hash(state, txi) when txi > 0 do
+    tx_hash = Txs.txi_to_hash(state, txi)
+    :aeser_api_encoder.encode(:tx_hash, tx_hash)
+  end
+
+  def encode_to_hash(_state, _txi), do: nil
+
+  @spec encode(atom(), pubkey()) :: String.t()
+  defdelegate encode(type, pk), to: :aeser_api_encoder
+end

--- a/priv/migrations/20221010130100_logs_by_index.ex
+++ b/priv/migrations/20221010130100_logs_by_index.ex
@@ -1,0 +1,37 @@
+defmodule AeMdw.Migrations.LogsByIndex do
+  @moduledoc """
+  Reindexes event logs by call txi and log index.
+  """
+
+  alias AeMdw.Collection
+  alias AeMdw.Database
+  alias AeMdw.Db.DeleteKeysMutation
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Db.WriteMutation
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    write_mutations =
+      state
+      |> Collection.stream(Model.IdxContractLog, nil)
+      |> Stream.map(&State.fetch!(state, Model.IdxContractLog, &1))
+      |> Enum.map(fn Model.idx_contract_log(index: {call_txi, create_txi, evt_hash, log_idx}) ->
+        WriteMutation.new(
+          Model.IdxContractLog,
+          Model.idx_contract_log(index: {call_txi, log_idx, create_txi, evt_hash})
+        )
+      end)
+
+    delete_mutation =
+      DeleteKeysMutation.new(%{Model.IdxContractLog => Database.all_keys(Model.IdxContractLog)})
+
+    mutations = [delete_mutation | write_mutations]
+
+    _state = State.commit(state, mutations)
+
+    {:ok, length(mutations)}
+  end
+end

--- a/test/ae_mdw/contracts_test.exs
+++ b/test/ae_mdw/contracts_test.exs
@@ -1,0 +1,85 @@
+defmodule AeMdw.ContractsTest do
+  use ExUnit.Case
+
+  alias AeMdw.Contracts
+  alias AeMdw.Db.Contract
+  alias AeMdw.Db.MemStore
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.NullStore
+  alias AeMdw.Db.State
+
+  import AeMdw.Node.ContractCallFixtures, only: [call_rec: 5]
+  import AeMdwWeb.Helpers.ViewHelper
+
+  require Model
+
+  describe "fetch_logs/5" do
+    test "lists logs sorted by call txi and log index" do
+      {height, mbi} = block_index = {100_000, 11}
+      contract_pk = :crypto.strong_rand_bytes(32)
+      <<evt_hash_bigger_int::256>> = evt_hash0 = AeMdw.Node.aexn_transfer_event_hash()
+      evt_hash1 = <<evt_hash_bigger_int - 1::256>>
+      extra_logs = [{contract_pk, [evt_hash1, <<3::256>>, <<4::256>>, <<1::256>>], <<>>}]
+      call_rec = call_rec("aex141_transfer", contract_pk, height, contract_pk, extra_logs)
+
+      call_txi = height * 1_000
+      create_txi = call_txi - 2
+      block_hash = <<100_011::256>>
+
+      state =
+        NullStore.new()
+        |> MemStore.new()
+        |> State.new()
+        |> State.put(
+          Model.Tx,
+          Model.tx(index: create_txi, id: <<create_txi::256>>, block_index: block_index)
+        )
+        |> State.put(
+          Model.Tx,
+          Model.tx(index: call_txi, id: <<call_txi::256>>, block_index: block_index)
+        )
+        |> State.put(Model.Block, Model.block(index: block_index, hash: block_hash))
+        |> State.put(
+          Model.RevOrigin,
+          Model.rev_origin(index: {create_txi, :contract_create_tx, contract_pk})
+        )
+        |> State.cache_put(:ct_create_sync_cache, contract_pk, create_txi)
+        |> Contract.logs_write(block_index, create_txi, call_txi, call_rec)
+
+      assert {:ok, _prev, [log1, log2], _next} =
+               Contracts.fetch_logs(state, {:forward, false, 100, false}, nil, %{}, nil)
+
+      contract_id = encode_ct(contract_pk)
+      contract_tx_hash = encode_to_hash(state, create_txi)
+      call_tx_hash = encode_to_hash(state, call_txi)
+      mb_hash = encode(:micro_block_hash, block_hash)
+
+      event_hash0 = Base.hex_encode32(evt_hash0)
+      event_hash1 = Base.hex_encode32(evt_hash1)
+
+      assert %{
+               contract_id: ^contract_id,
+               contract_tx_hash: ^contract_tx_hash,
+               call_txi: ^call_txi,
+               call_tx_hash: ^call_tx_hash,
+               event_hash: ^event_hash0,
+               height: ^height,
+               micro_index: ^mbi,
+               block_hash: ^mb_hash,
+               log_idx: 0
+             } = log1
+
+      assert %{
+               contract_id: ^contract_id,
+               contract_tx_hash: ^contract_tx_hash,
+               call_txi: ^call_txi,
+               call_tx_hash: ^call_tx_hash,
+               event_hash: ^event_hash1,
+               height: ^height,
+               micro_index: ^mbi,
+               block_hash: ^mb_hash,
+               log_idx: 1
+             } = log2
+    end
+  end
+end

--- a/test/ae_mdw/contracts_test.exs
+++ b/test/ae_mdw/contracts_test.exs
@@ -9,7 +9,7 @@ defmodule AeMdw.ContractsTest do
   alias AeMdw.Db.State
 
   import AeMdw.Node.ContractCallFixtures, only: [call_rec: 5]
-  import AeMdwWeb.Helpers.ViewHelper
+  import AeMdw.Util.Encoding
 
   require Model
 

--- a/test/ae_mdw/db/contract_create_mutation_test.exs
+++ b/test/ae_mdw/db/contract_create_mutation_test.exs
@@ -35,7 +35,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
           ]
         }
       ] do
-        block_index = {492_393, 0}
+        {height, _mbi} = block_index = {492_393, 0}
         create_txi1 = 21_608_343
         call_rec1 = call_rec("no_log", remote_pk, create_txi1)
 
@@ -65,7 +65,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
 
         create_txi2 = create_txi1 + 1
         contract_pk = :crypto.strong_rand_bytes(32)
-        call_rec2 = call_rec("remote_log", contract_pk, remote_pk, create_txi2)
+        call_rec2 = call_rec("remote_log", contract_pk, height, remote_pk)
 
         state2 =
           State.commit_mem(state1, [

--- a/test/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/ae_mdw_web/controllers/contract_controller_test.exs
@@ -806,7 +806,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
 
         m_data_log = Model.data_contract_log(index: {data, txi, create_txi, evt_hash, idx})
         m_evt_log = Model.evt_contract_log(index: {evt_hash, txi, create_txi, idx})
-        m_idx_log = Model.idx_contract_log(index: {txi, create_txi, evt_hash, idx})
+        m_idx_log = Model.idx_contract_log(index: {txi, idx, create_txi, evt_hash})
 
         store
         |> Store.put(
@@ -847,7 +847,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
 
         m_data_log = Model.data_contract_log(index: {data, txi, create_txi, evt_hash, idx})
         m_evt_log = Model.evt_contract_log(index: {evt_hash, txi, create_txi, idx})
-        m_idx_log = Model.idx_contract_log(index: {txi, create_txi, evt_hash, idx})
+        m_idx_log = Model.idx_contract_log(index: {txi, idx, create_txi, evt_hash})
 
         store
         |> Store.put(

--- a/test/support/ae_mdw/node/contract_call_fixtures.ex
+++ b/test/support/ae_mdw/node/contract_call_fixtures.ex
@@ -5,6 +5,7 @@ defmodule AeMdw.Node.ContractCallFixtures do
   @type fname :: String.t()
   @type fun_arg_res :: map()
   @type call_record :: tuple()
+  @type event_log :: {pubkey(), [binary()], binary()}
 
   @spec fun_args_res(fname()) :: %{arguments: list(), function: fname(), result: map()}
   def fun_args_res("mint") do
@@ -343,22 +344,35 @@ defmodule AeMdw.Node.ContractCallFixtures do
      ]}
   end
 
-  @spec call_rec(fname(), pubkey(), AeMdw.Txs.txi()) :: call_record()
-  def call_rec("no_log", contract_pk, txi) do
+  @spec call_rec(fname(), pubkey(), AeMdw.Blocks.height()) :: call_record()
+  def call_rec("no_log", contract_pk, height) do
     {:call,
      <<7, 3, 220, 129, 25, 69, 185, 205, 148, 53, 54, 115, 161, 72, 225, 149, 238, 18, 80, 50,
        185, 167, 125, 140, 71, 128, 149, 100, 229, 81, 223, 196>>, {:id, :account, <<1::256>>},
-     41, txi, {:id, :contract, contract_pk}, 1_000_000_000, 22_929,
+     41, height, {:id, :contract, contract_pk}, 1_000_000_000, 22_929,
      <<159, 2, 160, 111, 0, 117, 208, 6, 235, 44, 43, 240, 108, 173, 15, 111, 153, 4, 169, 116,
        46, 60, 160, 41, 181, 143, 70, 46, 129, 67, 189, 118, 173, 96, 204>>, :ok, []}
   end
 
-  @spec call_rec(fname(), pubkey(), pubkey(), AeMdw.Txs.txi()) :: call_record()
-  def call_rec("remote_log", contract_pk, remote_pk, txi) do
+  @spec call_rec(fname(), pubkey(), AeMdw.Blocks.height(), pubkey(), [event_log()]) ::
+          call_record()
+  def call_rec(fname, contract_pk, height, event_pk, extra_logs \\ [])
+
+  def call_rec("aex141_transfer", contract_pk, height, event_pk, extra_logs) do
+    {:call, :aect_call.id(<<1::256>>, 2, contract_pk), {:id, :account, <<1::256>>}, 2, height,
+     {:id, :contract, contract_pk}, 1_000_000_000, 22_929, "", :ok,
+     [
+       {event_pk, [AeMdw.Node.aexn_transfer_event_hash(), <<1::256>>, <<2::256>>, <<1::256>>],
+        <<>>}
+     ] ++
+       extra_logs}
+  end
+
+  def call_rec("remote_log", contract_pk, height, remote_pk, extra_logs) do
     {:call,
      <<7, 3, 220, 129, 25, 69, 185, 205, 148, 53, 54, 115, 161, 72, 225, 149, 238, 18, 80, 50,
        185, 167, 125, 140, 71, 128, 149, 100, 229, 81, 223, 196>>, {:id, :account, <<1::256>>},
-     41, txi, {:id, :contract, contract_pk}, 1_000_000_000, 22_929,
+     41, height, {:id, :contract, contract_pk}, 1_000_000_000, 22_929,
      <<159, 2, 160, 111, 0, 117, 208, 6, 235, 44, 43, 240, 108, 173, 15, 111, 153, 4, 169, 116,
        46, 60, 160, 41, 181, 143, 70, 46, 129, 67, 189, 118, 173, 96, 204>>, :ok,
      [
@@ -369,6 +383,7 @@ defmodule AeMdw.Node.ContractCallFixtures do
           <<83, 107, 86, 97, 199, 199, 69, 232, 131, 106, 241, 190, 181, 55, 62, 215, 254, 27,
             189, 54, 54, 3, 152, 10, 245, 52, 84, 143, 225, 73, 60, 7>>
         ], "1"}
-     ]}
+     ] ++
+       extra_logs}
   end
 end


### PR DESCRIPTION
## What

Displays the event logs by the order they happened (sorting by index on the `Model.idx_contract_log`).

## Why

Solves #943 
