### PR TITLE
chore: use master instead of latest to pull docker image

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         MIX_ENV: dev
-    image: aeternity/ae_mdw:latest
+    image: aeternity/ae_mdw:master
     ports:
       - "4000:4000" #MDW's default port
       - "4001:4001" #MDW's websocket default port

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -20,5 +20,6 @@ services:
       - ${PWD}/docker/aeternity.yaml:/home/aeternity/aeternity.yaml
       - ${PWD}/priv:/home/aeternity/node/ae_mdw/priv
       - ${PWD}:/app
+      - ${PWD}/docker/gitconfig:/root/.gitconfig
     environment:
       - AETERNITY_CONFIG=/home/aeternity/aeternity.yaml

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         MIX_ENV: dev
-    image: aeternity/ae_mdw_dev:latest
+    image: aeternity/ae_mdw_dev:master
     ports:
       - "4000:4000" #MDW's default port
       - "4001:4001" #MDW's websocket default port

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         MIX_ENV: dev
-    image: aeternity/ae_mdw_dev:master
+    image: aeternity/ae_mdw:latest
     ports:
       - "4000:4000" #MDW's default port
       - "4001:4001" #MDW's websocket default port

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./Dockerfile
       args:
         MIX_ENV: dev
-    image: aeternity/ae_mdw:master
+    image: aeternity/ae_mdw_dev:latest
     ports:
       - "4000:4000" #MDW's default port
       - "4001:4001" #MDW's websocket default port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       interval: 1m
       timeout: 50s
       retries: 3
-    image: aeternity/ae_mdw:master
+    image: aeternity/ae_mdw:latest
     ports:
       - "4000:4000" #MDW's default port
       - "4001:4001" #MDW's websocket default port

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       interval: 1m
       timeout: 50s
       retries: 3
-    image: aeternity/ae_mdw:latest
+    image: aeternity/ae_mdw:master
     ports:
       - "4000:4000" #MDW's default port
       - "4001:4001" #MDW's websocket default port

--- a/docker/gitconfig
+++ b/docker/gitconfig
@@ -1,0 +1,2 @@
+[safe]
+  directory = *

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -10,7 +10,7 @@ case $1 in
     ;;
 
   "docker-shell")
-    docker-compose run --rm --workdir=/app --entrypoint="" --service-ports ae_mdw /bin/bash
+    docker-compose -f docker-compose-dev.yml run --rm --workdir=/app --entrypoint="" --service-ports ae_mdw /bin/bash
     ;;
 
   "test-integration")


### PR DESCRIPTION
@venimus is the intention to use this `master` tag instead of latest? Also, I wasn't able to find the `ae_mdw_dev` image on dockerhub, do we need to name it?