### PR TITLE
fix: render binary pointer key on name related endpoints

### DIFF
--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -93,13 +93,13 @@ defmodule AeMdw.Db.Format do
 
   @spec encode_pointers(list() | map()) :: %{iodata() => String.t()}
   def encode_pointers(pointers) when is_map(pointers) do
-    Enum.into(pointers, %{}, fn {key, id} -> {maybe_to_list(key), enc_id(id)} end)
+    Enum.into(pointers, %{}, fn {key, id} -> {maybe_encode_base64(key), enc_id(id)} end)
   end
 
   def encode_pointers(pointers) do
     Enum.map(pointers, fn
-      %{"key" => key, "id" => id} -> %{"key" => maybe_to_list(key), "id" => id}
-      %{key: key, id: id} -> %{key: maybe_to_list(key), id: id}
+      %{"key" => key, "id" => id} -> %{"key" => maybe_encode_base64(key), "id" => id}
+      %{key: key, id: id} -> %{key: maybe_encode_base64(key), id: id}
     end)
   end
 
@@ -388,6 +388,14 @@ defmodule AeMdw.Db.Format do
 
   defp custom_encode(_state, _tx_type, tx, _tx_rec, _signed_tx, _txi, _block_hash),
     do: tx
+
+  defp maybe_encode_base64(bin) do
+    if String.valid?(bin) do
+      bin
+    else
+      Base.encode64(bin)
+    end
+  end
 
   defp maybe_base64(bin) do
     try do

--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -388,7 +388,7 @@ defmodule AeMdw.Db.Format do
     do: tx
 
   defp maybe_base64_pointer_key(key)
-       when key in ["account_pubkey", "oracle_pubkey", "contract_pubkey", "channel_pubkey"],
+       when key in ["account_pubkey", "oracle_pubkey", "contract_pubkey", "channel"],
        do: key
 
   defp maybe_base64_pointer_key(key), do: Base.encode64(key)

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -144,7 +144,7 @@ defmodule AeMdw.Db.Name do
       end
 
     pointers
-    |> Enum.map(&pointer_kv_raw/1)
+    |> Enum.into(%{}, &pointer_kv_raw/1)
     |> Format.encode_pointers()
   end
 

--- a/lib/ae_mdw/db/name.ex
+++ b/lib/ae_mdw/db/name.ex
@@ -144,8 +144,8 @@ defmodule AeMdw.Db.Name do
       end
 
     pointers
-    |> Stream.map(&pointer_kv_raw/1)
-    |> Enum.into(%{})
+    |> Enum.map(&pointer_kv_raw/1)
+    |> Format.encode_pointers()
   end
 
   @spec ownership(state(), Model.name()) :: %{

--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -433,16 +433,9 @@ defmodule AeMdw.Names do
       transfers: Enum.map(transfers, &expand_txi(state, &1, opts)),
       revoke: (revoke && expand_txi(state, revoke, opts)) || nil,
       auction_timeout: auction_timeout,
-      pointers: render_pointers(state, name),
+      pointers: Name.pointers(state, name),
       ownership: render_ownership(state, name)
     }
-  end
-
-  defp render_pointers(state, name) do
-    state
-    |> Name.pointers(name)
-    |> Enum.map(fn {key, id} -> {Format.maybe_to_list(key), Format.enc_id(id)} end)
-    |> Enum.into(%{})
   end
 
   defp render_ownership(state, name) do

--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -441,7 +441,7 @@ defmodule AeMdw.Names do
   defp render_pointers(state, name) do
     state
     |> Name.pointers(name)
-    |> Enum.map(fn {key, id} -> {key, Format.enc_id(id)} end)
+    |> Enum.map(fn {key, id} -> {Format.maybe_to_list(key), Format.enc_id(id)} end)
     |> Enum.into(%{})
   end
 

--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -171,7 +171,7 @@ defmodule AeMdwWeb.NameController do
   defp pointers_reply(%Conn{assigns: %{state: state}} = conn, plain_name) do
     case Name.locate(state, plain_name) do
       {m_name, Model.ActiveName} ->
