### PR TITLE
fix: scope contract calls filtered by function properly

### DIFF
--- a/lib/ae_mdw/contracts.ex
+++ b/lib/ae_mdw/contracts.ex
@@ -222,14 +222,12 @@ defmodule AeMdw.Contracts do
   end
 
   defp build_calls_pagination(
-         [fname: fname_prefix],
+         [fname: fname],
          state,
          {first_call_txi, last_call_txi},
          cursor
        ) do
-    key_boundary =
-      {{fname_prefix, first_call_txi, @min_idx},
-       {fname_prefix <> Util.max_256bit_bin(), last_call_txi, @max_idx}}
+    key_boundary = {{fname, first_call_txi, @min_idx}, {fname, last_call_txi, @max_idx}}
 
     cursor =
       case cursor do
@@ -358,8 +356,8 @@ defmodule AeMdw.Contracts do
     end
   end
 
-  defp build_calls_pagination(_query, _scope, _state, _cursor),
-    do: raise(ErrInput.Query, value: %{})
+  defp build_calls_pagination(query, _scope, _state, _cursor),
+    do: raise(ErrInput.Query, value: query)
 
   defp build_grp_id_calls_stream(state, direction, scope, cursor, tx_types) do
     state
@@ -422,9 +420,7 @@ defmodule AeMdw.Contracts do
     deserialize_scope(state, {:txi, first..last})
   end
 
-  defp deserialize_scope(_state, {:txi, first_txi..last_txi}) do
-    {first_txi, last_txi}
-  end
+  defp deserialize_scope(_state, {:txi, first_txi..last_txi}), do: {first_txi, last_txi}
 
   defp create_txi!(state, contract_id) do
     pk = Validate.id!(contract_id)

--- a/test/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/ae_mdw_web/controllers/contract_controller_test.exs
@@ -767,6 +767,15 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
       assert %{"data" => ^calls} =
                conn |> with_store(store) |> get(prev_calls) |> json_response(200)
     end
+
+    test "when filtering by function name and scope, it returns an error", %{conn: conn} do
+      error_msg = "invalid scope: can't scope when filtering by function"
+
+      assert %{"error" => ^error_msg} =
+               conn
+               |> get("/v2/contracts/calls", function: "asd", scope: "gen:0-1")
+               |> json_response(400)
+    end
   end
 
   defp enc_ct(pk), do: :aeser_api_encoder.encode(:contract_pubkey, pk)

--- a/test/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/ae_mdw_web/controllers/contract_controller_test.exs
@@ -725,12 +725,12 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
       conn: conn,
       store: store
     } do
-      fname_prefix = "Chain"
+      fname = "Chain.spend"
 
       assert %{"data" => calls, "next" => next} =
                conn
                |> with_store(store)
-               |> get("/v2/contracts/calls", function: fname_prefix)
+               |> get("/v2/contracts/calls", function: fname)
                |> json_response(200)
 
       assert Enum.all?(calls, fn %{
@@ -740,11 +740,13 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
                                    "micro_index" => micro_index,
                                    "block_hash" => block_hash
                                  } ->
-               String.starts_with?(function, fname_prefix) and call_txi in @call_txis and
+               function == fname and call_txi in @call_txis and
                  height == @call_kbi and
                  micro_index == @call_mbi and
                  block_hash == encode(:micro_block_hash, @call_block_hash)
              end)
+
+      assert 10 = length(calls)
 
       assert %{"data" => next_calls, "prev" => prev_calls} =
                conn |> with_store(store) |> get(next) |> json_response(200)
@@ -756,7 +758,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
                                         "micro_index" => micro_index,
                                         "block_hash" => block_hash
                                       } ->
-               String.starts_with?(function, fname_prefix) and call_txi in @call_txis and
+               function == fname and call_txi in @call_txis and
                  height == @call_kbi and
                  micro_index == @call_mbi and
                  block_hash == encode(:micro_block_hash, @call_block_hash)


### PR DESCRIPTION
When filtering by a function name prefix the scoping of the query was being ignored