### PR TITLE
chore: add template limit details to edition

### DIFF
--- a/lib/ae_mdw/aex141.ex
+++ b/lib/ae_mdw/aex141.ex
@@ -220,9 +220,21 @@ defmodule AeMdw.Aex141 do
         template_id: template_id,
         tx_hash: enc(:tx_hash, tx_hash),
         log_idx: log_idx,
-        limit: limit
+        edition: render_template_edition_limit(state, limit)
       }
     end)
+  end
+
+  defp render_template_edition_limit(_state, nil), do: nil
+
+  defp render_template_edition_limit(state, {amount, txi, log_idx}) do
+    tx_hash = Txs.txi_to_hash(state, txi)
+
+    %{
+      limit: amount,
+      limit_log_idx: log_idx,
+      limit_tx_hash: enc(:tx_hash, tx_hash)
+    }
   end
 
   defp render_owners(state, nft_tokens) do

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -372,10 +372,14 @@ defmodule AeMdw.Db.Contract do
     end
   end
 
-  defp write_aex141_edition_limit(state, event_type, contract_pk, args) do
+  defp write_aex141_edition_limit(state, event_type, contract_pk, txi, log_idx, args) do
     with {template_id, limit} <- get_edition_limit_from_args(event_type, args),
          {:ok, m_template} <- State.get(state, Model.NftTemplate, {contract_pk, template_id}) do
-      State.put(state, Model.NftTemplate, Model.nft_template(m_template, limit: limit))
+      State.put(
+        state,
+        Model.NftTemplate,
+        Model.nft_template(m_template, limit: {limit, txi, log_idx})
+      )
     else
       nil -> state
       :not_found -> state
@@ -517,9 +521,9 @@ defmodule AeMdw.Db.Contract do
     |> write_aex141_template(contract_pk, args, txi, log_idx)
   end
 
-  defp write_aex141_records(state, event_type, contract_pk, _txi, _log_idx, args)
+  defp write_aex141_records(state, event_type, contract_pk, txi, log_idx, args)
        when event_type in [:edition_limit, :edition_limit_decrease] do
-    write_aex141_edition_limit(state, event_type, contract_pk, args)
+    write_aex141_edition_limit(state, event_type, contract_pk, txi, log_idx, args)
   end
 
   defp write_aex141_records(state, event_type, contract_pk, txi, log_idx, args)

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -430,6 +430,9 @@ defmodule AeMdw.Db.Model do
 
   # AEX-141 templates
   #     index: {contract pubkey, template_id}
+  #     txi: creation txi
+  #     log_idx: creation event
+  #     limit: {amount, txi, log_idx} | nil
   @nft_template_defaults [index: {<<>>, -1}, txi: nil, log_idx: nil, limit: nil]
   defrecord :nft_template, @nft_template_defaults
 
@@ -438,7 +441,7 @@ defmodule AeMdw.Db.Model do
             index: {pubkey(), integer()},
             txi: txi() | nil,
             log_idx: log_idx() | nil,
-            limit: non_neg_integer() | nil
+            limit: {pos_integer(), txi(), log_idx()} | nil
           )
 
   # AEX-141 collection owners

--- a/test/ae_mdw/db/contract_call_mutation_test.exs
+++ b/test/ae_mdw/db/contract_call_mutation_test.exs
@@ -820,7 +820,7 @@ defmodule AeMdw.Db.ContractCallMutationTest do
         )
         |> change_store([mutation])
 
-      assert {:ok, Model.nft_template(txi: ^call_txi, log_idx: 1, limit: ^limit)} =
+      assert {:ok, Model.nft_template(txi: ^call_txi, log_idx: 1, limit: {^limit, ^call_txi, 2})} =
                Store.get(store, Model.NftTemplate, {contract_pk, template_id})
     end
 
@@ -878,7 +878,8 @@ defmodule AeMdw.Db.ContractCallMutationTest do
         )
         |> change_store([mutation])
 
-      assert {:ok, Model.nft_template(txi: ^template_txi, log_idx: 1, limit: ^limit)} =
+      assert {:ok,
+              Model.nft_template(txi: ^template_txi, log_idx: 1, limit: {^limit, ^call_txi, 0})} =
                Store.get(store, Model.NftTemplate, {contract_pk, template_id})
     end
   end


### PR DESCRIPTION
Use similar object/map for template limits likewise contract limits.

Note: there will be supply info related to edition object.