### PR TITLE
fix: order gen-scoped txs and activities properly

### DIFF
--- a/lib/ae_mdw/activities.ex
+++ b/lib/ae_mdw/activities.ex
@@ -90,8 +90,8 @@ defmodule AeMdw.Activities do
               {:gen, first_gen..last_gen} ->
                 {
                   {first_gen, last_gen},
-                  {DbUtil.first_gen_to_txi(state, first_gen, direction),
-                   DbUtil.last_gen_to_txi(state, last_gen, direction)}
+                  {DbUtil.first_gen_to_txi(state, first_gen),
+                   DbUtil.last_gen_to_txi(state, last_gen)}
                 }
 
               nil ->
@@ -210,7 +210,7 @@ defmodule AeMdw.Activities do
       |> Collection.stream(Model.TargetKindIntTransferTx, direction, key_boundary, cursor)
       |> Stream.filter(&match?({^account_pk, ^kind, {_height, -1}, _ref_txi}, &1))
       |> Stream.map(fn {^account_pk, ^kind, {height, -1}, ref_txi} ->
-        {height, {:int_transfer, account_pk, kind, ref_txi}}
+        {height, {:int_transfer, kind, ref_txi}}
       end)
     end)
     |> Collection.merge(direction)

--- a/lib/ae_mdw/db/util.ex
+++ b/lib/ae_mdw/db/util.ex
@@ -16,7 +16,6 @@ defmodule AeMdw.Db.Util do
 
   @typep state() :: State.t()
   @typep height() :: Blocks.height()
-  @typep direction() :: Collection.direction()
 
   @spec read_tx!(state(), Txs.txi()) :: Model.tx()
   def read_tx!(state, txi), do: State.fetch!(state, Model.Tx, txi)
@@ -84,13 +83,11 @@ defmodule AeMdw.Db.Util do
     end
   end
 
-  @spec first_gen_to_txi(state(), height(), direction()) :: height()
-  def first_gen_to_txi(state, first_gen, :forward), do: gen_to_txi(state, first_gen)
-  def first_gen_to_txi(state, first_gen, :backward), do: gen_to_txi(state, first_gen + 1) - 1
+  @spec first_gen_to_txi(state(), height()) :: height()
+  def first_gen_to_txi(state, first_gen), do: gen_to_txi(state, first_gen)
 
-  @spec last_gen_to_txi(state(), height(), direction()) :: height()
-  def last_gen_to_txi(state, last_gen, :forward), do: gen_to_txi(state, last_gen + 1) - 1
-  def last_gen_to_txi(state, last_gen, :backward), do: gen_to_txi(state, last_gen)
+  @spec last_gen_to_txi(state(), height()) :: height()
+  def last_gen_to_txi(state, last_gen), do: gen_to_txi(state, last_gen + 1) - 1
 
   @spec txi_to_gen(state(), Txs.txi()) :: Blocks.height()
   def txi_to_gen(state, txi) do

--- a/test/integration/ae_mdw_web/controllers/activity_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/activity_controller_test.exs
@@ -84,6 +84,7 @@ defmodule Integration.AeMdwWeb.ActivityControllerTest do
                conn
                |> get("/v2/accounts/#{account}/activities",
                  limit: 1,
+                 direction: "forward",
                  scope: "gen:#{height}-#{height}"
                )
                |> json_response(200)

--- a/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
@@ -1641,7 +1641,9 @@ defmodule Integration.AeMdwWeb.TxControllerTest do
       height = 273_000
 
       assert %{"data" => txs, "next" => next} =
-               conn |> get("/v2/txs", scope: "gen:#{height}-#{height}") |> json_response(200)
+               conn
+               |> get("/v2/txs", scope: "gen:#{height}-#{height}", direction: "forward")
+               |> json_response(200)
 
       txis = Enum.map(txs, fn %{"tx_index" => tx_index} -> tx_index end)
 


### PR DESCRIPTION
Fixes https://github.com/aeternity/ae_mdw/blob/master/test/integration/ae_mdw_web/controllers/tx_controller_test.exs and https://github.com/aeternity/ae_mdw/blob/master/test/integration/ae_mdw_web/controllers/activity_controller_test.exs