-        json(conn, Format.map_raw_values(Name.pointers(state, m_name), &Format.to_json/1))
+        json(conn, Name.pointers(state, m_name))
 
       {_m_name, Model.InactiveName} ->
         raise ErrInput.Expired, value: plain_name

--- a/test/ae_mdw/db/name_test.exs
+++ b/test/ae_mdw/db/name_test.exs
@@ -98,7 +98,7 @@ defmodule AeMdw.Db.NameTest do
                  name_id: :aeser_id.create(:name, name_hash),
                  name_ttl: 1_000,
                  pointers: [
-                   {:pointer, "channel_pubkey", channel_id},
+                   {:pointer, "channel", channel_id},
                    {:pointer, custom_string_pointer_key, pointer_id}
                  ],
                  client_ttl: 1_000,
@@ -120,7 +120,7 @@ defmodule AeMdw.Db.NameTest do
 
         pointers_map = %{
           custom_string_pointer_key64 => Format.enc_id(pointer_id),
-          "channel_pubkey" => Format.enc_id(channel_id)
+          "channel" => Format.enc_id(channel_id)
         }
 
         assert ^pointers_map =

--- a/test/ae_mdw/db/name_test.exs
+++ b/test/ae_mdw/db/name_test.exs
@@ -14,9 +14,10 @@ defmodule AeMdw.Db.NameTest do
   require Model
 
   describe "pointers/2" do
-    test "gets pointer with non-string pointer key" do
+    test "encodes non-string pointer key to base64" do
       name = "binarypointer.chain"
       pointer_id = :aeser_id.create(:account, <<1::256>>)
+      oracle_id = :aeser_id.create(:oracle, <<1::256>>)
 
       non_string_pointer_key =
         <<104, 65, 117, 174, 49, 251, 29, 202, 69, 174, 147, 56, 60, 150, 188, 247, 149, 85, 150,
@@ -27,10 +28,6 @@ defmodule AeMdw.Db.NameTest do
       tx_hash = :crypto.strong_rand_bytes(32)
 
       with_mocks [
-        {AeMdw.Node, [:passthrough],
-         [
-           id_type: fn :account -> :account_pubkey end
-         ]},
         {AeMdw.Node.Db, [:passthrough],
          [
            get_tx_data: fn ^tx_hash ->
@@ -42,7 +39,10 @@ defmodule AeMdw.Db.NameTest do
                  nonce: 1,
                  name_id: :aeser_id.create(:name, name_hash),
                  name_ttl: 1_000,
-                 pointers: [{:pointer, non_string_pointer_key, pointer_id}],
+                 pointers: [
+                   {:pointer, non_string_pointer_key, pointer_id},
+                   {:pointer, "oracle_pubkey", oracle_id}
+                 ],
                  client_ttl: 1_000,
                  fee: 5_000
                })
@@ -61,7 +61,66 @@ defmodule AeMdw.Db.NameTest do
           )
 
         pointers_map = %{
-          non_string_pointer_key64 => Format.enc_id(pointer_id)
+          non_string_pointer_key64 => Format.enc_id(pointer_id),
+          "oracle_pubkey" => Format.enc_id(oracle_id)
+        }
+
+        assert ^pointers_map =
+                 Name.pointers(
+                   State.new(store),
+                   Model.name(
+                     index: name,
+                     updates: [{{1, 1}, 2}]
+                   )
+                 )
+      end
+    end
+
+    test "encodes custom string pointer key to base64" do
+      name = "binarypointer.chain"
+      pointer_id = :aeser_id.create(:account, <<1::256>>)
+      channel_id = :aeser_id.create(:channel, <<2::256>>)
+      custom_string_pointer_key = "family_pubkey"
+      custom_string_pointer_key64 = Base.encode64(custom_string_pointer_key)
+
+      tx_hash = :crypto.strong_rand_bytes(32)
+
+      with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           get_tx_data: fn ^tx_hash ->
+             {:ok, name_hash} = :aens.get_name_hash(name)
+
+             {:ok, aetx} =
+               :aens_update_tx.new(%{
+                 account_id: :aeser_id.create(:account, <<2::256>>),
+                 nonce: 1,
+                 name_id: :aeser_id.create(:name, name_hash),
+                 name_ttl: 1_000,
+                 pointers: [
+                   {:pointer, "channel_pubkey", channel_id},
+                   {:pointer, custom_string_pointer_key, pointer_id}
+                 ],
+                 client_ttl: 1_000,
+                 fee: 5_000
+               })
+
+             {_mod, tx_rec} = :aetx.specialize_type(aetx)
+             {nil, :name_update_tx, nil, tx_rec}
+           end
+         ]}
+      ] do
+        store =
+          NullStore.new()
+          |> MemStore.new()
+          |> Store.put(
+            Model.Tx,
+            Model.tx(index: 2, id: tx_hash, block_index: {1, 1})
+          )
+
+        pointers_map = %{
+          custom_string_pointer_key64 => Format.enc_id(pointer_id),
+          "channel_pubkey" => Format.enc_id(channel_id)
         }
 
         assert ^pointers_map =

