### PR TITLE
chore: allow /txs/count to be filtered by tx_type

### DIFF
--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -50,6 +50,15 @@ defmodule AeMdw.Txs do
   @type_spend_tx "SpendTx"
 
   @spec count(state(), range(), map()) :: {:ok, non_neg_integer()} | {:error, Error.t()}
+  def count(state, nil, %{"tx_type" => tx_type} = params) do
+    params =
+      params
+      |> Map.delete("tx_type")
+      |> Map.put("type", tx_type)
+
+    count(state, nil, params)
+  end
+
   def count(state, nil, %{"type" => tx_type}) do
     case Validate.tx_type(tx_type) do
       {:ok, tx_type} ->

--- a/test/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/ae_mdw_web/controllers/tx_controller_test.exs
@@ -340,6 +340,23 @@ defmodule AeMdwWeb.TxControllerTest do
                |> json_response(200)
     end
 
+    test "when filtering by tx_type, it displays type_count number", %{conn: conn, store: store} do
+      count = 102
+
+      store =
+        Store.put(
+          store,
+          Model.TypeCount,
+          Model.type_count(index: :oracle_register_tx, count: count)
+        )
+
+      assert ^count =
+               conn
+               |> with_store(store)
+               |> get("/txs/count", tx_type: "oracle_register")
+               |> json_response(200)
+    end
+
     test "when filtering by id, it displays the total count for that address", %{
       conn: conn,
       store: store


### PR DESCRIPTION
This change allows filtering txs count by both `type` and `tx_type` to avoid the request being blocked by browser tracker/ad blockers.