### PR TITLE
ci: enable docker image tests

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,26 +8,18 @@ concurrency:
 jobs:
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-20.04
-
-    env:
-      MIX_ENV: test
-      NODEROOT: ./node/local
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Mdw Setup
-        uses: ./.github/actions/mdw-setup
-
-      - name: Node Setup
-        uses: ./.github/actions/node-setup
+      - name: Common tests setup
+        uses: ./.github/actions/tests-common
 
       - name: Execute tests
-        run: elixir --sname aeternity@localhost -S mix test
+        run: docker-compose run --rm --entrypoint="" ae_mdw ./test.sh
 
   test-coverage:
     name: Test coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,12 @@ RUN ${NODEDIR}/bin/aeternity check_config /home/aeternity/aeternity.yaml
 COPY config ./ae_mdw/config
 COPY lib ./ae_mdw/lib
 COPY priv ./ae_mdw/priv
+COPY test ./ae_mdw/test
 COPY mix.exs ae_mdw
 COPY mix.lock ae_mdw
 COPY Makefile ae_mdw
 COPY docker/entrypoint.sh ae_mdw/entrypoint.sh
+COPY scripts/test.sh ae_mdw/test.sh
 
 # Start building the mdw
 WORKDIR /home/aeternity/node/ae_mdw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - ${PWD}/data/mdw.db:/home/aeternity/node/local/rel/aeternity/data/mdw.db
       - ${PWD}/docker/aeternity.yaml:/home/aeternity/aeternity.yaml
       - ${PWD}/priv:/home/aeternity/node/ae_mdw/priv
+      - ${PWD}/test:/home/aeternity/node/ae_mdw/test
+      - ${PWD}/scripts/test.sh:/home/aeternity/node/ae_mdw/test.sh
       - ${PWD}:/app
     expose: [ 3013, 3014, 3113, 4001, 4000 ]
     environment:


### PR DESCRIPTION
Adds visibility to what happens running the middleware in a docker container.