--- a/test/ae_mdw/db/name_test.exs
+++ b/test/ae_mdw/db/name_test.exs
@@ -22,7 +22,7 @@ defmodule AeMdw.Db.NameTest do
         <<104, 65, 117, 174, 49, 251, 29, 202, 69, 174, 147, 56, 60, 150, 188, 247, 149, 85, 150,
           148, 88, 102, 186, 208, 87, 101, 78, 111, 189, 5, 144, 101>>
 
-      non_string_pointer_key_list = :erlang.binary_to_list(non_string_pointer_key)
+      non_string_pointer_key64 = Base.encode64(non_string_pointer_key)
 
       tx_hash = :crypto.strong_rand_bytes(32)
 
@@ -60,7 +60,11 @@ defmodule AeMdw.Db.NameTest do
             Model.tx(index: 2, id: tx_hash, block_index: {1, 1})
           )
 
-        assert pointers =
+        pointers_map = %{
+          non_string_pointer_key64 => Format.enc_id(pointer_id)
+        }
+
+        assert ^pointers_map =
                  Name.pointers(
                    State.new(store),
                    Model.name(
@@ -68,12 +72,6 @@ defmodule AeMdw.Db.NameTest do
                      updates: [{{1, 1}, 2}]
                    )
                  )
-
-        assert pointers == %{
-                 non_string_pointer_key_list => Format.enc_id(pointer_id)
-               }
-
-        assert {:ok, _} = Phoenix.json_library().encode(pointers)
       end
     end
   end

--- a/test/ae_mdw/db/name_test.exs
+++ b/test/ae_mdw/db/name_test.exs
@@ -1,0 +1,68 @@
+defmodule AeMdw.Db.NameTest do
+  use ExUnit.Case
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.MemStore
+  alias AeMdw.Db.Name
+  alias AeMdw.Db.NullStore
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Store
+
+  import AeMdwWeb.BlockchainSim, only: [with_blockchain: 3, name_tx: 3, name_tx: 4]
+  import AeMdw.Util.Encoding
+  import Mock
+
+  require Model
+
+  describe "pointers/2" do
+    test "get pointer with non-string pointer key" do
+      name = "binarypointers.chain"
+
+      non_string_pointer_key =
+        <<104, 65, 117, 174, 49, 251, 29, 202, 69, 174, 147, 56, 60, 150, 188, 247, 149, 85, 150,
+          148, 88, 102, 186, 208, 87, 101, 78, 111, 189, 5, 144, 101>>
+
+      non_string_pointer_key_list = :erlang.binary_to_list(non_string_pointer_key)
+
+      with_blockchain %{alice: 1_000, celia: 1_000},
+        mb: [
+          tx1: name_tx(:name_claim_tx, :alice, name),
+          tx2:
+            name_tx(:name_update_tx, :alice, name, %{
+              pointers: [{:pointer, non_string_pointer_key, :celia}]
+            })
+        ] do
+        %{txs: [tx1, tx2]} = blocks[:mb]
+        {:id, :account, celia_pk} = accounts[:celia]
+        celia_id = encode(:account_pubkey, celia_pk)
+
+        store =
+          NullStore.new()
+          |> MemStore.new()
+          |> Store.put(
+            Model.Tx,
+            Model.tx(index: 1, id: :aetx_sign.hash(tx1), block_index: {1, 1})
+          )
+          |> Store.put(
+            Model.Tx,
+            Model.tx(index: 2, id: :aetx_sign.hash(tx2), block_index: {1, 1})
+          )
+
+        assert pointers =
+                 Name.pointers(
+                   State.new(store),
+                   Model.name(
+                     index: name,
+                     updates: [{{1, 1}, 2}]
+                   )
+                 )
+
+        assert pointers == %{
+                 non_string_pointer_key_list => celia_id
+               }
+
+        assert {:ok, _} = Phoenix.json_library().encode(pointers)
+      end
+    end
+  end
+end

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -19,7 +19,7 @@ defmodule AeMdwWeb.NameControllerTest do
   alias AeMdw.TestSamples, as: TS
   alias AeMdw.Txs
 
