### PR TITLE
feat: track nft template edition supply 

### DIFF
--- a/lib/ae_mdw/aex141.ex
+++ b/lib/ae_mdw/aex141.ex
@@ -294,7 +294,7 @@ defmodule AeMdw.Aex141 do
   defp render_template_edition(state, contract_pk, template_id, limit) do
     stats_key = Stats.nft_template_tokens_key(contract_pk, template_id)
 
-    if nil != limit or :not_found != State.get(state, Model.Stat, stats_key) do
+    if nil != limit or State.exists?(state, Model.Stat, stats_key) do
       state
       |> render_template_edition_limit(limit)
       |> Map.merge(render_template_edition_supply(state, contract_pk, template_id))

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -454,17 +454,29 @@ defmodule AeMdw.Db.Model do
   #     txi: creation txi
   #     log_idx: creation event
   #     limit: {amount, txi, log_idx} | nil
-  #     supply: {tokens, txi, log_idx} | nil
-  @nft_template_defaults [index: {<<>>, -1}, txi: nil, log_idx: nil, limit: nil, supply: nil]
+  @nft_template_defaults [index: {<<>>, -1}, txi: nil, log_idx: nil, limit: nil]
   defrecord :nft_template, @nft_template_defaults
 
   @type nft_template() ::
           record(:nft_template,
             index: {pubkey(), integer()},
-            txi: txi() | nil,
-            log_idx: log_idx() | nil,
-            limit: {pos_integer(), txi(), log_idx()} | nil,
-            supply: {[pos_integer], txi(), log_idx()} | nil
+            txi: txi(),
+            log_idx: log_idx(),
+            limit: {pos_integer(), txi(), log_idx()} | nil
+          )
+
+  # AEX-141 template token
+  #     index: {contract pubkey, template_id, token_id}
+  #     txi: mint txi
+  #     log_idx: mint log_idx
+  @nft_template_token_defaults [index: {<<>>, -1, -1}, txi: nil, log_idx: nil]
+  defrecord :nft_template_token, @nft_template_token_defaults
+
+  @type nft_template_token() ::
+          record(:nft_template_token,
+            index: {pubkey(), AeMdw.Aex141.template_id(), AeMdw.Aex141.token_id()},
+            txi: txi(),
+            log_idx: log_idx()
           )
 
   # AEX-141 token template
@@ -475,7 +487,7 @@ defmodule AeMdw.Db.Model do
   @type nft_token_template() ::
           record(:nft_token_template,
             index: {pubkey(), AeMdw.Aex141.token_id()},
-            template: pos_integer()
+            template: AeMdw.Aex141.template_id()
           )
 
   # AEX-141 collection owners
@@ -1056,7 +1068,8 @@ defmodule AeMdw.Db.Model do
       AeMdw.Db.Model.NftTokenOwner,
       AeMdw.Db.Model.NftContractLimits,
       AeMdw.Db.Model.NftTokenTemplate,
-      AeMdw.Db.Model.NftTemplate
+      AeMdw.Db.Model.NftTemplate,
+      AeMdw.Db.Model.NftTemplateToken
     ]
   end
 
@@ -1154,6 +1167,7 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.NftContractLimits), do: :nft_contract_limits
   def record(AeMdw.Db.Model.NftTokenTemplate), do: :nft_token_template
   def record(AeMdw.Db.Model.NftTemplate), do: :nft_template
+  def record(AeMdw.Db.Model.NftTemplateToken), do: :nft_template_token
   def record(AeMdw.Db.Model.PlainName), do: :plain_name
   def record(AeMdw.Db.Model.AuctionBid), do: :auction_bid
   def record(AeMdw.Db.Model.Pointee), do: :pointee

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -40,6 +40,8 @@ defmodule AeMdw.Db.Model do
   @typep amount() :: non_neg_integer()
   @typep fname() :: Contract.fname()
 
+  @typep token_id :: AeMdw.Aex141.token_id()
+  @typep template_id :: AeMdw.Aex141.template_id()
   ################################################################################
 
   # index is timestamp (daylight saving order should be handle case by case)
@@ -445,8 +447,8 @@ defmodule AeMdw.Db.Model do
 
   @type nft_ownership() ::
           record(:nft_ownership,
-            index: {pubkey(), pubkey(), AeMdw.Aex141.token_id()},
-            template_id: integer()
+            index: {pubkey(), pubkey(), token_id()},
+            template_id: template_id()
           )
 
   # AEX-141 templates
