### PR TITLE
chore: put nft contract limits in a map

### DIFF
--- a/lib/ae_mdw/aex141.ex
+++ b/lib/ae_mdw/aex141.ex
@@ -114,7 +114,7 @@ defmodule AeMdw.Aex141 do
     end
   end
 
-  @spec fetch_limits(State.t(), pubkey()) :: limits()
+  @spec fetch_limits(State.t(), pubkey()) :: limits() | nil
   def fetch_limits(state, contract_pk) do
     Model.nft_contract_limits(
       token_limit: token_limit,
@@ -127,12 +127,14 @@ defmodule AeMdw.Aex141 do
         {:ok, m_limits} -> m_limits
       end
 
-    %{
-      token_limit: token_limit,
-      template_limit: template_limit,
-      limit_txi: txi,
-      limit_log_idx: log_idx
-    }
+    if token_limit != nil or template_limit != nil do
+      %{
+        token_limit: token_limit,
+        template_limit: template_limit,
+        limit_txi: txi,
+        limit_log_idx: log_idx
+      }
+    end
   end
 
   #

--- a/lib/ae_mdw_web/views/aexn_view.ex
+++ b/lib/ae_mdw_web/views/aexn_view.ex
@@ -193,10 +193,10 @@ defmodule AeMdwWeb.AexnView do
       contract_txi: txi,
       contract_id: enc_ct(contract_pk),
       metadata_type: metadata_type,
-      extensions: extensions
+      extensions: extensions,
+      limits: Aex141.fetch_limits(state, contract_pk)
     }
     |> Map.merge(Stats.fetch_nft_stats(state, contract_pk))
-    |> Map.merge(Aex141.fetch_limits(state, contract_pk))
   end
 
   defp do_transfer_to_map(


### PR DESCRIPTION
Returns nft contract limits under `limits` object in way that if there is no limit only one field is returned. 