### PR TITLE
fix: name of sender parameter of get_aex9_pair_transfers

### DIFF
--- a/priv/static/swagger/swagger_v2.yaml
+++ b/priv/static/swagger/swagger_v2.yaml
@@ -1275,7 +1275,7 @@ paths:
       - $ref: '#/components/parameters/DirectionParam'
       - description: Sender account id
         in: path
-        name: recipient
+        name: sender
         required: true
         type: string
         x-example: ak_17qFR9Zp6CbX9ZZrEYd5155KHGAsfbY1YZ2UsRpjH6WJc8Pk1


### PR DESCRIPTION
the parameter with `recipient` name is defined below