### PR TITLE
test: use strict version on otp ci

### DIFF
--- a/.github/actions/mdw-setup/action.yml
+++ b/.github/actions/mdw-setup/action.yml
@@ -8,6 +8,7 @@ runs:
       with:
         otp-version: 23.3.4.17
         elixir-version: 1.13.4
+        version-type: strict
 
     - name: Get Mdw dependencies
       shell: bash

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -26,7 +26,7 @@ jobs:
 
   test-coverage:
     name: Test coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       MIX_ENV: test
@@ -49,7 +49,7 @@ jobs:
 
   lint:
     name: Automated linting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       NODEROOT: ./node/local
@@ -87,7 +87,7 @@ jobs:
 
   dialyzer:
     name: Dialyzer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -108,7 +108,7 @@ jobs:
         id: plt-cache
         with:
           path: priv/plts
-          key: plts-v12-${{ hashFiles('mix.lock') }}
+          key: plts-v13-${{ hashFiles('mix.lock') }}
 
       - name: Mdw Setup
         uses: ./.github/actions/mdw-setup


### PR DESCRIPTION
Set os and otp according to https://github.com/erlef/setup-beam

Notes: 
- unit tests action continues to run on the mdw docker image os and otp
- for test coverage please see #1055 