### PR TITLE
feat: render call details for ga_attach and ga_meta

### DIFF
--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -445,7 +445,7 @@ defmodule AeMdw.Contract do
 
   defp contract_init_args(contract_pk, tx_rec, mod \\ :aect_create_tx) do
     with {:ok, {type_info, _compiler_vsn, _source_hash}} <- get_info(contract_pk),
-         call_data <- apply(mod, :call_data, [tx_rec]),
+         call_data <- mod.call_data(tx_rec),
          {"init", args} <- decode_call_data(type_info, call_data) do
       args_type_value(args)
     else

--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -49,7 +49,8 @@ defmodule AeMdw.Contract do
           return: any()
         }
   @type fun_arg_res_or_error :: fun_arg_res() | {:error, any()}
-  @type local_idx() :: non_neg_integer()
+  @type local_idx :: non_neg_integer()
+  @typep pubkey :: DBN.pubkey()
   @typep tx :: Node.tx()
   @typep signed_tx :: Node.signed_tx()
   @typep block_hash :: <<_::256>>
@@ -298,6 +299,18 @@ defmodule AeMdw.Contract do
     |> Map.put("source_hash", source_hash && Base.encode64(source_hash))
   end
 
+  @spec get_ga_attach_call_details(signed_tx(), pubkey(), block_hash()) :: serialized_call()
+  def get_ga_attach_call_details(signed_tx, contract_pk, block_hash) do
+    call_rec = call_rec(signed_tx, contract_pk, block_hash)
+    {mod, tx_rec} = signed_tx |> :aetx_sign.tx() |> :aetx.specialize_callback()
+
+    %{
+      "args" => contract_init_args(contract_pk, tx_rec, mod),
+      "gas_used" => :aect_call.gas_used(call_rec),
+      "return_type" => :aect_call.return_type(call_rec)
+    }
+  end
+
   @spec stringfy_log_topics([map()]) :: [map()]
   def stringfy_log_topics(logs) do
     Enum.map(logs, fn log ->
@@ -430,9 +443,9 @@ defmodule AeMdw.Contract do
     end
   end
 
-  defp contract_init_args(contract_pk, tx_rec) do
+  defp contract_init_args(contract_pk, tx_rec, mod \\ :aect_create_tx) do
     with {:ok, {type_info, _compiler_vsn, _source_hash}} <- get_info(contract_pk),
-         call_data <- :aect_create_tx.call_data(tx_rec),
+         call_data <- apply(mod, :call_data, [tx_rec]),
          {"init", args} <- decode_call_data(type_info, call_data) do
       args_type_value(args)
     else

--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -285,11 +285,11 @@ defmodule AeMdw.Db.Format do
 
   defp custom_encode(_state, :ga_attach_tx, tx, tx_rec, signed_tx, _txi, block_hash) do
     contract_pk = :aega_attach_tx.contract_pubkey(tx_rec)
-    call_rec = Contract.call_rec(signed_tx, contract_pk, block_hash)
+    call_details = Contract.get_ga_attach_call_details(signed_tx, contract_pk, block_hash)
 
     tx
     |> Map.put("contract_id", Enc.encode(:contract_pubkey, contract_pk))
-    |> Map.put("return_type", :aect_call.return_type(call_rec))
+    |> Map.merge(call_details)
   end
 
   defp custom_encode(_state, :ga_meta_tx, tx, tx_rec, _signed_tx, _txi, block_hash) do

--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -298,10 +298,14 @@ defmodule AeMdw.Db.Format do
 
     case :aec_chain.get_ga_call(owner_pk, auth_id, block_hash) do
       {:ok, ga_object} ->
-        Map.put(tx, "return_type", :aega_call.return_type(ga_object))
+        tx
+        |> Map.put("return_type", :aega_call.return_type(ga_object))
+        |> Map.put("gas_used", :aega_call.gas_used(ga_object))
 
       _error_revert ->
-        Map.put(tx, "return_type", :unknown)
+        tx
+        |> Map.put("return_type", :unknown)
+        |> Map.put("gas_used", nil)
     end
   end
 

--- a/test/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/ae_mdw_web/controllers/tx_controller_test.exs
@@ -153,7 +153,8 @@ defmodule AeMdwWeb.TxControllerTest do
                  "hash" => ^tx_hash,
                  "tx" => %{
                    "ga_id" => ^account_id,
-                   "return_type" => "some_return_type",
+                   "gas_used" => 2_000,
+                   "return_type" => "ok",
                    "tx" => %{
                      "tx" => %{
                        "sender_id" => ^account_id,

--- a/test/support/blockchain_sim.ex
+++ b/test/support/blockchain_sim.ex
@@ -54,11 +54,12 @@ defmodule AeMdwWeb.BlockchainSim do
             if ga_tx_hash do
               [
                 {:aec_chain, [:passthrough],
-                 get_ga_call: fn ^ga_pk, _auth_id, _block_hash -> {:ok, ga_tx_hash} end,
-                 get_contract_call: fn _pk, _call_id, ^block_hash ->
+                 get_ga_call: fn ^ga_pk, _auth_id, _block_hash ->
+                   {:ok, :aega_call.new({:id, :account, ga_pk}, ga_pk, 1, 10_000, 2_000, :ok, "")}
+                 end,
+                 get_contract_call: fn _ga_pk, _call_id, ^block_hash ->
                    {:ok, call_rec("attach", ga_pk)}
-                 end},
-                {:aega_call, [:passthrough], return_type: fn ^ga_tx_hash -> :some_return_type end}
+                 end}
               ]
             else
               []


### PR DESCRIPTION
As requested by @marc0olo this adds more details to the `ga_attach_tx` call: `gas_used` and decoded `args` 

Added `gas_used` for `ga_meta_tx`