-  import AeMdwWeb.BlockchainSim, only: [with_blockchain: 3, name_tx: 3]
+  import AeMdwWeb.BlockchainSim, only: [with_blockchain: 3, name_tx: 3, name_tx: 4]
 
   import Mock
 

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -19,7 +19,7 @@ defmodule AeMdwWeb.NameControllerTest do
   alias AeMdw.TestSamples, as: TS
   alias AeMdw.Txs
 
-  import AeMdwWeb.BlockchainSim, only: [with_blockchain: 3, name_tx: 3, name_tx: 4]
+  import AeMdwWeb.BlockchainSim, only: [with_blockchain: 3, name_tx: 3]
 
   import Mock
 

--- a/test/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/ae_mdw_web/controllers/tx_controller_test.exs
@@ -308,7 +308,7 @@ defmodule AeMdwWeb.TxControllerTest do
         <<104, 65, 117, 174, 49, 251, 29, 202, 69, 174, 147, 56, 60, 150, 188, 247, 149, 85, 150,
           148, 88, 102, 186, 208, 87, 101, 78, 111, 189, 5, 144, 101>>
 
-      non_string_pointer_key_list = :erlang.binary_to_list(non_string_pointer_key)
+      non_string_pointer_key64 = Base.encode64(non_string_pointer_key)
 
       with_blockchain %{alice1: 1_000, alice2: 1_000},
         mb: [
@@ -342,7 +342,7 @@ defmodule AeMdwWeb.TxControllerTest do
                    "pointers" => [
                      %{
                        "id" => ^alice_id2,
-                       "key" => ^non_string_pointer_key_list
+                       "key" => ^non_string_pointer_key64
                      }
                    ]
                  }

--- a/test/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/ae_mdw_web/controllers/tx_controller_test.exs
@@ -8,7 +8,7 @@ defmodule AeMdwWeb.TxControllerTest do
   alias AeMdw.Node.Db
   alias AeMdw.TestSamples, as: TS
 
-  import AeMdwWeb.BlockchainSim, only: [with_blockchain: 3, tx: 3, name_tx: 3]
+  import AeMdwWeb.BlockchainSim, only: [with_blockchain: 3, tx: 3, name_tx: 3, name_tx: 4]
   import AeMdw.Util.Encoding
   import Mock
 
