### PR TITLE
fix: remove extra colon before in path parameter name

### DIFF
--- a/priv/static/swagger/swagger_v2.yaml
+++ b/priv/static/swagger/swagger_v2.yaml
@@ -1373,7 +1373,7 @@ paths:
           description: Bad request
           schema:
             $ref: '#/components/schemas/ErrorResponse'
-  /aex9/{:contract_id}/balances:
+  /aex9/{contract_id}/balances:
     get:
       deprecated: false
       description: Get AEX9 balances on a contract.


### PR DESCRIPTION
I've checked the swagger docs at
https://swagger.io/docs/specification/describing-parameters/#path-parameters
and I can't find the meaning of this `:`, also it doesn't appear in other places, so I think this is a typo.