### PR TITLE
fix: handle any meta info value

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -51,7 +51,7 @@ defmodule AeMdw.Db.Contract do
     name = elem(aexn_meta_info, 0)
     symbol = elem(aexn_meta_info, 1)
 
-    if name == :out_of_gas_error do
+    if name in [:format_error, :out_of_gas_error] do
       state2
     else
       m_contract_name =

--- a/test/ae_mdw/aexn_contracts_test.exs
+++ b/test/ae_mdw/aexn_contracts_test.exs
@@ -34,7 +34,7 @@ defmodule AeMdw.AexnContractsTest do
         {AeMdw.DryRun.Runner, [:passthrough],
          [
            call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
-             variant_url = {:variant, [0, 1], 1, "https://some-base-url.com"}
+             variant_url = {:variant, [0, 1], 1, base_url}
              variant_type = {:variant, [0, 0, 0, 0], 0, {}}
              meta_info_tuple = {"name", "SYMBOL", variant_url, variant_type}
              {:ok, {:tuple, meta_info_tuple}}
@@ -48,20 +48,19 @@ defmodule AeMdw.AexnContractsTest do
 
     test "succeeds with nft standard meta info" do
       contract_pk = :crypto.strong_rand_bytes(32)
-      base_url = "https://some-base-url.com"
 
       with_mocks [
         {AeMdw.DryRun.Runner, [:passthrough],
          [
            call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
-             variant_url = {:variant, [0, 1], 1, "https://some-base-url.com"}
-             variant_type = {:variant, [0, 0, 0, 0], 0, {}}
+             variant_url = {:variant, [0, 1], 0, ""}
+             variant_type = {:variant, [0, 0, 0], 2, {}}
              meta_info_tuple = {"name", "SYMBOL", variant_url, variant_type}
              {:ok, {:tuple, meta_info_tuple}}
            end
          ]}
       ] do
-        assert {:ok, {"name", "SYMBOL", ^base_url, :url}} =
+        assert {:ok, {"name", "SYMBOL", nil, :map}} =
                  AexnContracts.call_meta_info(:aex141, contract_pk)
       end
     end

--- a/test/ae_mdw/aexn_contracts_test.exs
+++ b/test/ae_mdw/aexn_contracts_test.exs
@@ -9,6 +9,115 @@ defmodule AeMdw.AexnContractsTest do
   @wrong_mint {[], {[:address, :string, {:variant, [tuple: [], tuple: [:string]]}], :integer},
                %{}}
 
+  describe "call_meta_info/2" do
+    test "succeeds with aex9 meta_info" do
+      contract_pk = :crypto.strong_rand_bytes(32)
+
+      with_mocks [
+        {AeMdw.DryRun.Runner, [:passthrough],
+         [
+           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+             meta_info_tuple = {"name", "SYMBOL", 18}
+             {:ok, {:tuple, meta_info_tuple}}
+           end
+         ]}
+      ] do
+        assert {:ok, {"name", "SYMBOL", 18}} = AexnContracts.call_meta_info(:aex9, contract_pk)
+      end
+    end
+
+    test "succeeds with meta info from previous nft draft (hackaton)" do
+      contract_pk = :crypto.strong_rand_bytes(32)
+      base_url = "https://some-base-url.com"
+
+      with_mocks [
+        {AeMdw.DryRun.Runner, [:passthrough],
+         [
+           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+             variant_url = {:variant, [0, 1], 1, "https://some-base-url.com"}
+             variant_type = {:variant, [0, 0, 0, 0], 0, {}}
+             meta_info_tuple = {"name", "SYMBOL", variant_url, variant_type}
+             {:ok, {:tuple, meta_info_tuple}}
+           end
+         ]}
+      ] do
+        assert {:ok, {"name", "SYMBOL", ^base_url, :url}} =
+                 AexnContracts.call_meta_info(:aex141, contract_pk)
+      end
+    end
+
+    test "succeeds with nft standard meta info" do
+      contract_pk = :crypto.strong_rand_bytes(32)
+      base_url = "https://some-base-url.com"
+
+      with_mocks [
+        {AeMdw.DryRun.Runner, [:passthrough],
+         [
+           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+             variant_url = {:variant, [0, 1], 1, "https://some-base-url.com"}
+             variant_type = {:variant, [0, 0, 0, 0], 0, {}}
+             meta_info_tuple = {"name", "SYMBOL", variant_url, variant_type}
+             {:ok, {:tuple, meta_info_tuple}}
+           end
+         ]}
+      ] do
+        assert {:ok, {"name", "SYMBOL", ^base_url, :url}} =
+                 AexnContracts.call_meta_info(:aex141, contract_pk)
+      end
+    end
+
+    test "returns :unknown metadata type when does not comply to nft standard" do
+      contract_pk = :crypto.strong_rand_bytes(32)
+
+      with_mocks [
+        {AeMdw.DryRun.Runner, [:passthrough],
+         [
+           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+             variant_url = {:variant, [0, 1], 0, ""}
+             variant_type = {:variant, [0, 0], 0, {}}
+             meta_info_tuple = {"name", "SYMBOL", variant_url, variant_type}
+             {:ok, {:tuple, meta_info_tuple}}
+           end
+         ]}
+      ] do
+        assert {:ok, {"name", "SYMBOL", nil, :unknown}} =
+                 AexnContracts.call_meta_info(:aex141, contract_pk)
+      end
+    end
+
+    test "returns format error values when tuple format is unexpected" do
+      contract_pk = :crypto.strong_rand_bytes(32)
+
+      with_mocks [
+        {AeMdw.DryRun.Runner, [:passthrough],
+         [
+           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+             {:ok, {:tuple, {"name", "symbol"}}}
+           end
+         ]}
+      ] do
+        assert {:ok, {:format_error, :format_error, nil}} =
+                 AexnContracts.call_meta_info(:aex9, contract_pk)
+      end
+    end
+
+    test "returns out of gas error when call_contract fails" do
+      contract_pk = :crypto.strong_rand_bytes(32)
+
+      with_mocks [
+        {AeMdw.DryRun.Runner, [:passthrough],
+         [
+           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+             {:error, :dry_run_error}
+           end
+         ]}
+      ] do
+        assert {:ok, {:out_of_gas_error, :out_of_gas_error, :out_of_gas_error, nil}} =
+                 AexnContracts.call_meta_info(:aex141, contract_pk)
+      end
+    end
+  end
+
   describe "is_aex141?/1" do
     test "returns true for a mintable" do
       contract_pk = :crypto.strong_rand_bytes(32)

--- a/test/ae_mdw/db/aexn_create_contract_mutation_test.exs
+++ b/test/ae_mdw/db/aexn_create_contract_mutation_test.exs
@@ -184,7 +184,7 @@ defmodule AeMdw.Db.AexnCreateContractMutationTest do
 
     test "indexes aex141 with error meta_info without sorting records" do
       contract_pk = Validate.id!("ct_ukZe6BBpuSWxT8hxd87z11vdgRnwKnedEWqJ7SyQucbX1C1pc")
-      aex141_meta_info = {:out_of_gas_error, :out_of_gas_error, :out_of_gas_error, nil}
+      aex141_meta_info = {:format_error, :format_error, :format_error, nil}
       state = State.new()
 
       extensions = ["ext1", "ext2"]
@@ -215,13 +215,13 @@ defmodule AeMdw.Db.AexnCreateContractMutationTest do
       refute State.exists?(
                state,
                Model.AexnContractName,
-               {:aex141, :out_of_gas_error, contract_pk}
+               {:aex141, :format_error, contract_pk}
              )
 
       refute State.exists?(
                state,
                Model.AexnContractSymbol,
-               {:aex141, :out_of_gas_error, contract_pk}
+               {:aex141, :format_error, contract_pk}
              )
     end
   end

--- a/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
@@ -84,7 +84,7 @@ defmodule Integration.AeMdwWeb.Aex9ControllerTest do
         assert is_binary(name)
         assert is_binary(symbol)
 
-        if name == "out_of_gas_error" do
+        if name in ["format_error", "out_of_gas_error"] do
           assert is_nil(decimals)
         else
           assert is_integer(decimals) and decimals >= 0


### PR DESCRIPTION
Adds defensive handling of meta info returned by a contract during AEX-N validation and indexation.