### PR TITLE
feat: return event name when it is aexn

### DIFF
--- a/lib/ae_mdw/aexn_contracts.ex
+++ b/lib/ae_mdw/aexn_contracts.ex
@@ -12,6 +12,7 @@ defmodule AeMdw.AexnContracts do
 
   import AeMdw.Util.Encoding, only: [encode_contract: 1]
 
+  @type event_name() :: String.t()
   @typep pubkey :: NodeDb.pubkey()
   @typep height :: AeMdw.Blocks.height()
 
@@ -111,7 +112,7 @@ defmodule AeMdw.AexnContracts do
     end
   end
 
-  @spec event_name(AeMdw.Contracts.event_hash()) :: String.t() | nil
+  @spec event_name(AeMdw.Contracts.event_hash()) :: event_name() | nil
   def event_name(event_hash) do
     Node.aexn_event_names()
     |> Map.get(event_hash)

--- a/lib/ae_mdw/aexn_contracts.ex
+++ b/lib/ae_mdw/aexn_contracts.ex
@@ -6,6 +6,7 @@ defmodule AeMdw.AexnContracts do
   alias AeMdw.Contract
   alias AeMdw.Db.Model
   alias AeMdw.DryRun.Runner
+  alias AeMdw.Node
   alias AeMdw.Node.Db, as: NodeDb
   alias AeMdw.Log
 
@@ -108,6 +109,12 @@ defmodule AeMdw.AexnContracts do
 
         :error
     end
+  end
+
+  @spec event_name(AeMdw.Contracts.event_hash()) :: String.t() | nil
+  def event_name(event_hash) do
+    Node.aexn_event_names()
+    |> Map.get(event_hash)
   end
 
   #

--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -155,6 +155,7 @@ defmodule AeMdw.Application do
         aeo_tree_pos: field_pos_map.(aeo_state_tree_code, :oracle_tree),
         aex9_signatures: [{[], AeMdw.Node.aex9_signatures()}],
         aexn_event_hash_types: [{[], AeMdw.Node.aexn_event_hash_types()}],
+        aexn_event_names: [{[], AeMdw.Node.aexn_event_names()}],
         aex141_signatures: [{[], AeMdw.Node.aex141_signatures()}],
         previous_aex141_signatures: [{[], AeMdw.Node.previous_aex141_signatures()}],
         height_proto: [{[], AeMdw.Node.height_proto()}],

--- a/lib/ae_mdw/contract.ex
+++ b/lib/ae_mdw/contract.ex
@@ -18,7 +18,6 @@ defmodule AeMdw.Contract do
   @type fname :: binary()
 
   @typep tx_hash :: binary()
-  @typep event_name :: {:internal_call_tx, fname()}
   # :aec_blocks.micro_block()
   @typep micro_block :: term()
   @typep event_info :: Node.aetx() | :error
@@ -26,7 +25,7 @@ defmodule AeMdw.Contract do
   @typep event_type :: atom()
   @type event_data :: %{tx_hash: tx_hash(), type: event_type(), info: event_info()}
 
-  @type event :: {event_name(), event_data()}
+  @type event :: {{:internal_call_tx, fname()}, event_data()}
   @type event_hash :: <<_::256>>
 
   @type call :: tuple()

--- a/lib/ae_mdw/contracts.ex
+++ b/lib/ae_mdw/contracts.ex
@@ -3,6 +3,7 @@ defmodule AeMdw.Contracts do
   Context module for dealing with Contracts.
   """
 
+  alias AeMdw.AexnContracts
   alias AeMdw.Collection
   alias AeMdw.Contract
   alias AeMdw.Db.Format
@@ -29,7 +30,7 @@ defmodule AeMdw.Contracts do
   @type query() :: %{binary() => binary()}
   @type local_idx() :: non_neg_integer()
   @type log_key() :: {create_txi(), local_idx()}
-  @type event_hash() :: binary()
+  @type event_hash() :: <<_::256>>
   @type log_idx() :: non_neg_integer()
   @type call_key() :: {create_txi(), txi(), event_hash(), log_idx()}
 
@@ -523,6 +524,7 @@ defmodule AeMdw.Contracts do
       args: Enum.map(args, fn <<topic::256>> -> to_string(topic) end),
       data: maybe_encode_base64(data),
       event_hash: Base.hex_encode32(event_hash),
+      event_name: AexnContracts.event_name(event_hash),
       height: height,
       micro_index: micro_index,
       block_hash: encode(:micro_block_hash, block_hash),

--- a/lib/ae_mdw/node.ex
+++ b/lib/ae_mdw/node.ex
@@ -9,6 +9,7 @@ defmodule AeMdw.Node do
   """
 
   alias AeMdw.Contract
+  alias AeMdw.Contracts
 
   @type tx_type ::
           :spend_tx
@@ -44,7 +45,6 @@ defmodule AeMdw.Node do
   @opaque tx() :: tuple()
   @opaque aect_call :: tuple()
 
-  @type event_hash :: <<_::256>>
   @type aexn_event_type ::
           :burn
           | :mint
@@ -98,7 +98,7 @@ defmodule AeMdw.Node do
     |> Enum.into(%{}, fn {k, v} -> {Contract.function_hash(k), v} end)
   end
 
-  @spec aexn_event_hash_types() :: %{event_hash() => aexn_event_type()}
+  @spec aexn_event_hash_types() :: %{Contracts.event_hash() => aexn_event_type()}
   def aexn_event_hash_types() do
     %{
       :aec_hash.blake2b_256_hash("Burn") => :burn,
@@ -115,6 +115,14 @@ defmodule AeMdw.Node do
       :aec_hash.blake2b_256_hash("TokenLimitDecrease") => :token_limit_decrease,
       :aec_hash.blake2b_256_hash("Transfer") => :transfer
     }
+  end
+
+  @spec aexn_event_names() :: %{Contracts.event_hash() => String.t()}
+  def aexn_event_names() do
+    aexn_event_hash_types()
+    |> Enum.into(%{}, fn {hash, atom} ->
+      {hash, Macro.camelize("#{atom}")}
+    end)
   end
 
   @spec hdr_fields(:key | :micro) :: [atom()]

--- a/lib/ae_mdw/node.ex
+++ b/lib/ae_mdw/node.ex
@@ -8,6 +8,7 @@ defmodule AeMdw.Node do
   all of these functions more explicit.
   """
 
+  alias AeMdw.AexnContracts
   alias AeMdw.Contract
   alias AeMdw.Contracts
 
@@ -117,7 +118,7 @@ defmodule AeMdw.Node do
     }
   end
 
-  @spec aexn_event_names() :: %{Contracts.event_hash() => String.t()}
+  @spec aexn_event_names() :: %{Contracts.event_hash() => AexnContracts.event_name()}
   def aexn_event_names() do
     aexn_event_hash_types()
     |> Enum.into(%{}, fn {hash, atom} ->


### PR DESCRIPTION
Set `event_name` on `/contracts/logs` response if it's an AEX-N event.
