### PR TITLE
fix: events from the node are obtained in reverse order

### DIFF
--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -407,7 +407,7 @@ defmodule AeMdw.Contract do
       {:ok, _, _, events} =
         :aec_block_micro_candidate.apply_block_txs_strict(txs_taken, trees_in, env)
 
-      events
+      Enum.reverse(events)
     else
       []
     end

--- a/priv/migrations/20221027120000_reverse_internal_tx_calls.ex
+++ b/priv/migrations/20221027120000_reverse_internal_tx_calls.ex
@@ -1,0 +1,150 @@
+defmodule AeMdw.Migrations.ReverseInternalTxCalls do
+  @moduledoc """
+  Fixes the fact that internal calls are in reverse order.
+  """
+
+  alias AeMdw.Collection
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Db.DeleteKeysMutation
+  alias AeMdw.Db.WriteMutation
+  alias AeMdw.Node
+  alias AeMdw.Validate
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    case State.prev(state, Model.Tx, nil) do
+      {:ok, total_txis} -> run_with_txis(state, total_txis)
+      :none -> {:ok, 0}
+    end
+  end
+
+  defp run_with_txis(state, total_txis) do
+    txis_per_100 = div(total_txis, 100)
+
+    deletion_keys = %{
+      Model.IdIntContractCall => [],
+      Model.GrpIdIntContractCall => [],
+      Model.IdFnameIntContractCall => [],
+      Model.GrpIdFnameIntContractCall => []
+    }
+
+    {mutations, {_next_percentage, deletion_keys}} =
+      state
+      |> Collection.stream(Model.IntContractCall, nil)
+      |> Stream.chunk_by(fn {call_txi, _local_idx} -> call_txi end)
+      |> Enum.flat_map_reduce({txis_per_100, deletion_keys}, fn [{call_txi, _local_idx} | _rest] =
+                                                                  call_int_calls,
+                                                                {next_percentage, deletion_keys} ->
+        last_idx = length(call_int_calls) - 1
+
+        next_percentage =
+          if call_txi > next_percentage do
+            IO.puts("Processed #{call_txi - 1} of #{total_txis}")
+            next_percentage + txis_per_100
+          else
+            next_percentage
+          end
+
+        {mutations, deletion_keys} =
+          Enum.map_reduce(call_int_calls, deletion_keys, fn {^call_txi, local_idx} = key,
+                                                            deletion_keys ->
+            new_idx = last_idx - local_idx
+
+            Model.int_contract_call(
+              create_txi: create_txi,
+              fname: fname,
+              tx: tx
+            ) = call = State.fetch!(state, Model.IntContractCall, key)
+
+            new_call = Model.int_contract_call(call, index: {call_txi, new_idx})
+            new_grp_call = Model.grp_int_contract_call(index: {create_txi, call_txi, new_idx})
+            new_fname_call = Model.fname_int_contract_call(index: {fname, call_txi, new_idx})
+
+            new_fname_grp_call =
+              Model.fname_grp_int_contract_call(index: {fname, create_txi, call_txi, new_idx})
+
+            {tx_type, raw_tx} = :aetx.specialize_type(tx)
+
+            {id_mutations, deletion_keys} =
+              id_mutations_deletions(call, new_idx, tx_type, raw_tx, deletion_keys)
+
+            {[
+               WriteMutation.new(Model.IntContractCall, new_call),
+               WriteMutation.new(Model.GrpIntContractCall, new_grp_call),
+               WriteMutation.new(Model.FnameIntContractCall, new_fname_call),
+               WriteMutation.new(Model.FnameGrpIntContractCall, new_fname_grp_call)
+               | id_mutations
+             ], deletion_keys}
+          end)
+
+        {mutations, {next_percentage, deletion_keys}}
+      end)
+
+    mutations = [DeleteKeysMutation.new(deletion_keys) | List.flatten(mutations)]
+
+    _state = State.commit(state, mutations)
+
+    IO.puts("DONE")
+
+    {:ok, length(mutations)}
+  end
+
+  defp id_mutations_deletions(
+         Model.int_contract_call(
+           index: {call_txi, local_idx},
+           create_txi: create_txi,
+           fname: fname
+         ),
+         new_idx,
+         tx_type,
+         raw_tx,
+         deletion_keys
+       ) do
+    tx_type
+    |> Node.tx_ids()
+    |> Enum.map_reduce(deletion_keys, fn {_field, pos}, deletion_keys ->
+      pk = Validate.id!(elem(raw_tx, pos))
+      m_id_call = Model.id_int_contract_call(index: {pk, pos, call_txi, new_idx})
+
+      m_grp_id_call =
+        Model.grp_id_int_contract_call(index: {create_txi, pk, pos, call_txi, new_idx})
+
+      m_id_fname_call =
+        Model.id_fname_int_contract_call(index: {pk, fname, pos, call_txi, new_idx})
+
+      m_grp_id_fname_call =
+        Model.grp_id_fname_int_contract_call(
+          index: {create_txi, pk, fname, pos, call_txi, new_idx}
+        )
+
+      deletion_keys =
+        deletion_keys
+        |> Map.update!(Model.IdIntContractCall, &[{pk, pos, call_txi, local_idx} | &1])
+        |> Map.update!(
+          Model.GrpIdIntContractCall,
+          &[{create_txi, pk, pos, call_txi, local_idx} | &1]
+        )
+        |> Map.update!(
+          Model.IdFnameIntContractCall,
+          &[{pk, fname, pos, call_txi, local_idx} | &1]
+        )
+        |> Map.update!(
+          Model.GrpIdFnameIntContractCall,
+          &[{create_txi, pk, fname, pos, call_txi, local_idx} | &1]
+        )
+
+      {
+        [
+          WriteMutation.new(Model.IdIntContractCall, m_id_call),
+          WriteMutation.new(Model.GrpIdIntContractCall, m_grp_id_call),
+          WriteMutation.new(Model.IdFnameIntContractCall, m_id_fname_call),
+          WriteMutation.new(Model.GrpIdFnameIntContractCall, m_grp_id_fname_call)
+        ],
+        deletion_keys
+      }
+    end)
+  end
+end

