### PR TITLE
feat: add v2 websocket implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4717,8 +4717,9 @@ In order to differentiate, please check the "source" field on [Publishing Messag
   * Transactions
   * Object, which takes a further field, `target` - can be any æternity entity. So you may subscribe to any æternity object type, and be sent all transactions which reference the object. For instance, if you have an oracle `ok_JcUaMCu9FzTwonCZkFE5BXsgxueagub9fVzywuQRDiCogTzse` you may subscribe to this object and be notified of any events which relate to it - presumable you would be interested in queries, to which you would respond. Of course you can also subscribe to accounts, contracts, names, whatever you like.
 
+### `/websocket`
 
-The websocket interface accepts JSON - encoded commands to subscribe and unsubscribe, and answers these with the list of subscriptions. A session will look like this:
+The V1 websocket interface accepts JSON - encoded commands to subscribe and unsubscribe, and answers these with the list of subscriptions. A session will look like this:
 
 ```
 wscat -c wss://mainnet.aeternity.io/mdw/websocket
@@ -4755,6 +4756,10 @@ Actual chain data is wrapped in a JSON structure identifying the subscription to
 
 When the `source` is "node" it means that the Node is synching the block or transaction (not yet indexed by AeMdw).
 If it's "mdw", it indicates that it's already avaiable through AeMdw Api.
+
+### `/v2/websocket`
+
+The V2 websocket interface behaves the same way as the V1 interface, but when the published message has source `mdw` it returns the renderered representation of the object as it would be rendered by the middleware (e.g. the returned object for the `Transactions` subscription will be the same object as returned by the `/v2/txs` endpoint).
 
 ## Tests
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -42,24 +42,8 @@ config :ae_mdw, AeMdwWeb.Endpoint,
   pubsub: [name: AeMdw.PubSub, adapter: Phoenix.PubSub.PG2],
   live_view: [signing_salt: "Oy680JAN"]
 
-config :ae_mdw, AeWebsocket.Websocket.SocketHandler,
-  port: 4001,
-  path: "/websocket",
-  # don't accept connections if server already has this number of connections
-  max_connections: 10000,
-  # force to disconnect a connection if the duration passed. if :infinity is set, do nothing.
-  max_connection_age: :infinity,
-  # disconnect if no event comes on a connection during this duration
-  idle_timeout: :infinity,
-  # TCP SO_REUSEPORT flag
-  reuse_port: false,
-  show_debug_logs: false,
-  transmission_limit: [
-    # if 1000 frames are sent on a connection
-    capacity: 1000,
-    # in 2 seconds, disconnect it.
-    duration: 2000
-  ]
+config :ae_mdw, AeMdwWeb.WebsocketEndpoint,
+  http: [port: 4001]
 
 # Configures Elixir's Logger
 config :logger,

--- a/config/config.exs
+++ b/config/config.exs
@@ -42,8 +42,7 @@ config :ae_mdw, AeMdwWeb.Endpoint,
   pubsub: [name: AeMdw.PubSub, adapter: Phoenix.PubSub.PG2],
   live_view: [signing_salt: "Oy680JAN"]
 
-config :ae_mdw, AeMdwWeb.WebsocketEndpoint,
-  http: [port: 4001]
+config :ae_mdw, AeMdwWeb.WebsocketEndpoint, http: [port: 4001]
 
 # Configures Elixir's Logger
 config :logger,

--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -91,7 +91,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
   defp do_broadcast_key_block(block, :v2, :mdw) do
     header = :aec_blocks.to_header(block)
     height = :aec_headers.height(header)
-    state = State.new()
+    state = State.mem_state()
 
     case Blocks.fetch_key_block(state, "#{height}") do
       {:ok, block} ->
@@ -136,7 +136,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
   defp do_broadcast_micro_block(block, :v2, :mdw) do
     header = :aec_blocks.to_header(block)
     {:ok, hash} = :aec_headers.hash_header(header)
-    state = State.new()
+    state = State.mem_state()
 
     case Blocks.fetch_micro_block(state, hash) do
       {:ok, block} ->
@@ -169,7 +169,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
   end
 
   defp do_broadcast_txs(block, :v2, :mdw) do
-    state = State.new()
+    state = State.mem_state()
 
     block
     |> :aec_blocks.txs()
@@ -177,13 +177,13 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
       tx_hash = :aetx_sign.hash(tx)
 
       case Txs.fetch(state, tx_hash, true) do
-        {:ok, tx} ->
-          mdw_msg = encode_message(tx, "Transactions", :mdw)
+        {:ok, mdw_tx} ->
+          mdw_msg = encode_message(mdw_tx, "Transactions", :mdw)
           broadcast("Transactions", :v2, mdw_msg)
 
           tx
           |> get_ids_from_tx()
-          |> Enum.each(&broadcast(&1, :v2, encode_message(tx, "Object", :mdw)))
+          |> Enum.each(&broadcast(&1, :v2, encode_message(mdw_tx, "Object", :mdw)))
 
         {:error, _reason} ->
           :ok

--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -4,16 +4,21 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
   """
   use GenServer
 
+  alias AeMdw.Blocks
+  alias AeMdw.Db.State
   alias AeMdw.EtsCache
+  alias AeMdw.Node.Db
+  alias AeMdw.Txs
   alias AeMdwWeb.Websocket.Subscriptions
   alias AeMdwWeb.Websocket.SocketHandler
 
   require Ex2ms
 
-  @dialyzer {:no_return, broadcast: 2}
-
   @hashes_table :broadcast_hashes
   @expiration_minutes 120
+
+  @typep source() :: :node | :mdw
+  @typep version() :: Subscriptions.version()
 
   @spec start_link(any()) :: GenServer.on_start()
   def start_link(_arg), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
@@ -24,72 +29,81 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
   @spec ets_config() :: {EtsCache.table(), EtsCache.expiration()}
   def ets_config(), do: {@hashes_table, @expiration_minutes}
 
-  @spec broadcast_key_block(tuple(), :node | :mdw) :: :ok
-  def broadcast_key_block(block, source) do
-    GenServer.cast(__MODULE__, {:broadcast_key_block, block, source})
+  @spec broadcast_key_block(Db.key_block(), version(), source()) :: :ok
+  def broadcast_key_block(block, version, source) do
+    GenServer.cast(__MODULE__, {:broadcast_key_block, version, block, source})
   end
 
-  @spec broadcast_micro_block(tuple(), :node | :mdw) :: :ok
-  def broadcast_micro_block(block, source) do
-    GenServer.cast(__MODULE__, {:broadcast_micro_block, block, source})
+  @spec broadcast_micro_block(Db.micro_block(), version(), source()) :: :ok
+  def broadcast_micro_block(block, version, source) do
+    GenServer.cast(__MODULE__, {:broadcast_micro_block, version, block, source})
   end
 
-  @spec broadcast_txs(tuple(), :node | :mdw) :: :ok
-  def broadcast_txs(block, source) do
-    GenServer.cast(__MODULE__, {:broadcast_txs, block, source})
+  @spec broadcast_txs(Db.micro_block(), version(), source()) :: :ok
+  def broadcast_txs(block, version, source) do
+    GenServer.cast(__MODULE__, {:broadcast_txs, version, block, source})
   end
 
   @impl GenServer
-  def handle_cast({:broadcast_key_block, block, source}, state) do
+  def handle_cast({:broadcast_key_block, version, block, source}, state) do
     {:ok, hash} = block |> :aec_blocks.to_header() |> :aec_headers.hash_header()
 
-    if not already_processed?({:key, hash, source}) do
-      do_broadcast_key_block(block, source)
-      set_processed({:key, hash, source})
+    if not already_processed?({:key, version, hash, source}) do
+      do_broadcast_key_block(block, version, source)
+      set_processed({:key, version, hash, source})
     end
 
     {:noreply, state}
   end
 
   @impl GenServer
-  def handle_cast({:broadcast_micro_block, block, source}, state) do
+  def handle_cast({:broadcast_micro_block, version, block, source}, state) do
     {:ok, hash} = block |> :aec_blocks.to_header() |> :aec_headers.hash_header()
 
-    if not already_processed?({:micro, hash, source}) do
-      do_broadcast_micro_block(block, source)
-      set_processed({:micro, hash, source})
+    if not already_processed?({:micro, version, hash, source}) do
+      do_broadcast_micro_block(block, version, source)
+      set_processed({:micro, version, hash, source})
     end
 
     {:noreply, state}
   end
 
   @impl GenServer
-  def handle_cast({:broadcast_txs, block, source}, state) do
+  def handle_cast({:broadcast_txs, version, block, source}, state) do
     {:ok, hash} = block |> :aec_blocks.to_header() |> :aec_headers.hash_header()
 
-    if not already_processed?({:txs, hash, source}) do
-      do_broadcast_txs(block, source)
-      set_processed({:txs, hash, source})
+    if not already_processed?({:txs, version, hash, source}) do
+      do_broadcast_txs(block, version, source)
+      set_processed({:txs, version, hash, source})
     end
 
     {:noreply, state}
   end
 
   @impl GenServer
-  def handle_info({:broadcast_objects, header, tx, source}, state) do
-    ser_tx = :aetx_sign.serialize_for_client(header, tx)
-
-    tx
-    |> get_ids_from_tx()
-    |> Enum.each(&broadcast(&1, encode_message(ser_tx, "Object", source)))
-
+  def handle_info(_msg, state) do
     {:noreply, state}
   end
 
   #
   # Private functions
   #
-  defp do_broadcast_key_block(block, source) do
+  defp do_broadcast_key_block(block, :v2, :mdw) do
+    header = :aec_blocks.to_header(block)
+    height = :aec_headers.height(header)
+    state = State.new()
+
+    case Blocks.fetch_key_block(state, "#{height}") do
+      {:ok, block} ->
+        msg = encode_message(block, "KeyBlocks", block)
+        broadcast("KeyBlocks", :v2, msg)
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp do_broadcast_key_block(block, version, source) do
     header = :aec_blocks.to_header(block)
 
     if :aec_blocks.height(block) == 0 do
@@ -98,7 +112,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
         |> :aec_headers.serialize_for_client(:key)
         |> encode_message("KeyBlocks", source)
 
-      broadcast("KeyBlocks", msg)
+      broadcast("KeyBlocks", version, msg)
     else
       prev_block_hash = :aec_blocks.prev_hash(block)
 
@@ -111,8 +125,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
             |> :aec_headers.serialize_for_client(prev_block_type)
             |> encode_message("KeyBlocks", source)
 
-          broadcast("KeyBlocks", msg)
-          :ok
+          broadcast("KeyBlocks", version, msg)
 
         :error ->
           :ok
@@ -120,7 +133,22 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
     end
   end
 
-  defp do_broadcast_micro_block(block, source) do
+  defp do_broadcast_micro_block(block, :v2, :mdw) do
+    header = :aec_blocks.to_header(block)
+    {:ok, hash} = :aec_headers.hash_header(header)
+    state = State.new()
+
+    case Blocks.fetch_micro_block(state, hash) do
+      {:ok, block} ->
+        msg = encode_message(block, "MicroBlocks", block)
+        broadcast("MicroBlocks", :v2, msg)
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp do_broadcast_micro_block(block, version, source) do
     prev_block_hash = :aec_blocks.prev_hash(block)
 
     case :aec_chain.get_block(prev_block_hash) do
@@ -133,35 +161,61 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
           |> :aec_headers.serialize_for_client(prev_block_type)
           |> encode_message("MicroBlocks", source)
 
-        broadcast("MicroBlocks", msg)
-        :ok
+        broadcast("MicroBlocks", version, msg)
 
       :error ->
         :ok
     end
   end
 
-  defp do_broadcast_txs(block, source) do
+  defp do_broadcast_txs(block, :v2, :mdw) do
+    state = State.new()
+
+    block
+    |> :aec_blocks.txs()
+    |> Enum.each(fn tx ->
+      tx_hash = :aetx_sign.hash(tx)
+
+      case Txs.fetch(state, tx_hash, true) do
+        {:ok, tx} ->
+          mdw_msg = encode_message(tx, "Transactions", :mdw)
+          broadcast("Transactions", :v2, mdw_msg)
+
+          tx
+          |> get_ids_from_tx()
+          |> Enum.each(&broadcast(&1, :v2, encode_message(tx, "Object", :mdw)))
+
+        {:error, _reason} ->
+          :ok
+      end
+    end)
+  end
+
+  defp do_broadcast_txs(block, version, source) do
     header = :aec_blocks.to_header(block)
 
     block
     |> :aec_blocks.txs()
     |> Enum.each(fn tx ->
       # sends Objects in separate message as broadcast has not_return
-      Process.send(__MODULE__, {:broadcast_objects, header, tx, source}, [:noconnect])
+      ser_tx = :aetx_sign.serialize_for_client(header, tx)
 
       msg =
         header
         |> :aetx_sign.serialize_for_client(tx)
         |> encode_message("Transactions", source)
 
-      broadcast("Transactions", msg)
+      broadcast("Transactions", version, msg)
+
+      tx
+      |> get_ids_from_tx()
+      |> Enum.each(&broadcast(&1, version, encode_message(ser_tx, "Object", source)))
     end)
   end
 
-  defp broadcast(channel, msg) do
-    channel
-    |> Subscriptions.subscribers()
+  defp broadcast(channel, version, msg) do
+    version
+    |> Subscriptions.subscribers(channel)
     |> Enum.each(&SocketHandler.send(&1, msg))
   end
 

--- a/lib/ae_mdw_web/websocket/chain_listener.ex
+++ b/lib/ae_mdw_web/websocket/chain_listener.ex
@@ -23,8 +23,10 @@ defmodule AeMdwWeb.Websocket.ChainListener do
   def handle_info({:gproc_ps_event, :top_changed, %{info: %{block_type: :micro} = info}}, state) do
     case :aehttp_logic.get_micro_block_by_hash(info.block_hash) do
       {:ok, block} ->
-        Broadcaster.broadcast_micro_block(block, :node)
-        Broadcaster.broadcast_txs(block, :node)
+        Broadcaster.broadcast_micro_block(block, :v1, :node)
+        Broadcaster.broadcast_micro_block(block, :v2, :node)
+        Broadcaster.broadcast_txs(block, :v1, :node)
+        Broadcaster.broadcast_txs(block, :v2, :node)
 
       {:error, :block_not_found} ->
         Log.warn("gproc_ps_event with block not found: block_hash = #{inspect(info.block_hash)}")
@@ -37,7 +39,8 @@ defmodule AeMdwWeb.Websocket.ChainListener do
   def handle_info({:gproc_ps_event, :top_changed, %{info: %{block_type: :key} = info}}, state) do
     case :aec_chain.get_key_block_by_height(info.height) do
       {:ok, block} ->
-        Broadcaster.broadcast_key_block(block, :node)
+        Broadcaster.broadcast_key_block(block, :v1, :node)
+        Broadcaster.broadcast_key_block(block, :v2, :node)
 
       {:error, _rsn} ->
         Log.warn("gproc_ps_event with block not found: block_hash = #{inspect(info.block_hash)}")

--- a/lib/ae_mdw_web/websocket/subscriptions.ex
+++ b/lib/ae_mdw_web/websocket/subscriptions.ex
@@ -160,9 +160,6 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
     end
   end
 
-  # :ets.delete_object(@subs_channel_pid, {channel_key, pid})
-  # :ets.delete_object(@subs_pid_channel, {pid, {channel_key, channel}})
-
   defp channel_key(version, channel) when channel in @known_channels,
     do: {:ok, {version, channel}}
 

--- a/lib/ae_mdw_web/websocket_endpoint.ex
+++ b/lib/ae_mdw_web/websocket_endpoint.ex
@@ -18,6 +18,14 @@ defmodule AeMdwWeb.WebsocketEndpoint do
       connect_info: [session: @session_options],
       path: "/",
       timeout: 660_000,
-      max_frame_size: 256_000
+      max_frame_size: 128_000
+    ]
+
+  socket "/v2/websocket", AeMdwWeb.Websocket.SocketHandler,
+    websocket: [
+      connect_info: [session: @session_options],
+      path: "/",
+      timeout: 660_000,
+      max_frame_size: 128_000
     ]
 end

--- a/test/ae_mdw/websocket/broadcaster_test.exs
+++ b/test/ae_mdw/websocket/broadcaster_test.exs
@@ -128,13 +128,13 @@ defmodule AeMdw.Websocket.BroadcasterTest do
           "subscription" => "Object"
         }
 
-        Broadcaster.broadcast_txs(block0, :node)
+        Broadcaster.broadcast_txs(block0, :v1, :node)
 
         assert_websocket_receive(clients, :objs, [
           Map.put(expected_msg, "source", "node")
         ])
 
-        Broadcaster.broadcast_txs(block0, :mdw)
+        Broadcaster.broadcast_txs(block0, :v1, :mdw)
 
         assert_websocket_receive(clients, :objs, [
           Map.put(expected_msg, "source", "mdw")
@@ -174,14 +174,14 @@ defmodule AeMdw.Websocket.BroadcasterTest do
           "subscription" => "Object"
         }
 
-        Broadcaster.broadcast_txs(block1, :node)
+        Broadcaster.broadcast_txs(block1, :v1, :node)
 
         assert_websocket_receive(clients, :objs, [
           Map.put(expected_msg1, "source", "node"),
           Map.put(expected_msg2, "source", "node")
         ])
 
-        Broadcaster.broadcast_txs(block1, :mdw)
+        Broadcaster.broadcast_txs(block1, :v1, :mdw)
 
         assert_websocket_receive(clients, :objs, [
           Map.put(expected_msg1, "source", "mdw"),
@@ -204,20 +204,20 @@ defmodule AeMdw.Websocket.BroadcasterTest do
           "subscription" => "Object"
         }
 
-        Broadcaster.broadcast_txs(block2, :node)
+        Broadcaster.broadcast_txs(block2, :v1, :node)
 
         assert_websocket_receive(clients, :objs, [
           Map.put(expected_msg, "source", "node")
         ])
 
-        Broadcaster.broadcast_txs(block2, :mdw)
+        Broadcaster.broadcast_txs(block2, :v1, :mdw)
 
         assert_websocket_receive(clients, :objs, [
           Map.put(expected_msg, "source", "mdw")
         ])
 
         %{hash: _mb_hash3, height: 3, block: block3, txs: [_tx7]} = blocks[:mb3]
-        Broadcaster.broadcast_txs(block3, :node)
+        Broadcaster.broadcast_txs(block3, :v1, :node)
         assert_websocket_receive(clients, :objs, [])
 
         %{hash: mb_hash, height: 4, block: block4, txs: [tx8]} = blocks[:mb4]
@@ -237,31 +237,31 @@ defmodule AeMdw.Websocket.BroadcasterTest do
           "subscription" => "Object"
         }
 
-        Broadcaster.broadcast_txs(block4, :node)
+        Broadcaster.broadcast_txs(block4, :v1, :node)
 
         assert_websocket_receive(clients, :objs, [
           Map.put(expected_msg, "source", "node")
         ])
 
-        Broadcaster.broadcast_txs(block4, :mdw)
+        Broadcaster.broadcast_txs(block4, :v1, :mdw)
 
         assert_websocket_receive(clients, :objs, [
           Map.put(expected_msg, "source", "mdw")
         ])
 
-        Broadcaster.broadcast_txs(block0, :node)
+        Broadcaster.broadcast_txs(block0, :v1, :node)
         assert_websocket_receive(clients, :objs, [])
 
-        Broadcaster.broadcast_txs(block1, :mdw)
+        Broadcaster.broadcast_txs(block1, :v1, :mdw)
         assert_websocket_receive(clients, :objs, [])
 
-        Broadcaster.broadcast_txs(block2, :node)
+        Broadcaster.broadcast_txs(block2, :v1, :node)
         assert_websocket_receive(clients, :objs, [])
 
-        Broadcaster.broadcast_txs(block3, :mdw)
+        Broadcaster.broadcast_txs(block3, :v1, :mdw)
         assert_websocket_receive(clients, :objs, [])
 
-        Broadcaster.broadcast_txs(block4, :mdw)
+        Broadcaster.broadcast_txs(block4, :v1, :mdw)
         assert_websocket_receive(clients, :objs, [])
       end
     end
@@ -275,7 +275,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
     %{hash: kb_hash1, height: 1, block: block1} = blocks[:kb1]
     %{hash: kb_hash2, height: 2, block: block2} = blocks[:kb2]
 
-    Broadcaster.broadcast_key_block(block0, :node)
+    Broadcaster.broadcast_key_block(block0, :v1, :node)
 
     assert_websocket_receive(clients, :kb, %{
       "payload" => %{"hash" => kb_hash0, "height" => 0},
@@ -283,7 +283,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
       "subscription" => "KeyBlocks"
     })
 
-    Broadcaster.broadcast_key_block(block1, :node)
+    Broadcaster.broadcast_key_block(block1, :v1, :node)
 
     assert_websocket_receive(clients, :kb, %{
       "payload" => %{"hash" => kb_hash1, "height" => 1},
@@ -291,7 +291,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
       "subscription" => "KeyBlocks"
     })
 
-    Broadcaster.broadcast_key_block(block0, :mdw)
+    Broadcaster.broadcast_key_block(block0, :v1, :mdw)
 
     assert_websocket_receive(clients, :kb, %{
       "payload" => %{"hash" => kb_hash0, "height" => 0},
@@ -299,7 +299,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
       "subscription" => "KeyBlocks"
     })
 
-    Broadcaster.broadcast_key_block(block1, :mdw)
+    Broadcaster.broadcast_key_block(block1, :v1, :mdw)
 
     assert_websocket_receive(clients, :kb, %{
       "payload" => %{"hash" => kb_hash1, "height" => 1},
@@ -307,13 +307,13 @@ defmodule AeMdw.Websocket.BroadcasterTest do
       "subscription" => "KeyBlocks"
     })
 
-    Broadcaster.broadcast_key_block(block2, :node)
+    Broadcaster.broadcast_key_block(block2, :v1, :node)
     assert_websocket_receive(clients, :kb, %{"payload" => %{"hash" => kb_hash2, "height" => 2}})
 
-    Broadcaster.broadcast_key_block(block0, :node)
+    Broadcaster.broadcast_key_block(block0, :v1, :node)
     assert_websocket_receive(clients, :kb, %{"payload" => %{"hash" => kb_hash2, "height" => 2}})
 
-    Broadcaster.broadcast_key_block(block1, :mdw)
+    Broadcaster.broadcast_key_block(block1, :v1, :mdw)
     assert_websocket_receive(clients, :kb, %{"payload" => %{"hash" => kb_hash2, "height" => 2}})
   end
 
@@ -325,7 +325,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
     %{hash: mb_hash1, height: 1, block: block1} = blocks[:mb1]
     %{hash: mb_hash2, height: 2, block: block2} = blocks[:mb2]
 
-    Broadcaster.broadcast_micro_block(block0, :node)
+    Broadcaster.broadcast_micro_block(block0, :v1, :node)
 
     assert_websocket_receive(clients, :mb, %{
       "payload" => %{"hash" => mb_hash0, "height" => 0},
@@ -333,7 +333,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
       "subscription" => "MicroBlocks"
     })
 
-    Broadcaster.broadcast_micro_block(block1, :node)
+    Broadcaster.broadcast_micro_block(block1, :v1, :node)
 
     assert_websocket_receive(clients, :mb, %{
       "payload" => %{"hash" => mb_hash1, "height" => 1},
@@ -341,7 +341,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
       "subscription" => "MicroBlocks"
     })
 
-    Broadcaster.broadcast_micro_block(block0, :mdw)
+    Broadcaster.broadcast_micro_block(block0, :v1, :mdw)
 
     assert_websocket_receive(clients, :mb, %{
       "payload" => %{"hash" => mb_hash0, "height" => 0},
@@ -349,7 +349,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
       "subscription" => "MicroBlocks"
     })
 
-    Broadcaster.broadcast_micro_block(block1, :mdw)
+    Broadcaster.broadcast_micro_block(block1, :v1, :mdw)
 
     assert_websocket_receive(clients, :mb, %{
       "payload" => %{"hash" => mb_hash1, "height" => 1},
@@ -357,19 +357,19 @@ defmodule AeMdw.Websocket.BroadcasterTest do
       "subscription" => "MicroBlocks"
     })
 
-    Broadcaster.broadcast_micro_block(block2, :node)
+    Broadcaster.broadcast_micro_block(block2, :v1, :node)
 
     assert_websocket_receive(clients, :mb, %{
       "payload" => %{"hash" => mb_hash2, "height" => 2}
     })
 
-    Broadcaster.broadcast_micro_block(block0, :node)
+    Broadcaster.broadcast_micro_block(block0, :v1, :node)
 
     assert_websocket_receive(clients, :mb, %{
       "payload" => %{"hash" => mb_hash2, "height" => 2}
     })
 
-    Broadcaster.broadcast_micro_block(block1, :mdw)
+    Broadcaster.broadcast_micro_block(block1, :v1, :mdw)
 
     assert_websocket_receive(clients, :mb, %{
       "payload" => %{"hash" => mb_hash2, "height" => 2}
@@ -388,7 +388,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
     tx_hash2 = encode(:tx_hash, :aetx_sign.hash(tx2))
     tx_hash3 = encode(:tx_hash, :aetx_sign.hash(tx3))
 
-    Broadcaster.broadcast_txs(block0, :node)
+    Broadcaster.broadcast_txs(block0, :v1, :node)
 
     assert_websocket_receive(clients, :txs, [
       %{
@@ -404,7 +404,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
     ])
 
     Enum.each(clients, &WsClient.delete_transactions/1)
-    Broadcaster.broadcast_txs(block1, :node)
+    Broadcaster.broadcast_txs(block1, :v1, :node)
 
     assert_websocket_receive(clients, :txs, [
       %{
@@ -430,7 +430,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
     ])
 
     Enum.each(clients, &WsClient.delete_transactions/1)
-    Broadcaster.broadcast_txs(block0, :mdw)
+    Broadcaster.broadcast_txs(block0, :v1, :mdw)
 
     assert_websocket_receive(clients, :txs, [
       %{
@@ -446,7 +446,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
     ])
 
     Enum.each(clients, &WsClient.delete_transactions/1)
-    Broadcaster.broadcast_txs(block1, :mdw)
+    Broadcaster.broadcast_txs(block1, :v1, :mdw)
 
     assert_websocket_receive(clients, :txs, [
       %{
@@ -472,7 +472,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
     ])
 
     Enum.each(clients, &WsClient.delete_transactions/1)
-    Broadcaster.broadcast_txs(block2, :node)
+    Broadcaster.broadcast_txs(block2, :v1, :node)
 
     assert_websocket_receive(clients, :txs, [
       %{
@@ -488,11 +488,11 @@ defmodule AeMdw.Websocket.BroadcasterTest do
     ])
 
     Enum.each(clients, &WsClient.delete_transactions/1)
-    Broadcaster.broadcast_txs(block0, :node)
+    Broadcaster.broadcast_txs(block0, :v1, :node)
     assert_websocket_receive(clients, :txs, [])
 
     Enum.each(clients, &WsClient.delete_transactions/1)
-    Broadcaster.broadcast_txs(block1, :mdw)
+    Broadcaster.broadcast_txs(block1, :v1, :mdw)
     assert_websocket_receive(clients, :txs, [])
   end
 

--- a/test/ae_mdw/websocket/socket_handler_test.exs
+++ b/test/ae_mdw/websocket/socket_handler_test.exs
@@ -114,7 +114,7 @@ defmodule AeMdw.Websocket.SocketHandlerTest do
 
       account_id = encode(:account_pubkey, <<1::256>>)
       contract_id = encode(:contract_pubkey, <<2::256>>)
-      oracle_id = encode(:oracle_pubkey, <<1::256>>)
+      oracle_id = encode(:oracle_pubkey, <<3::256>>)
       name_id = encode(:name, <<4::256>>)
       channel_id = encode(:channel, <<5::256>>)
 

--- a/test/ae_mdw/websocket/subscriptions_test.exs
+++ b/test/ae_mdw/websocket/subscriptions_test.exs
@@ -40,6 +40,15 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
       assert {:ok, [^channel]} = Subscriptions.subscribe(pid, :v1, channel)
       assert {:error, :already_subscribed} = Subscriptions.subscribe(pid, :v1, channel)
     end
+
+    test "does not allow duplicate subscription of account and oracle with same pubkey" do
+      pid = new_pid()
+      channel = encode(:account_pubkey, <<13::256>>)
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid, :v2, channel)
+
+      channel = encode(:oracle_pubkey, <<13::256>>)
+      assert {:error, :already_subscribed} = Subscriptions.subscribe(pid, :v2, channel)
+    end
   end
 
   describe "unsubscribe/2" do
@@ -68,6 +77,16 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
     test "returns error on uknonw unsubscription" do
       assert {:error, :not_subscribed} = Subscriptions.unsubscribe(new_pid(), :v1, "KeyBlocks")
+    end
+
+    test "allowed for account and oracle with same pubkey" do
+      pid = new_pid()
+      channel = encode(:account_pubkey, <<14::256>>)
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid, :v2, channel)
+
+      channel = encode(:oracle_pubkey, <<14::256>>)
+      assert {:ok, []} = Subscriptions.unsubscribe(pid, :v2, channel)
+      assert {:error, :not_subscribed} = Subscriptions.unsubscribe(pid, :v2, channel)
     end
   end
 

--- a/test/ae_mdw/websocket/subscriptions_test.exs
+++ b/test/ae_mdw/websocket/subscriptions_test.exs
@@ -15,26 +15,30 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
       on_exit(fn -> unsubscribe_all([pid1, pid2, pid3]) end)
 
-      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, "KeyBlocks")
-      assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, "MicroBlocks")
-      assert {:ok, ["KeyBlocks", "Transactions"]} = Subscriptions.subscribe(pid1, "Transactions")
+      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, :v1, "KeyBlocks")
+      assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, :v1, "MicroBlocks")
+
+      assert {:ok, ["KeyBlocks", "Transactions"]} =
+               Subscriptions.subscribe(pid1, :v1, "Transactions")
 
       channel = encode(:account_pubkey, <<11::256>>)
-      assert {:ok, [^channel]} = Subscriptions.subscribe(pid3, channel)
-      assert {:ok, [^channel, "Transactions"]} = Subscriptions.subscribe(pid3, "Transactions")
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid3, :v1, channel)
+
+      assert {:ok, [^channel, "Transactions"]} =
+               Subscriptions.subscribe(pid3, :v1, "Transactions")
     end
 
     test "returns invalid channel when unknown and not a valid id" do
       channel = "ak_2iK7D3t5xyN8GHxQktvBnfoC3tpq1eVMzTpABQY72FXRfg3HMZ"
       assert {:error, _reason} = Validate.id(channel)
-      assert {:error, :invalid_channel} = Subscriptions.subscribe(new_pid(), channel)
+      assert {:error, :invalid_channel} = Subscriptions.subscribe(new_pid(), :v1, channel)
     end
 
     test "returns error on duplicate subscriptions" do
       pid = new_pid()
       channel = encode(:account_pubkey, <<12::256>>)
-      assert {:ok, [^channel]} = Subscriptions.subscribe(pid, channel)
-      assert {:error, :already_subscribed} = Subscriptions.subscribe(pid, channel)
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid, :v1, channel)
+      assert {:error, :already_subscribed} = Subscriptions.subscribe(pid, :v1, channel)
     end
   end
 
@@ -45,22 +49,25 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
       on_exit(fn -> unsubscribe_all([pid1, pid2]) end)
 
-      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, "KeyBlocks")
-      assert {:ok, ["KeyBlocks", "Transactions"]} = Subscriptions.subscribe(pid1, "Transactions")
-      assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, "MicroBlocks")
+      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, :v1, "KeyBlocks")
 
-      assert {:ok, ["Transactions"]} = Subscriptions.unsubscribe(pid1, "KeyBlocks")
-      assert {:ok, []} = Subscriptions.unsubscribe(pid2, "MicroBlocks")
+      assert {:ok, ["KeyBlocks", "Transactions"]} =
+               Subscriptions.subscribe(pid1, :v1, "Transactions")
+
+      assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, :v1, "MicroBlocks")
+
+      assert {:ok, ["Transactions"]} = Subscriptions.unsubscribe(pid1, :v1, "KeyBlocks")
+      assert {:ok, []} = Subscriptions.unsubscribe(pid2, :v1, "MicroBlocks")
     end
 
     test "returns error when channel is unknown and not a valid id" do
       pk_channel = "ak_2iK7D3t5xyN8GHxQktvBnfoC3tpq1eVMzTpABQY72FXRfg3HMZ"
       assert {:error, _reason} = Validate.id(pk_channel)
-      assert {:error, :invalid_channel} = Subscriptions.unsubscribe(new_pid(), pk_channel)
+      assert {:error, :invalid_channel} = Subscriptions.unsubscribe(new_pid(), :v1, pk_channel)
     end
 
     test "returns error on uknonw unsubscription" do
-      assert {:error, :not_subscribed} = Subscriptions.unsubscribe(new_pid(), "KeyBlocks")
+      assert {:error, :not_subscribed} = Subscriptions.unsubscribe(new_pid(), :v1, "KeyBlocks")
     end
   end
 
@@ -72,19 +79,19 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
       on_exit(fn -> unsubscribe_all([pid1, pid2, pid3]) end)
 
-      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, "KeyBlocks")
+      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, :v1, "KeyBlocks")
       channel = encode(:account_pubkey, <<13::256>>)
-      assert {:ok, [^channel]} = Subscriptions.subscribe(pid2, channel)
-      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid3, "KeyBlocks")
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid2, :v1, channel)
+      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid3, :v1, "KeyBlocks")
 
-      list = Subscriptions.subscribers("KeyBlocks")
+      list = Subscriptions.subscribers(:v1, "KeyBlocks")
       assert pid1 in list and pid3 in list
-      assert [^pid2] = Subscriptions.subscribers(Validate.id!(channel))
+      assert [^pid2] = Subscriptions.subscribers(:v1, channel)
     end
 
     test "returns empty list when there are none for a channel" do
       channel = encode(:account_pubkey, <<14::256>>)
-      assert [] = Subscriptions.subscribers(channel)
+      assert [] = Subscriptions.subscribers(:v1, channel)
     end
   end
 
@@ -95,9 +102,9 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
       on_exit(fn -> unsubscribe_all([pid1, pid2]) end)
 
-      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, "KeyBlocks")
+      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, :v1, "KeyBlocks")
       channel = encode(:account_pubkey, <<15::256>>)
-      assert {:ok, [^channel]} = Subscriptions.subscribe(pid2, channel)
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid2, :v1, channel)
 
       assert ["KeyBlocks"] = Subscriptions.subscribed_channels(pid1)
       assert [^channel] = Subscriptions.subscribed_channels(pid2)
@@ -109,8 +116,8 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
       on_exit(fn -> unsubscribe_all([pid1, pid2]) end)
 
-      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, "KeyBlocks")
-      assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, "MicroBlocks")
+      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, :v1, "KeyBlocks")
+      assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, :v1, "MicroBlocks")
 
       assert ["KeyBlocks"] = Subscriptions.subscribed_channels(pid1)
       Process.exit(pid1, :kill)

--- a/test/integration/ae_mdw_web/websocket_test.exs
+++ b/test/integration/ae_mdw_web/websocket_test.exs
@@ -433,20 +433,20 @@ defmodule Integration.AeMdwWeb.WebsocketTest do
       assert_receive [^recipient_id], 200
 
       {key_block, micro_blocks} = get_blocks(state, 311_860)
-      Broadcaster.broadcast_key_block(key_block, :mdw)
+      Broadcaster.broadcast_key_block(key_block, :v1, :mdw)
       Process.send_after(client1, {:kb, self()}, 100)
 
       kb_payload = @key_block_mdw
       assert_receive ^kb_payload, 300
 
       [mb1 | _] = micro_blocks
-      Broadcaster.broadcast_micro_block(mb1, :mdw)
+      Broadcaster.broadcast_micro_block(mb1, :v1, :mdw)
       Process.send_after(client2, {:mb, self()}, 100)
 
       mb1_payload = @micro_block_mdw
       assert_receive ^mb1_payload, 300
 
-      Broadcaster.broadcast_txs(mb1, :mdw)
+      Broadcaster.broadcast_txs(mb1, :v1, :mdw)
       Process.send_after(client3, {:tx, self()}, 200)
       Process.send_after(client4, {:obj, self()}, 200)
 
@@ -475,11 +475,11 @@ defmodule Integration.AeMdwWeb.WebsocketTest do
       assert_receive ["KeyBlocks", "MicroBlocks", "Transactions", ^recipient_id], 200
 
       {key_block, micro_blocks} = get_blocks(state, 311_860)
-      Broadcaster.broadcast_key_block(key_block, :mdw)
-      Broadcaster.broadcast_key_block(key_block, :mdw)
-      Broadcaster.broadcast_key_block(key_block, :mdw)
-      Broadcaster.broadcast_key_block(key_block, :node)
-      Broadcaster.broadcast_key_block(key_block, :node)
+      Broadcaster.broadcast_key_block(key_block, :v1, :mdw)
+      Broadcaster.broadcast_key_block(key_block, :v1, :mdw)
+      Broadcaster.broadcast_key_block(key_block, :v1, :mdw)
+      Broadcaster.broadcast_key_block(key_block, :v1, :node)
+      Broadcaster.broadcast_key_block(key_block, :v1, :node)
       Process.send_after(client, {:kb, self()}, 100)
 
       kb_payload = @key_block_mdw
@@ -488,13 +488,13 @@ defmodule Integration.AeMdwWeb.WebsocketTest do
       assert_receive ^kb_payload_node, 300
 
       [mb1 | _rest] = micro_blocks
-      Broadcaster.broadcast_micro_block(mb1, :mdw)
+      Broadcaster.broadcast_micro_block(mb1, :v1, :mdw)
       Process.send_after(client, {:mb, self()}, 100)
 
       mb1_payload = @micro_block_mdw
       assert_receive ^mb1_payload, 300
 
-      Broadcaster.broadcast_txs(mb1, :mdw)
+      Broadcaster.broadcast_txs(mb1, :v1, :mdw)
       Process.send_after(client, {:tx, self()}, 200)
       Process.send_after(client, {:obj, self()}, 200)
 

--- a/test/support/ws_util.ex
+++ b/test/support/ws_util.ex
@@ -1,8 +1,6 @@
 defmodule Support.WsUtil do
   # credo:disable-for-this-file
 
-  alias AeMdw.Validate
-
   def unsubscribe_all(pids) when is_list(pids) do
     Enum.each(pids, &do_unsubscribe_all/1)
   end
@@ -12,12 +10,8 @@ defmodule Support.WsUtil do
 
     :subs_pid_channel
     |> :ets.match_object({pid, :"$1"})
-    |> Enum.each(fn {^pid, channel} ->
-      :ets.delete_object(:subs_pid_channel, {pid, channel})
-
-      channel_key =
-        if String.starts_with?(channel, "ak"), do: Validate.id!(channel), else: channel
-
+    |> Enum.each(fn {^pid, channel_key} ->
+      :ets.delete_object(:subs_pid_channel, {pid, channel_key})
       :ets.delete_object(:subs_channel_pid, {channel_key, pid})
     end)
   end


### PR DESCRIPTION
To connect to the v2 websocket a param needs to be passsed when establishing the WS connection: `/websocket?version=2`

These new websocket messages will:

* Contain the additional block/tx information that the middleware already provides in the `/v2/key-blocks/:height`, `/v2/micro-blocks/:hash` and `/v2/txs/:hash` endpoints.
* Order the blocks emitted in the order from the chain: for each generation the key-block is emitted before the generation micro-blocks.