### PR TITLE
fix: render bid for names in auction

### DIFF
--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -90,10 +90,10 @@ defmodule AeMdw.Db.Name do
   def source(Model.InactiveName, :name), do: Model.InactiveName
   def source(Model.InactiveName, :expiration), do: Model.InactiveNameExpiration
 
-  @spec locate_bid(state(), Names.plain_name()) :: {:ok, Model.auction_bid()} | nil
+  @spec locate_bid(state(), Names.plain_name()) :: Model.auction_bid() | nil
   def locate_bid(state, plain_name) do
     case State.get(state, Model.AuctionBid, plain_name) do
-      {:ok, auction_bid} -> {:ok, auction_bid}
+      {:ok, auction_bid} -> auction_bid
       :not_found -> nil
     end
   end
@@ -110,7 +110,7 @@ defmodule AeMdw.Db.Name do
     else
       {:active, {:ok, active_name}} -> {active_name, Model.ActiveName}
       {:inactive, {:ok, inactive_name}} -> {inactive_name, Model.InactiveName}
-      {:auction_bid, {:ok, auction}} -> {auction, Model.AuctionBid}
+      {:auction_bid, auction} -> {auction, Model.AuctionBid}
     end
   end
 

--- a/lib/ae_mdw/node.ex
+++ b/lib/ae_mdw/node.ex
@@ -155,7 +155,7 @@ defmodule AeMdw.Node do
     MapSet.new()
   end
 
-  @spec tx_fields(atom()) :: [atom()]
+  @spec tx_fields(tx_type()) :: [atom()]
   def tx_fields(_arg) do
     []
   end

--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -219,8 +219,8 @@ defmodule AeMdwWeb.NameController do
 
       locator = fn plain_name ->
         case Name.locate_bid(state, plain_name) do
-          {:ok, auction_bid} -> {auction_bid, Model.AuctionBid}
           nil -> :not_found
+          auction_bid -> {auction_bid, Model.AuctionBid}
         end
       end
 

--- a/test/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/ae_mdw_web/controllers/contract_controller_test.exs
@@ -769,7 +769,6 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
 
   defp enc_ct(pk), do: :aeser_api_encoder.encode(:contract_pubkey, pk)
   defp enc_id(pk), do: :aeser_api_encoder.encode(:account_pubkey, pk)
-  defp encode(type, pk), do: :aeser_api_encoder.encode(type, pk)
 
   defp logs_setup(store, contract_pk) do
     block_index1 = {100, 1}

--- a/test/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/ae_mdw_web/controllers/tx_controller_test.exs
@@ -311,6 +311,4 @@ defmodule AeMdwWeb.TxControllerTest do
       end
     end
   end
-
-  defp encode(type, bin), do: :aeser_api_encoder.encode(type, bin)
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -27,6 +27,8 @@ defmodule AeMdwWeb.ConnCase do
       import AeMdw.TestUtil
       alias AeMdwWeb.Router.Helpers, as: Routes
 
+      import AeMdw.Util.Encoding
+
       # The default endpoint for testing
       @endpoint AeMdwWeb.Endpoint
     end


### PR DESCRIPTION
## What/Why

Fix for https://mainnet.aeternity.io/mdw/v2/names/:name when name is in auction. 

## Notes

Adds `:name_claim_tx` to `BlockchainSim`