@@ -474,7 +476,7 @@ defmodule AeMdw.Db.Model do
 
   @type nft_template_token() ::
           record(:nft_template_token,
-            index: {pubkey(), AeMdw.Aex141.template_id(), AeMdw.Aex141.token_id()},
+            index: {pubkey(), template_id(), token_id()},
             txi: txi(),
             log_idx: log_idx()
           )
@@ -486,8 +488,8 @@ defmodule AeMdw.Db.Model do
 
   @type nft_token_template() ::
           record(:nft_token_template,
-            index: {pubkey(), AeMdw.Aex141.token_id()},
-            template: AeMdw.Aex141.template_id()
+            index: {pubkey(), token_id()},
+            template: template_id()
           )
 
   # AEX-141 collection owners

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -454,7 +454,8 @@ defmodule AeMdw.Db.Model do
   #     txi: creation txi
   #     log_idx: creation event
   #     limit: {amount, txi, log_idx} | nil
-  @nft_template_defaults [index: {<<>>, -1}, txi: nil, log_idx: nil, limit: nil]
+  #     supply: {tokens, txi, log_idx} | nil
+  @nft_template_defaults [index: {<<>>, -1}, txi: nil, log_idx: nil, limit: nil, supply: nil]
   defrecord :nft_template, @nft_template_defaults
 
   @type nft_template() ::
@@ -462,7 +463,19 @@ defmodule AeMdw.Db.Model do
             index: {pubkey(), integer()},
             txi: txi() | nil,
             log_idx: log_idx() | nil,
-            limit: {pos_integer(), txi(), log_idx()} | nil
+            limit: {pos_integer(), txi(), log_idx()} | nil,
+            supply: {[pos_integer], txi(), log_idx()} | nil
+          )
+
+  # AEX-141 token template
+  #     index: {contract pubkey, token_id}, template: template id
+  @nft_token_template_defaults [index: {<<>>, -1}, template: nil]
+  defrecord :nft_token_template, @nft_token_template_defaults
+
+  @type nft_token_template() ::
+          record(:nft_token_template,
+            index: {pubkey(), AeMdw.Aex141.token_id()},
+            template: pos_integer()
           )
 
   # AEX-141 collection owners
@@ -1042,6 +1055,7 @@ defmodule AeMdw.Db.Model do
       AeMdw.Db.Model.NftOwnerToken,
       AeMdw.Db.Model.NftTokenOwner,
       AeMdw.Db.Model.NftContractLimits,
+      AeMdw.Db.Model.NftTokenTemplate,
       AeMdw.Db.Model.NftTemplate
     ]
   end
@@ -1138,6 +1152,7 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.NftOwnerToken), do: :nft_owner_token
   def record(AeMdw.Db.Model.NftTokenOwner), do: :nft_token_owner
   def record(AeMdw.Db.Model.NftContractLimits), do: :nft_contract_limits
+  def record(AeMdw.Db.Model.NftTokenTemplate), do: :nft_token_template
   def record(AeMdw.Db.Model.NftTemplate), do: :nft_template
   def record(AeMdw.Db.Model.PlainName), do: :plain_name
   def record(AeMdw.Db.Model.AuctionBid), do: :auction_bid

--- a/lib/ae_mdw/db/sync/stats.ex
+++ b/lib/ae_mdw/db/sync/stats.ex
@@ -11,6 +11,7 @@ defmodule AeMdw.Db.Sync.Stats do
   require Model
 
   @typep pubkey :: AeMdw.Node.Db.pubkey()
+  @typep template_id :: AeMdw.Aex141.template_id()
 
   @spec update_nft_stats(State.t(), pubkey(), nil | pubkey(), nil | pubkey()) :: State.t()
   def update_nft_stats(state, contract_pk, prev_owner_pk, to_pk) do
@@ -19,6 +20,19 @@ defmodule AeMdw.Db.Sync.Stats do
     |> decrement_collection_owners(contract_pk, prev_owner_pk)
     |> increment_collection_owners(contract_pk, to_pk)
   end
+
+  @spec increment_nft_template_tokens(State.t(), pubkey(), template_id()) :: State.t()
+  def increment_nft_template_tokens(state, contract_pk, template_id),
+    do: update_stat_counter(state, Stats.nft_template_tokens_key(contract_pk, template_id))
+
+  @spec decrement_nft_template_tokens(State.t(), pubkey(), template_id()) :: State.t()
+  def decrement_nft_template_tokens(state, contract_pk, template_id),
+    do:
+      update_stat_counter(
+        state,
+        Stats.nft_template_tokens_key(contract_pk, template_id),
+        &(&1 - 1)
+      )
 
   defp increment_collection_nfts(state, contract_pk, nil),
     do: update_stat_counter(state, Stats.nfts_count_key(contract_pk))