--- a/test/ae_mdw/db/sync/contract_test.exs
+++ b/test/ae_mdw/db/sync/contract_test.exs
@@ -70,10 +70,10 @@ defmodule AeMdw.Db.Sync.ContractTest do
       tx_2 = {:tx2, contract_pk}
 
       events = [
-        {{:internal_call_tx, "Chain.create"}, %{info: :error}},
         {{:internal_call_tx, "Call.amount"}, %{info: tx_1}},
-        {{:internal_call_tx, "Chain.clone"}, %{info: :error}},
-        {{:internal_call_tx, "Call.amount"}, %{info: tx_2}}
+        {{:internal_call_tx, "Chain.create"}, %{info: :error}},
+        {{:internal_call_tx, "Call.amount"}, %{info: tx_2}},
+        {{:internal_call_tx, "Chain.clone"}, %{info: :error}}
       ]
 
       int_calls = [
@@ -99,14 +99,6 @@ defmodule AeMdw.Db.Sync.ContractTest do
       aex9_contract_pk = Validate.id!("ct_2n7xLuQPWWw8Yj8yXPyrhZz3nucu2Cpjg7FxnoTmuVTgGAsUbJ")
 
       tx_events = [
-        {{:internal_call_tx, "Chain.clone"},
-         %{
-           info: :error,
-           tx_hash:
-             <<50, 175, 183, 105, 50, 158, 138, 149, 125, 12, 47, 89, 117, 207, 2, 97, 50, 90,
-               155, 225, 217, 103, 11, 202, 211, 247, 57, 189, 103, 224, 171, 230>>,
-           type: :contract_call_tx
-         }},
         {{:internal_call_tx, "Call.amount"},
          %{
            info:
@@ -116,6 +108,14 @@ defmodule AeMdw.Db.Sync.ContractTest do
                 <<119, 188, 109, 120, 250, 56, 247, 180, 131, 241, 75, 129, 38, 118, 119, 224,
                   142, 113, 227, 78, 233, 147, 100, 188, 163, 26, 145, 253, 121, 183, 62, 80>>},
                {:id, :account, aex9_contract_pk}, 0, 0, 0, 0, "Call.amount"}},
+           tx_hash:
+             <<50, 175, 183, 105, 50, 158, 138, 149, 125, 12, 47, 89, 117, 207, 2, 97, 50, 90,
+               155, 225, 217, 103, 11, 202, 211, 247, 57, 189, 103, 224, 171, 230>>,
+           type: :contract_call_tx
+         }},
+        {{:internal_call_tx, "Chain.clone"},
+         %{
+           info: :error,
            tx_hash:
              <<50, 175, 183, 105, 50, 158, 138, 149, 125, 12, 47, 89, 117, 207, 2, 97, 50, 90,
                155, 225, 217, 103, 11, 202, 211, 247, 57, 189, 103, 224, 171, 230>>,


### PR DESCRIPTION
Events are added to the tx_env in a reverse order: https://github.com/aeternity/aeternity/blob/e66a588a41d8af5f4ce8467f28258d3f2c74cd8e/apps/aetx/src/aetx_env.erl#L324