### PR TITLE
fix: adjust git revision digits to allow variable length

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,12 +9,12 @@ import Config
 
 mdw_revision =
   case File.read("AEMDW_REVISION") do
-    {:ok, <<git_commit::binary-7, "\n">>} ->
-      git_commit
+    {:ok, revision} ->
+      String.trim(revision)
 
     {:error, :enoent} ->
-      {<<git_head_commit::binary-7, "\n">>, 0} = System.cmd("git", ["log", "-1", "--format=%h"])
-      git_head_commit
+      {revision, 0} = System.cmd("git", ["log", "-1", "--format=%h"])
+      String.trim(revision)
   end
 
 config :ae_mdw, build_revision: mdw_revision


### PR DESCRIPTION
`--format=%h` returns an abbreviated number of digits for a given commit SHA-1. Depending on the amount of objects in the git repository the length of this identifier will change. As per git docs:

> will vary according to the number of objects in the repository with a default of 7