### PR TITLE
chore: allow network id for local environment

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,7 @@
 import Config
 
+config :aecore, network_id: System.get_env("NETWORK_ID", "ae_mainnet")
+
 config :ae_mdw, AeMdwWeb.Endpoint,
   http: [port: 4000],
   debug_errors: true,

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,8 @@ if System.get_env("INTEGRATION_TEST") != "1" do
   config :ae_mdw, AeMdw.Db.RocksDb, data_dir: "test_data.db"
 end
 
+config :aecore, network_id: System.get_env("NETWORK_ID", "ae_mainnet")
+
 # HTTP
 config :ae_mdw, AeMdwWeb.Endpoint,
   http: [port: 4002],


### PR DESCRIPTION
## What

Enable setting network id for dev and test environments

## Why

Required when running locally with `make shell` to allow using `uat_backup_v1_full_latest.tar.zst`