@@ -289,6 +289,60 @@ defmodule AeMdwWeb.TxControllerTest do
                      %{
                        "id" => ^oracle_id,
                        "key" => "oracle_pubkey"
+                     }
+                   ]
+                 }
+               } =
+                 conn
+                 |> with_store(store)
+                 |> get("/v2/txs/#{tx_hash}")
+                 |> json_response(200)
+      end
+    end
+
+    test "returns a name_update_tx with non-string pointers", %{conn: conn, store: store} do
+      plain_name = "aliceinchains.chain"
+      {:ok, name_hash} = :aens.get_name_hash(plain_name)
+
+      non_string_pointer_key =
+        <<104, 65, 117, 174, 49, 251, 29, 202, 69, 174, 147, 56, 60, 150, 188, 247, 149, 85, 150,
+          148, 88, 102, 186, 208, 87, 101, 78, 111, 189, 5, 144, 101>>
+
+      non_string_pointer_key_list = :erlang.binary_to_list(non_string_pointer_key)
+
+      with_blockchain %{alice1: 1_000, alice2: 1_000},
+        mb: [
+          tx:
+            name_tx(:name_update_tx, :alice1, plain_name, %{
+              pointers: [{:pointer, non_string_pointer_key, :alice2}]
+            })
+        ] do
+        %{txs: [tx]} = blocks[:mb]
+        {:id, :account, alice_pk1} = accounts[:alice1]
+        {:id, :account, alice_pk2} = accounts[:alice2]
+        alice_id1 = encode(:account_pubkey, alice_pk1)
+        alice_id2 = encode(:account_pubkey, alice_pk2)
+
+        store =
+          store
+          |> Store.put(Model.Tx, Model.tx(index: 1, block_index: {0, 0}, id: :aetx_sign.hash(tx)))
+          |> Store.put(Model.PlainName, Model.plain_name(index: name_hash, value: plain_name))
+          |> Store.put(Model.ActiveName, Model.name(index: plain_name))
+          |> Store.put(Model.Block, Model.block(index: {0, -1}, tx_index: 1))
+          |> Store.put(Model.Block, Model.block(index: {0, 0}, tx_index: 1))
+          |> Store.put(Model.Block, Model.block(index: {1, -1}, tx_index: 2))
+
+        tx_hash = encode(:tx_hash, :aetx_sign.hash(tx))
+
+        assert %{
+                 "hash" => ^tx_hash,
+                 "tx" => %{
+                   "account_id" => ^alice_id1,
+                   "name" => ^plain_name,
+                   "pointers" => [
+                     %{
+                       "id" => ^alice_id2,
+                       "key" => ^non_string_pointer_key_list
                      }
                    ]
                  }

--- a/test/integration/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/name_controller_test.exs
@@ -1241,7 +1241,7 @@ defmodule Integration.AeMdwWeb.NameControllerTest do
 
     case Name.locate(state, name) do
       {m_name, Model.ActiveName} ->
-        Format.map_raw_values(Name.pointers(state, m_name), &Format.to_json/1)
+        Name.pointers(state, m_name)
 
       {_info, Model.InactiveName} ->
         raise ErrInput.Expired, value: name

--- a/test/support/blockchain_sim.ex
+++ b/test/support/blockchain_sim.ex
@@ -371,10 +371,25 @@ defmodule AeMdwWeb.BlockchainSim do
     {:id, :account, pubkey} = account_id = Map.fetch!(accounts, account_name)
     {:ok, name_hash} = :aens.get_name_hash(plain_name)
 
-    pointers = [
-      {:pointer, "account_pubkey", account_id},
-      {:pointer, "oracle_pubkey", :aeser_id.create(:oracle, pubkey)}
-    ]
+    pointers =
+      case args[:pointers] do
+        nil ->
+          [
+            {:pointer, "account_pubkey", account_id},
+            {:pointer, "oracle_pubkey", :aeser_id.create(:oracle, pubkey)}
+          ]
+
+        list ->
+          Enum.map(list, fn
+            {:pointer, key, account_atom} when is_atom(account_atom) ->
+              {:pointer, key, Map.fetch!(accounts, account_atom)}
+
+            another_pointer ->
+              another_pointer
+          end)
+      end
+
+    args = Map.delete(args, :pointers)
 
     %{
       account_id: account_id,


### PR DESCRIPTION
## What

Fixes the rendering of binary pointer keys: https://testnet.aeternity.art/mdw/v2/txs?type=name_update&limit=20&direction=forward  
where the "invalid byte 0xAE" is in the non-string binary pointer: `<<104, 65, 117, 174, 49, 251, 29, 202, 69, 174, 147, 56, 60, 150, 188, 247, 149, 85, 150, 148, 88, 102, 186, 208, 87, 101, 78, 111, 189, 5, 144, 101>>`

Sample urls fixed:
http://localhost:4000/v2/names?cursor=138231-test.test&direction=forward&limit=1
http://localhost:4000/v2/names/test.test
http://localhost:4000/name/test.test
http://localhost:4000/v2/txs?cursor=29614&limit=1
http://localhost:4000/v2/txs/29614

## Why

Closes #986 (it turns out that ce9293bf was a revert).

## Notes

*binary* here in the meaning of not text (every pointer key is a `binary()`)
