### PR TITLE
chore(ci): conditional dockerhub build env

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -7,15 +7,25 @@ on:
     tags:
       - v*
 
+env:
+  MIX_ENV: dev
+
 jobs:
   dockerhub:
     name: "Publish to Dockehub"
     runs-on: ubuntu-latest
+    # Don't run on forks
+    if: github.repository == 'aeternity/ae_mdw'
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 100
+
+      - name: Sets MIX_ENV to prod for release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          echo "MIX_ENV=prod" >> $GITHUB_ENV
 
       - name: Extract metadata for docker
         id: meta
@@ -26,7 +36,7 @@ jobs:
             type=raw,value=master,enable={{is_default_branch}}
             type=sha,prefix=,enable={{is_default_branch}}
             type=semver,pattern={{version}},enable={{is_default_branch}}
-  
+
       - name: Login to Dockerhub
         uses: docker/login-action@v2
         with:
@@ -38,7 +48,7 @@ jobs:
         if: ${{ steps.meta.outputs.tags }}
         with:
           context: .
-          build-args: MIX_ENV=prod
+          build-args: MIX_ENV=${{env.MIX_ENV}}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Use MIX_ENV=prod on version tags and MIX_ENV=dev for master

* Since master is the development branch it makes sense that is build with MIX_ENV=dev

ref: https://github.com/aeternity/ae_mdw/pull/1100