--- a/lib/ae_mdw/stats.ex
+++ b/lib/ae_mdw/stats.ex
@@ -30,10 +30,12 @@ defmodule AeMdw.Stats do
   @typep range() :: {:gen, Range.t()} | nil
 
   @type nft_stats :: %{nfts_amount: non_neg_integer(), nft_owners: non_neg_integer()}
+  @typep template_id() :: AeMdw.Aex141.template_id()
   @tps_stat_key :max_tps
   @miners_count_stat_key :miners_count
   @nfts_count_stat :nfts_count
   @nft_owners_count_stat :nft_owners_count
+  @nft_template_tokens_stat :nft_template_tokens_count
 
   @spec mutation(height(), Db.key_block(), [Db.micro_block()], txi(), txi(), boolean()) ::
           StatsMutation.t()
@@ -64,6 +66,10 @@ defmodule AeMdw.Stats do
 
   @spec nfts_count_key(pubkey()) :: {atom(), pubkey()}
   def nfts_count_key(contract_pk), do: {@nfts_count_stat, contract_pk}
+
+  @spec nft_template_tokens_key(pubkey(), template_id()) :: {atom(), pubkey(), template_id()}
+  def nft_template_tokens_key(contract_pk, template_id),
+    do: {@nft_template_tokens_stat, contract_pk, template_id}
 
   @spec nft_owners_count_key(pubkey()) :: {atom(), pubkey()}
   def nft_owners_count_key(contract_pk), do: {@nft_owners_count_stat, contract_pk}

--- a/lib/ae_mdw_web/controllers/aex141_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex141_controller.ex
@@ -49,6 +49,25 @@ defmodule AeMdwWeb.Aex141Controller do
     end
   end
 
+  @spec collection_template_tokens(Conn.t(), map()) :: Conn.t() | {:error, ErrInput.t()}
+  def collection_template_tokens(%Conn{assigns: assigns} = conn, %{
+        "contract_id" => contract_id,
+        "template_id" => template_id
+      }) do
+    %{
+      state: state,
+      pagination: pagination,
+      cursor: cursor
+    } = assigns
+
+    with {:ok, contract_pk} <- Validate.id(contract_id),
+         {template_id, ""} <- Integer.parse(template_id),
+         {:ok, {prev_cursor, template_tokens, next_cursor}} <-
+           Aex141.fetch_template_tokens(state, contract_pk, template_id, cursor, pagination) do
+      WebUtil.paginate(conn, prev_cursor, template_tokens, next_cursor)
+    end
+  end
+
   @spec nft_owner(Conn.t(), map()) :: Conn.t()
   def nft_owner(conn, %{"contract_id" => contract_id, "token_id" => token_id}) do
     with {:ok, contract_pk} <- Validate.id(contract_id, [:contract_pubkey]),

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -16,6 +16,8 @@ defmodule AeMdwWeb.Router do
     {"/aex141/:contract_id/owner/:token_id", AeMdwWeb.Aex141Controller, :nft_owner},
     {"/aex141/:contract_id/owners", AeMdwWeb.Aex141Controller, :collection_owners},
     {"/aex141/:contract_id/templates", AeMdwWeb.Aex141Controller, :collection_templates},
+    {"/aex141/:contract_id/templates/:template_id", AeMdwWeb.Aex141Controller,
+     :collection_template_tokens},
     {"/aex141/owned-nfts/:account_id", AeMdwWeb.Aex141Controller, :owned_nfts}
   ]
 

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -16,7 +16,7 @@ defmodule AeMdwWeb.Router do
     {"/aex141/:contract_id/owner/:token_id", AeMdwWeb.Aex141Controller, :nft_owner},
     {"/aex141/:contract_id/owners", AeMdwWeb.Aex141Controller, :collection_owners},
     {"/aex141/:contract_id/templates", AeMdwWeb.Aex141Controller, :collection_templates},
-    {"/aex141/:contract_id/templates/:template_id", AeMdwWeb.Aex141Controller,
+    {"/aex141/:contract_id/templates/:template_id/tokens", AeMdwWeb.Aex141Controller,
      :collection_template_tokens},
     {"/aex141/owned-nfts/:account_id", AeMdwWeb.Aex141Controller, :owned_nfts}
   ]

