### PR TITLE
fix: handle account_pubkey recipient pointee

### DIFF
--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -100,6 +100,7 @@ defmodule AeMdw.Db.Format do
     Enum.map(pointers, fn
       %{"key" => key, "id" => id} -> %{"key" => maybe_base64_pointer_key(key), "id" => id}
       %{key: key, id: id} -> %{key: maybe_base64_pointer_key(key), id: id}
+      {:pointer, key, id} -> %{key: maybe_base64_pointer_key(key), id: enc_id(id)}
     end)
   end
 

--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -482,8 +482,7 @@ defmodule AeMdw.Txs do
 
   defp get_recipient(state, spend_tx_recipient_nm, spend_txi) do
     with {:ok, plain_name} <- Validate.plain_name(state, spend_tx_recipient_nm),
-         {:ok, pointee_pk} <- Name.account_pointer_at(state, plain_name, spend_txi) do
-      recipient_account = :aeser_api_encoder.encode(:account_pubkey, pointee_pk)
+         {:ok, recipient_account} <- Name.account_pointer_at(state, plain_name, spend_txi) do
       %{"recipient" => %{"name" => plain_name, "account" => recipient_account}}
     else
       {:error, reason} ->

--- a/test/support/blockchain_sim.ex
+++ b/test/support/blockchain_sim.ex
@@ -98,8 +98,8 @@ defmodule AeMdwWeb.BlockchainSim do
   end
 
   @spec spend_tx(account_name(), account_name(), non_neg_integer()) :: tuple()
-  def spend_tx(sender_name, recipient_name, amount) do
-    {:spend_tx, sender_name, recipient_name, amount}
+  def spend_tx(sender_name, recipient, amount) do
+    {:spend_tx, sender_name, recipient, amount}
   end
 
   @spec tx(tx_type(), account_name(), map()) :: tuple()
@@ -333,7 +333,7 @@ defmodule AeMdwWeb.BlockchainSim do
   defp create_aetx({:spend_tx, sender_name, recipient, amount}, accounts) do
     recipient_id =
       case recipient do
-        {:id, _type, _pk} = id -> id
+        {:id, :name, _hash} = id -> id
         recipient_name -> Map.fetch!(accounts, recipient_name)
       end
 


### PR DESCRIPTION
## What

Encode `SpendTx` name recipient when pointer is not formatted.

## Why

Fix for https://testnet.aeternity.art/mdw/v2/txs/th_79Lt9CPHotYmcSUoi9A4WddAdhq9vipdyXPst8TiFwcBcPnJt

## Validation steps

`elixir --sname aeternity@localhost -S mix test test/ae_mdw_web/controllers/tx_controller_test.exs:256`