### PR TITLE
test: complement coverage for oracle syncing

### DIFF
--- a/test/ae_mdw/db/oracle_register_mutation_test.exs
+++ b/test/ae_mdw/db/oracle_register_mutation_test.exs
@@ -1,0 +1,151 @@
+defmodule AeMdw.Db.OracleRegisterMutationTest do
+  use AeMdw.Db.MutationCase
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Store
+  alias AeMdw.Db.OracleRegisterMutation
+
+  require Model
+
+  describe "execute" do
+    test "replaces an active oracle", %{store: store} do
+      height = Enum.random(1_000..500_000)
+      block_index = {height, 1}
+      txi = 1_000_000
+
+      ttl = 5_000
+      pubkey = <<1::256>>
+      new_expire = height + ttl - 1
+
+      mutation =
+        OracleRegisterMutation.new(
+          pubkey,
+          block_index,
+          new_expire,
+          txi
+        )
+
+      old_height = height - 100
+      old_expire = height - 1
+
+      m_previous =
+        Model.oracle(
+          index: pubkey,
+          active: old_height,
+          expire: old_expire,
+          register: {{old_height, 0}, txi - 1_000}
+        )
+
+      store =
+        store
+        |> Store.put(Model.ActiveOracle, m_previous)
+        |> Store.put(
+          Model.ActiveOracleExpiration,
+          Model.expiration(index: {old_expire, pubkey})
+        )
+        |> change_store([mutation])
+
+      assert {:ok,
+              Model.oracle(
+                index: ^pubkey,
+                active: ^height,
+                expire: ^new_expire,
+                register: {^block_index, ^txi},
+                previous: ^m_previous
+              )} = Store.get(store, Model.ActiveOracle, pubkey)
+
+      assert {:ok, Model.expiration(index: {^new_expire, ^pubkey})} =
+               Store.get(store, Model.ActiveOracleExpiration, {new_expire, pubkey})
+
+      assert :not_found = Store.get(store, Model.ActiveOracleExpiration, {old_expire, pubkey})
+    end
+
+    test "reactivates an inactive oracle", %{store: store} do
+      height = Enum.random(1_000..500_000)
+      block_index = {height, 2}
+      txi = 1_000_000
+
+      ttl = 5_000
+      pubkey = <<2::256>>
+      new_expire = height + ttl - 1
+
+      mutation =
+        OracleRegisterMutation.new(
+          pubkey,
+          block_index,
+          new_expire,
+          txi
+        )
+
+      old_height = height - 100
+      old_expire = height - 1
+
+      m_previous =
+        Model.oracle(
+          index: pubkey,
+          active: old_height,
+          expire: old_expire,
+          register: {{old_height, 0}, txi - 1_000}
+        )
+
+      store =
+        store
+        |> Store.put(Model.InactiveOracle, m_previous)
+        |> Store.put(
+          Model.InactiveOracleExpiration,
+          Model.expiration(index: {old_expire, pubkey})
+        )
+        |> change_store([mutation])
+
+      assert :not_found = Store.get(store, Model.InactiveOracle, pubkey)
+      assert :not_found = Store.get(store, Model.InactiveOracleExpiration, {old_expire, pubkey})
+
+      assert {:ok,
+              Model.oracle(
+                index: ^pubkey,
+                active: ^height,
+                expire: ^new_expire,
+                register: {^block_index, ^txi},
+                previous: ^m_previous
+              )} = Store.get(store, Model.ActiveOracle, pubkey)
+
+      assert {:ok, Model.expiration(index: {^new_expire, ^pubkey})} =
+               Store.get(store, Model.ActiveOracleExpiration, {new_expire, pubkey})
+    end
+
+    test "registers a new oracle", %{store: store} do
+      height = Enum.random(1_000..500_000)
+      block_index = {height, 2}
+      txi = 1_000_000
+
+      ttl = 5_000
+      pubkey = <<3::256>>
+      new_expire = height + ttl - 1
+
+      mutation =
+        OracleRegisterMutation.new(
+          pubkey,
+          block_index,
+          new_expire,
+          txi
+        )
+
+      assert :not_found = Store.get(store, Model.InactiveOracle, pubkey)
+      assert :not_found = Store.get(store, Model.Oracle, pubkey)
+
+      store = change_store(store, [mutation])
+
+      assert {:ok,
+              Model.oracle(
+                index: ^pubkey,
+                active: ^height,
+                expire: ^new_expire,
+                register: {^block_index, ^txi},
+                previous: nil
+              )} = Store.get(store, Model.ActiveOracle, pubkey)
+
+      assert {:ok, Model.expiration(index: {^new_expire, ^pubkey})} =
+               Store.get(store, Model.ActiveOracleExpiration, {new_expire, pubkey})
+    end
+  end
+end