--- a/test/ae_mdw_web/controllers/aex141_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex141_controller_test.exs
@@ -28,7 +28,7 @@ defmodule AeMdwWeb.Aex141ControllerTest do
       |> MemStore.new()
 
     store =
-      Enum.reduce(1_411..1_413, empty_store, fn i, store ->
+      Enum.reduce(1_411..1_414, empty_store, fn i, store ->
         meta_info = {"some-nft-#{i}", "SAEX#{i}", "http://some-url.com", :url}
         txi = 1_000 + i
 
@@ -75,7 +75,7 @@ defmodule AeMdwWeb.Aex141ControllerTest do
             limit: {template_id * 10, txi + 100, log_idx + 1}
           )
 
-        m_template_token3 =
+        m_template_token =
           Model.nft_template_token(
             index: {contract_pk, template_id, token_id + 2},
             txi: txi + 200,
@@ -88,7 +88,7 @@ defmodule AeMdwWeb.Aex141ControllerTest do
         store =
           store
           |> Store.put(Model.NftTemplate, m_template)
-          |> Store.put(Model.NftTemplateToken, m_template_token3)
+          |> Store.put(Model.NftTemplateToken, m_template_token)
           |> Store.put(Model.Stat, m_stat)
           |> Store.put(Model.Tx, Model.tx(index: txi, id: <<txi::256>>))
           |> Store.put(Model.Tx, Model.tx(index: txi + 100, id: <<txi + 100::256>>))
@@ -104,6 +104,49 @@ defmodule AeMdwWeb.Aex141ControllerTest do
         end
       end)
 
+    contract_pk = <<1_414::256>>
+    template_id = 10
+
+    m_template =
+      Model.nft_template(
+        index: {contract_pk, template_id},
+        txi: 1_414_000,
+        log_idx: 0
+      )
+
+    store =
+      store
+      |> Store.put(Model.Tx, Model.tx(index: 1_414_000, id: <<1_414_000::256>>))
+      |> Store.put(Model.NftTemplate, Model.nft_template(m_template, index: {contract_pk, 1}))
+      |> Store.put(Model.NftTemplate, m_template)
+
+    store =
+      Enum.reduce(1_414_001..1_414_040, store, fn j, store ->
+        token_id = j - 1_414_000
+        owner_pk = if rem(j, 2) == 0, do: @owner_pk1, else: @owner_pk2
+
+        m_ownership = Model.nft_ownership(index: {owner_pk, contract_pk, token_id})
+        m_owner_token = Model.nft_owner_token(index: {contract_pk, owner_pk, token_id})
+        m_token_owner = Model.nft_token_owner(index: {contract_pk, token_id}, owner: owner_pk)
+
+        txi = j
+        log_idx = rem(token_id, 2)
+
+        m_template_token =
+          Model.nft_template_token(
+            index: {contract_pk, template_id, token_id},
+            txi: txi + 200,
+            log_idx: log_idx + 2
+          )
+
+        store
+        |> Store.put(Model.NftOwnership, m_ownership)
+        |> Store.put(Model.NftOwnerToken, m_owner_token)
+        |> Store.put(Model.NftTokenOwner, m_token_owner)
+        |> Store.put(Model.NftTemplateToken, m_template_token)
+        |> Store.put(Model.Tx, Model.tx(index: txi + 200, id: <<txi + 200::256>>))
+      end)
+
     owner_pk = :crypto.strong_rand_bytes(32)
     token_id = 1_413_010
     m_ownership = Model.nft_ownership(index: {owner_pk, contract_pk, token_id})
@@ -116,7 +159,7 @@ defmodule AeMdwWeb.Aex141ControllerTest do
       |> Store.put(Model.NftOwnerToken, m_owner_token)
       |> Store.put(Model.NftTokenOwner, m_token_owner)
 
-    [conn: with_store(build_conn(), store), random_owner_pk: owner_pk]
+    [conn: with_store(build_conn(), store), random_owner_pk: owner_pk, store: store]
   end
 
   describe "aex141_contract" do
@@ -620,6 +663,83 @@ defmodule AeMdwWeb.Aex141ControllerTest do
       assert Enum.all?(next_templates, &(&1["contract_id"] == contract_id))
 
       assert %{"data" => ^templates} = conn |> get(prev_templates) |> json_response(200)
+    end
+  end
+
+  describe "collection_template_tokens" do
+    test "returns an empty list when collection has no nft from template", %{conn: conn} do
+      contract_id = encode_contract(<<1_414::256>>)
+
+      assert %{"data" => [], "next" => nil, "prev" => nil} =
+               conn
+               |> get("/aex141/#{contract_id}/templates/1")
+               |> json_response(200)
+    end
+
+    test "returns collection templates sorted by ascending ids", %{
+      conn: conn,
+      store: store
+    } do
+      contract_pk = <<1_414::256>>
+      contract_id = encode_contract(contract_pk)
+      template_id = 10
+
+      assert %{"data" => template_tokens, "next" => next} =
+               conn
+               |> get("/v2/aex141/#{contract_id}/templates/#{template_id}", direction: :forward)
+               |> json_response(200)
+
+      assert @default_limit = length(template_tokens)
+      assert ^template_tokens = Enum.sort_by(template_tokens, & &1["token_id"])
+
+      assert template_tokens
+             |> Enum.with_index(1)
+             |> Enum.all?(fn {%{
+                                "token_id" => token_id,
+                                "owner_id" => owner_id,
+                                "tx_hash" => tx_hash,
+                                "log_idx" => log_idx
+                              }, token_id} ->
+               tx_hash = Validate.id!(tx_hash)
+               owner_pk = Validate.id!(owner_id)
+
+               {:ok, Model.nft_token_owner(owner: ^owner_pk)} =
+                 Store.get(store, Model.NftTokenOwner, {contract_pk, token_id})
+
+               tx_hash == <<1_414_000 + token_id + 200::256>> and log_idx == rem(token_id, 2) + 2
+             end)
+
+      assert %{"data" => next_template_tokens, "prev" => prev_template_tokens} =
+               conn |> get(next) |> json_response(200)
+
+      assert @default_limit = length(next_template_tokens)
+      assert ^next_template_tokens = Enum.sort_by(next_template_tokens, & &1["token_id"])
+
+      assert %{"data" => ^template_tokens} =
+               conn |> get(prev_template_tokens) |> json_response(200)
+    end
+
+    test "returns collection templates sorted by descending ids", %{conn: conn} do
+      contract_pk = <<1_414::256>>
+      contract_id = encode_contract(contract_pk)
+      template_id = 10
+
+      assert %{"data" => template_tokens, "next" => next} =
+               conn
+               |> get("/v2/aex141/#{contract_id}/templates/#{template_id}")
+               |> json_response(200)
+
+      assert @default_limit = length(template_tokens)
+      assert ^template_tokens = Enum.sort_by(template_tokens, & &1["token_id"], :desc)
+
+      assert %{"data" => next_template_tokens, "prev" => prev_template_tokens} =
+               conn |> get(next) |> json_response(200)
+
+      assert @default_limit = length(next_template_tokens)
+      assert ^next_template_tokens = Enum.sort_by(next_template_tokens, & &1["token_id"], :desc)
+
+      assert %{"data" => ^template_tokens} =
+               conn |> get(prev_template_tokens) |> json_response(200)
     end
   end
 end

--- a/test/ae_mdw_web/controllers/aex141_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex141_controller_test.exs
@@ -72,13 +72,24 @@ defmodule AeMdwWeb.Aex141ControllerTest do
             index: {contract_pk, template_id},
             txi: txi,
             log_idx: log_idx,
-            limit: {template_id * 10, txi + 100, log_idx + 1},
-            supply: {[1, 2, 3], txi + 200, log_idx + 2}
+            limit: {template_id * 10, txi + 100, log_idx + 1}
           )
