### PR TITLE
chore: handle dry run timeout

### DIFF
--- a/lib/ae_mdw/db/mutations/update_aex9_state_mutation.ex
+++ b/lib/ae_mdw/db/mutations/update_aex9_state_mutation.ex
@@ -45,6 +45,8 @@ defmodule AeMdw.Db.UpdateAex9StateMutation do
         },
         state
       ) do
-    Contract.aex9_write_balances(state, contract_pk, balances, block_index, txi)
+    state
+    |> Contract.aex9_write_balances(contract_pk, balances, block_index, txi)
+    |> Contract.aex9_init_event_balances(contract_pk, balances, txi)
   end
 end

--- a/lib/ae_mdw/sync/async_tasks/producer.ex
+++ b/lib/ae_mdw/sync/async_tasks/producer.ex
@@ -33,6 +33,7 @@ defmodule AeMdw.Sync.AsyncTasks.Producer do
   @spec save_enqueued() :: :ok
   def save_enqueued() do
     Store.save()
+    Stats.update_db_count()
   end
 
   @spec dequeue() :: nil | Model.async_task_record()

--- a/lib/ae_mdw/sync/async_tasks/stats.ex
+++ b/lib/ae_mdw/sync/async_tasks/stats.ex
@@ -32,6 +32,14 @@ defmodule AeMdw.Sync.AsyncTasks.Stats do
     :ok
   end
 
+  @spec update_db_count() :: :ok
+  def update_db_count do
+    db_pending_count = Database.count(Model.AsyncTask)
+    :ets.update_element(@tab, @stats_key, {@db_count_pos, db_pending_count})
+
+    :ok
+  end
+
   @spec update_consumed() :: :ok
   def update_consumed do
     dec_db_count()
@@ -56,10 +64,5 @@ defmodule AeMdw.Sync.AsyncTasks.Stats do
   #
   defp dec_db_count() do
     :ets.update_counter(@tab, @stats_key, {@db_count_pos, -1, 0, 0})
-  end
-
-  defp update_db_count() do
-    db_pending_count = Database.count(Model.AsyncTask)
-    :ets.update_element(@tab, @stats_key, {@db_count_pos, db_pending_count})
   end
 end


### PR DESCRIPTION
## What

Handle dry run timeout (when server is busy and it doesn't respond after 250ms) by initializing aex9 event balance with async task.

## Why

Refs #969