--- a/test/ae_mdw/db/oracle_response_mutation_test.exs
+++ b/test/ae_mdw/db/oracle_response_mutation_test.exs
@@ -1,0 +1,42 @@
+defmodule AeMdw.Db.OracleResponseMutationTest do
+  use AeMdw.Db.MutationCase
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Store
+  alias AeMdw.Db.OracleResponseMutation
+
+  require Model
+
+  describe "execute" do
+    test "writes reward fee for an oracle", %{store: store} do
+      height = Enum.random(1_000..500_000)
+      block_index = {height, 1}
+      txi = 1_000_000
+      pubkey = <<1::256>>
+      fee = Enum.random(100..999)
+
+      mutation =
+        OracleResponseMutation.new(
+          block_index,
+          txi,
+          pubkey,
+          fee
+        )
+
+      store = change_store(store, [mutation])
+
+      int_key = {{height, txi}, "reward_oracle", pubkey, txi}
+      kind_key = {"reward_oracle", {height, txi}, pubkey, txi}
+      target_key = {pubkey, "reward_oracle", {height, txi}, txi}
+
+      assert {:ok, Model.int_transfer_tx(index: ^int_key, amount: ^fee)} =
+               Store.get(store, Model.IntTransferTx, int_key)
+
+      assert {:ok, Model.kind_int_transfer_tx(index: ^kind_key)} =
+               Store.get(store, Model.KindIntTransferTx, kind_key)
+
+      assert {:ok, Model.target_kind_int_transfer_tx(index: ^target_key)} =
+               Store.get(store, Model.TargetKindIntTransferTx, target_key)
+    end
+  end
+end

--- a/test/ae_mdw/sync/oracle_test.exs
+++ b/test/ae_mdw/sync/oracle_test.exs
@@ -1,43 +1,100 @@
 defmodule AeMdw.Db.Sync.OracleTest do
-  use AeMdw.Db.MutationCase
+  use ExUnit.Case
 
   alias AeMdw.Db.Model
-  alias AeMdw.Db.Store
+  alias AeMdw.Db.Sync.Origin
   alias AeMdw.Db.Sync.Oracle
-  alias AeMdw.Validate
+  alias AeMdw.Db.OracleExtendMutation
+  alias AeMdw.Db.OracleRegisterMutation
+  alias AeMdw.Db.OracleResponseMutation
+
+  import Mock
 
   require Model
 
   describe "register_mutations/4" do
-    test "registers an oracle on :oracle_register_tx putting its origin", %{store: store} do
-      pubkey =
-        <<11, 180, 237, 121, 39, 249, 123, 81, 225, 188, 181, 225, 52, 13, 18, 51, 91, 42, 43, 18,
-          200, 188, 82, 33, 214, 60, 75, 203, 57, 212, 30, 97>>
-
-      sync_height = 50_000
+    test "creates mutations including origin for the oracle" do
+      pubkey = <<1::256>>
+      block_index = {height, _mbi} = {Enum.random(100_000..999_999), 1}
       ttl = 10_000
-      expire = sync_height + ttl
-      txi = sync_height * 1000
+      expire = height + ttl
+      txi = height * 1000
+      tx_hash = <<123_456::256>>
 
-      tx_hash = Validate.id!("th_WQ9yMkEFe45drDzGEnhnYanH5Rov2ewAkjzbwcPzX32krZRyG")
+      {:ok, aetx} =
+        :aeo_register_tx.new(%{
+          account_id: :aeser_id.create(:account, pubkey),
+          nonce: 1,
+          query_format: "{\"foo\": 0}",
+          abi_version: 0,
+          response_format: "{\"bar\": 1}",
+          query_fee: 2_000_000,
+          oracle_ttl: {:delta, ttl},
+          fee: 2_000
+        })
 
