### PR TITLE
feat: add aex9 presence after event

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -673,7 +673,9 @@ defmodule AeMdw.Db.Contract do
         amount: from_amount - burn_value
       )
 
-    State.put(state, Model.Aex9EventBalance, m_from)
+    state
+    |> State.put(Model.Aex9EventBalance, m_from)
+    |> aex9_write_presence(contract_pk, txi, from_pk)
   end
 
   defp burn_aex9_balance(state, _pk, _txi, _idx, _args), do: state
@@ -689,7 +691,9 @@ defmodule AeMdw.Db.Contract do
         amount: to_amount + mint_value
       )
 
-    State.put(state, Model.Aex9EventBalance, m_to)
+    state
+    |> State.put(Model.Aex9EventBalance, m_to)
+    |> aex9_write_presence(contract_pk, txi, to_pk)
   end
 
   defp mint_aex9_balance(state, _pk, _txi, _idx, _args), do: state
@@ -727,6 +731,7 @@ defmodule AeMdw.Db.Contract do
       state
       |> State.put(Model.Aex9EventBalance, m_from)
       |> State.put(Model.Aex9EventBalance, m_to)
+      |> aex9_write_presence(contract_pk, txi, to_pk)
     else
       state
     end


### PR DESCRIPTION
## What

- Replaces the dry run with events in regards to sync (next is the endpoint)
- Improves test setup

## Why

Refs #969
Scoped as part of the latest request to replace the aex9 dry-run balance with the event ones.