### PR TITLE
chore(ci): use custom token instead of default

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,5 +9,6 @@ jobs:
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
+          token: ${{secrets.BOT_GITHUB_TOKEN}}
           release-type: elixir
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"ci","section":"CI / CD","hidden":false},{"type":"test","section":"Testing","hidden":false},{"type":"refactor","section":"Refactorings","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'


### PR DESCRIPTION
It is possible that since release-please is creating the git tags it won't trigger the dockerhub workflow that is bind to it. Similar issue with `on:release` when both workflows use the default github-token. There is now a organization-wide secret (available for all projects) for similar cases so we can use it. 
Note: as a side-effect release-please changes would appear as made from different "user" (bot) in github