-      tx =
-        {:oracle_register_tx, {:id, :account, pubkey}, 8904, "{\"bla\": str}", "{\"bla\": str}",
-         ttl, {:delta, ttl}, 2_000_000_000_000_000_000, 0, 0}
+      {_mod, tx_rec} = :aetx.specialize_callback(aetx)
 
-      store = change_store(store, Oracle.register_mutations(tx, tx_hash, {sync_height, 0}, txi))
+      mutations = [
+        Origin.origin_mutations(:oracle_register_tx, nil, pubkey, txi, tx_hash),
+        OracleRegisterMutation.new(pubkey, block_index, expire, txi)
+      ]
 
-      assert {:ok, Model.oracle(index: ^pubkey, expire: ^expire)} =
-               Store.get(store, Model.ActiveOracle, pubkey)
+      assert ^mutations = Oracle.register_mutations(tx_rec, tx_hash, block_index, txi)
+    end
+  end
 
-      assert {:ok, Model.expiration(index: {^expire, ^pubkey})} =
-               Store.get(store, Model.ActiveOracleExpiration, {expire, pubkey})
+  describe "response_mutation/4" do
+    test "creates mutation for the oracle" do
+      pubkey = <<2::256>>
+      block_index = {Enum.random(100_000..999_999), 1}
+      block_hash = <<22::256>>
+      txi = Enum.random(100_000_000..999_999_999)
+      fee = Enum.random(100..999)
 
-      assert {:ok, Model.rev_origin(index: {^txi, :oracle_register_tx, ^pubkey})} =
-               Store.get(store, Model.RevOrigin, {txi, :oracle_register_tx, pubkey})
+      {:ok, aetx} =
+        :aeo_response_tx.new(%{
+          oracle_id: :aeser_id.create(:oracle, pubkey),
+          nonce: 1,
+          query_id: <<0::256>>,
+          response: "",
+          response_ttl: {:delta, 0},
+          fee: fee
+        })
 
-      assert :not_found = Store.get(store, Model.InactiveOracle, pubkey)
-      assert :not_found = Store.get(store, Model.InactiveOracleExpiration, {expire, pubkey})
+      {_mod, tx_rec} = :aetx.specialize_callback(aetx)
+
+      with_mocks [
+        {:aec_db, [:passthrough], get_block_state: fn ^block_hash -> block_hash end},
+        {:aec_trees, [:passthrough], oracles: fn ^block_hash -> :otree end},
+        {:aeo_state_tree, [:passthrough], get_query: fn ^pubkey, _query_id, :otree -> pubkey end},
+        {:aeo_query, [:passthrough], fee: fn ^pubkey -> fee end}
+      ] do
+        mutation = OracleResponseMutation.new(block_index, txi, pubkey, fee)
+        assert ^mutation = Oracle.response_mutation(tx_rec, block_index, block_hash, txi)
+      end
+    end
+  end
+
+  describe "extend_mutation/4" do
+    test "creates mutation with ttl for the oracle" do
+      pubkey = <<3::256>>
+      block_index = {Enum.random(100_000..999_999), 1}
+      txi = Enum.random(100_000_000..999_999_999)
+      ttl = 10_000
+
+      {:ok, aetx} =
+        :aeo_extend_tx.new(%{
+          oracle_id: :aeser_id.create(:oracle, pubkey),
+          nonce: 1,
+          oracle_ttl: {:delta, ttl},
+          fee: 2_000
+        })
+
+      {_mod, tx_rec} = :aetx.specialize_callback(aetx)
+
+      mutation = OracleExtendMutation.new(block_index, txi, pubkey, ttl)
+      assert ^mutation = Oracle.extend_mutation(tx_rec, block_index, txi)
     end
   end
 end


### PR DESCRIPTION
## What

Complement test coverage for oracles syncing to validate multiple oracle register scenarios and have a case for each mutation (like for name ones). 

## Why 

Part of increasing test coverage in order to prevent regressions. Following to be done for aex9, aex141 and names (factory method) as well. 