+
+        m_template_token3 =
+          Model.nft_template_token(
+            index: {contract_pk, template_id, token_id + 2},
+            txi: txi + 200,
+            log_idx: log_idx + 2
+          )
+
+        m_stat =
+          Model.stat(index: Stats.nft_template_tokens_key(contract_pk, template_id), payload: 3)
 
         store =
           store
           |> Store.put(Model.NftTemplate, m_template)
+          |> Store.put(Model.NftTemplateToken, m_template_token3)
+          |> Store.put(Model.Stat, m_stat)
           |> Store.put(Model.Tx, Model.tx(index: txi, id: <<txi::256>>))
           |> Store.put(Model.Tx, Model.tx(index: txi + 100, id: <<txi + 100::256>>))
           |> Store.put(Model.Tx, Model.tx(index: txi + 200, id: <<txi + 200::256>>))
@@ -550,7 +561,7 @@ defmodule AeMdwWeb.Aex141ControllerTest do
                                          "limit" => edition_limit,
                                          "limit_tx_hash" => limit_tx_hash,
                                          "limit_log_idx" => limit_log_idx,
-                                         "supply_tokens" => [1, 2, 3],
+                                         "supply" => 3,
                                          "supply_tx_hash" => supply_tx_hash,
                                          "supply_log_idx" => supply_log_idx
                                        }

--- a/test/ae_mdw_web/controllers/aex141_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex141_controller_test.exs
@@ -672,7 +672,7 @@ defmodule AeMdwWeb.Aex141ControllerTest do
 
       assert %{"data" => [], "next" => nil, "prev" => nil} =
                conn
-               |> get("/aex141/#{contract_id}/templates/1")
+               |> get("/aex141/#{contract_id}/templates/1/tokens")
                |> json_response(200)
     end
 
@@ -686,7 +686,9 @@ defmodule AeMdwWeb.Aex141ControllerTest do
 
       assert %{"data" => template_tokens, "next" => next} =
                conn
-               |> get("/v2/aex141/#{contract_id}/templates/#{template_id}", direction: :forward)
+               |> get("/v2/aex141/#{contract_id}/templates/#{template_id}/tokens",
+                 direction: :forward
+               )
                |> json_response(200)
 
       assert @default_limit = length(template_tokens)
@@ -726,7 +728,7 @@ defmodule AeMdwWeb.Aex141ControllerTest do
 
       assert %{"data" => template_tokens, "next" => next} =
                conn
-               |> get("/v2/aex141/#{contract_id}/templates/#{template_id}")
+               |> get("/v2/aex141/#{contract_id}/templates/#{template_id}/tokens")
                |> json_response(200)
 
       assert @default_limit = length(template_tokens)

--- a/test/ae_mdw_web/controllers/aex141_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex141_controller_test.exs
@@ -72,7 +72,8 @@ defmodule AeMdwWeb.Aex141ControllerTest do
             index: {contract_pk, template_id},
             txi: txi,
             log_idx: log_idx,
-            limit: {template_id * 10, txi + 100, log_idx + 1}
+            limit: {template_id * 10, txi + 100, log_idx + 1},
+            supply: {[1, 2, 3], txi + 200, log_idx + 2}
           )
 
         store =
@@ -80,6 +81,7 @@ defmodule AeMdwWeb.Aex141ControllerTest do
           |> Store.put(Model.NftTemplate, m_template)
           |> Store.put(Model.Tx, Model.tx(index: txi, id: <<txi::256>>))
           |> Store.put(Model.Tx, Model.tx(index: txi + 100, id: <<txi + 100::256>>))
+          |> Store.put(Model.Tx, Model.tx(index: txi + 200, id: <<txi + 200::256>>))
 
         if token_id != 1_413_010 do
           store
@@ -547,17 +549,23 @@ defmodule AeMdwWeb.Aex141ControllerTest do
                                        "edition" => %{
                                          "limit" => edition_limit,
                                          "limit_tx_hash" => limit_tx_hash,
-                                         "limit_log_idx" => limit_log_idx
+                                         "limit_log_idx" => limit_log_idx,
+                                         "supply_tokens" => [1, 2, 3],
+                                         "supply_tx_hash" => supply_tx_hash,
+                                         "supply_log_idx" => supply_log_idx
                                        }
                                      } ->
                tx_hash = Validate.id!(tx_hash)
                limit_tx_hash = Validate.id!(limit_tx_hash)
+               supply_tx_hash = Validate.id!(supply_tx_hash)
 
                ct_id == contract_id and template_id in 1..10 and
                  tx_hash == <<template_id + 1_413_000::256>> and log_idx == rem(template_id, 2) and
                  edition_limit == template_id * 10 and
                  limit_tx_hash == <<template_id + 1_413_100::256>> and
-                 limit_log_idx == rem(template_id, 2) + 1
+                 limit_log_idx == rem(template_id, 2) + 1 and
+                 supply_tx_hash == <<template_id + 1_413_200::256>> and
+                 supply_log_idx == rem(template_id, 2) + 2
              end)
 
       assert %{"data" => next_templates, "prev" => prev_templates} =


### PR DESCRIPTION
## What

- Adds endpoint `/aex141/:contract_id/templates/:template_id/tokens`
- Adds supply info to `/aex141/:contract_id/templates` edition response field

## Why

- Final request from @marc0olo to allow comparing the template edition limit to the actual supply (refs #629)

## Notes

Docs to be updated on a following PR