### PR TITLE
feat: allow filtering activities by ownership only

### DIFF
--- a/lib/ae_mdw/db/util.ex
+++ b/lib/ae_mdw/db/util.ex
@@ -220,8 +220,12 @@ defmodule AeMdw.Db.Util do
 
   @spec call_account_pk(state(), txi()) :: Db.pubkey()
   def call_account_pk(state, call_txi) do
-    {tx, _tx_hash, :contract_call_tx} = read_node_tx_details(state, {call_txi, -1})
+    case read_node_tx_details(state, {call_txi, -1}) do
+      {tx, _tx_hash, :contract_call_tx} ->
+        tx |> :aect_call_tx.caller_id() |> :aeser_id.specialize(:account)
 
-    tx |> :aect_call_tx.caller_id() |> :aeser_id.specialize(:account)
+      {tx, _tx_hash, :contract_create_tx} ->
+        tx |> :aect_create_tx.owner_id() |> :aeser_id.specialize(:account)
+    end
   end
 end

--- a/lib/ae_mdw/db/util.ex
+++ b/lib/ae_mdw/db/util.ex
@@ -18,6 +18,7 @@ defmodule AeMdw.Db.Util do
 
   @typep state() :: State.t()
   @typep height() :: Blocks.height()
+  @typep txi() :: Txs.txi()
 
   @spec read_tx!(state(), Txs.txi()) :: Model.tx()
   def read_tx!(state, txi), do: State.fetch!(state, Model.Tx, txi)
@@ -215,5 +216,12 @@ defmodule AeMdw.Db.Util do
       end
 
     {type, :aec_headers.height(header)}
+  end
+
+  @spec call_account_pk(state(), txi()) :: Db.pubkey()
+  def call_account_pk(state, call_txi) do
+    {tx, _tx_hash, :contract_call_tx} = read_node_tx_details(state, {call_txi, -1})
+
+    tx |> :aect_call_tx.caller_id() |> :aeser_id.specialize(:account)
   end
 end

--- a/lib/ae_mdw/fields.ex
+++ b/lib/ae_mdw/fields.ex
@@ -18,23 +18,19 @@ defmodule AeMdw.Fields do
   @typep cursor() :: Txs.txi() | nil
 
   @create_tx_types ~w(contract_create_tx channel_create_tx oracle_register_tx ga_attach_tx)a
+  @non_owner_fields [
+    {:channel_create_tx, 3},
+    {:channel_offchain_tx, 1},
+    {:name_preclaim_tx, 3},
+    {:name_transfer_tx, 4},
+    {:spend_tx, 2}
+  ]
 
-  @spec account_fields_stream(state(), pubkey(), direction(), txi_scope(), cursor()) ::
+  @spec account_fields_stream(state(), pubkey(), direction(), txi_scope(), cursor(), boolean()) ::
           Enumerable.t()
-  def account_fields_stream(state, account_pk, direction, txi_scope, cursor) do
-    Node.tx_types()
-    |> Enum.flat_map(fn tx_type ->
-      types_pos =
-        tx_type
-        |> Node.tx_ids()
-        |> Enum.map(fn {_field, pos} -> {tx_type, pos} end)
-
-      if tx_type in @create_tx_types do
-        [{tx_type, nil} | types_pos]
-      else
-        types_pos
-      end
-    end)
+  def account_fields_stream(state, account_pk, direction, txi_scope, cursor, ownership_only?) do
+    tx_types_pos()
+    |> Enum.reject(&(ownership_only? and &1 in @non_owner_fields))
     |> Enum.map(fn {tx_type, tx_field_pos} ->
       scope =
         case txi_scope do
@@ -59,5 +55,21 @@ defmodule AeMdw.Fields do
       end)
     end)
     |> Collection.merge(direction)
+  end
+
+  defp tx_types_pos do
+    Node.tx_types()
+    |> Enum.flat_map(fn tx_type ->
+      types_pos =
+        tx_type
+        |> Node.tx_ids()
+        |> Enum.map(fn {_field, pos} -> {tx_type, pos} end)
+
+      if tx_type in @create_tx_types do
+        [{tx_type, nil} | types_pos]
+      else
+        types_pos
+      end
+    end)
   end
 end

--- a/test/ae_mdw_web/controllers/activities_controller_test.exs
+++ b/test/ae_mdw_web/controllers/activities_controller_test.exs
@@ -1017,7 +1017,7 @@ defmodule AeMdwWeb.ActivitiesControllerTest do
     {:ok, aetx} =
       :aec_spend_tx.new(%{
         sender_id: account_id,
-        recipient_id: account_id,
+        recipient_id: next_account_id,
         amount: 2,
         fee: 3,
         nonce: 4,

--- a/test/ae_mdw_web/controllers/activities_controller_test.exs
+++ b/test/ae_mdw_web/controllers/activities_controller_test.exs
@@ -1000,5 +1000,138 @@ defmodule AeMdwWeb.ActivitiesControllerTest do
     end
   end
 
+  test "when ownership_only param given, it only returns owned by activities", %{conn: conn} do
+    account_pk = TS.address(0)
+    next_account_pk = TS.address(1)
+    contract_pk = TS.address(2)
+    account = Enc.encode(:account_pubkey, account_pk)
+    account_id = :aeser_id.create(:account, account_pk)
+    next_account_id = :aeser_id.create(:account, next_account_pk)
+    contract_id = :aeser_id.create(:contract, contract_pk)
+    height = 398
+    mbi = 2
+    kb_hash = TS.key_block_hash(0)
+    mb_hash = TS.micro_block_hash(0)
+    enc_mb_hash = Enc.encode(:micro_block_hash, mb_hash)
+
+    {:ok, aetx} =
+      :aec_spend_tx.new(%{
+        sender_id: account_id,
+        recipient_id: account_id,
+        amount: 2,
+        fee: 3,
+        nonce: 4,
+        payload: ""
+      })
+
+    {:spend_tx, tx} = :aetx.specialize_type(aetx)
+
+    {:ok, contract_call4_aetx} =
+      :aect_call_tx.new(%{
+        caller_id: account_id,
+        nonce: 2,
+        contract_id: contract_id,
+        abi_version: 2,
+        fee: 1,
+        amount: 1,
+        gas: 1,
+        gas_price: 1,
+        call_data: ""
+      })
+
+    {:contract_call_tx, contract_call4_tx} = :aetx.specialize_type(contract_call4_aetx)
+
+    {:ok, contract_call5_aetx} =
+      :aect_call_tx.new(%{
+        caller_id: next_account_id,
+        nonce: 2,
+        contract_id: contract_id,
+        abi_version: 2,
+        fee: 1,
+        amount: 1,
+        gas: 1,
+        gas_price: 1,
+        call_data: ""
+      })
+
+    {:contract_call_tx, contract_call5_tx} = :aetx.specialize_type(contract_call5_aetx)
+
+    store =
+      empty_store()
+      |> Store.put(Model.Field, Model.field(index: {:contract_call_tx, 1, account_pk, 1}))
+      |> Store.put(Model.Tx, Model.tx(index: 1, block_index: {height, mbi}, id: "tx-hash1"))
+      |> Store.put(Model.Field, Model.field(index: {:contract_call_tx, 1, account_pk, 2}))
+      |> Store.put(Model.Tx, Model.tx(index: 2, block_index: {height, mbi}, id: "tx-hash2"))
+      # Skipped
+      |> Store.put(Model.Field, Model.field(index: {:spend_tx, 2, account_pk, 6}))
+      |> Store.put(
+        Model.Field,
+        Model.field(index: {:contract_create_tx, nil, next_account_pk, 4})
+      )
+      |> Store.put(Model.Block, Model.block(index: {height, -1}, hash: kb_hash))
+      |> Store.put(Model.Block, Model.block(index: {height, mbi}, hash: mb_hash))
+      |> Store.put(
+        Model.AexnTransfer,
+        Model.aexn_transfer(index: {:aex9, account_pk, 4, next_account_pk, 1, 1})
+      )
+      |> Store.put(Model.Tx, Model.tx(index: 4, block_index: {height, mbi}, id: "tx-hash4"))
+      |> Store.put(
+        # Skipped
+        Model.RevAexnTransfer,
+        Model.aexn_transfer(index: {:aex141, account_pk, 5, next_account_pk, 2, 2})
+      )
+      |> Store.put(
+        Model.AexnTransfer,
+        Model.aexn_transfer(index: {:aex141, next_account_pk, 5, account_pk, 2, 2})
+      )
+      |> Store.put(Model.Tx, Model.tx(index: 5, block_index: {height, mbi}, id: "tx-hash5"))
+      |> Store.put(
+        # Skipped
+        Model.TargetKindIntTransferTx,
+        Model.target_kind_int_transfer_tx(index: {account_pk, "reward_oracle", {height, 6}, 6})
+      )
+
+    with_mocks [
+      {Db, [],
+       [
+         get_tx_data: fn
+           "tx-hash1" -> {"", :spend_tx, aetx, tx}
+           "tx-hash2" -> {"", :spend_tx, aetx, tx}
+           "tx-hash4" -> {"", :contract_call_tx, contract_call4_aetx, contract_call4_tx}
+           "tx-hash5" -> {"", :contract_call_tx, contract_call5_aetx, contract_call5_tx}
+         end
+       ]},
+      {:aec_db, [], [get_header: fn _block_hash -> :header end]},
+      {:aetx_sign, [], [serialize_for_client: fn :header, ^aetx -> %{} end]}
+    ] do
+      assert %{"prev" => nil, "data" => [tx1, tx2, tx3], "next" => _next_url} =
+               conn
+               |> with_store(store)
+               |> get("/v2/accounts/#{account}/activities", owned_only: 1, direction: "forward")
+               |> json_response(200)
+
+      assert %{
+               "height" => ^height,
+               "block_hash" => ^enc_mb_hash,
+               "type" => "ContractCallTxEvent",
+               "payload" => %{"micro_index" => ^mbi}
+             } = tx1
+
+      assert %{
+               "height" => ^height,
+               "block_hash" => ^enc_mb_hash,
+               "type" => "ContractCallTxEvent",
+               "payload" => %{"micro_index" => ^mbi}
+             } = tx2
+
+      assert %{
+               "height" => ^height,
+               "block_hash" => ^enc_mb_hash,
+               "type" => "Aex9TransferEvent",
+               "payload" => %{"amount" => 1}
+             } = tx3
+    end
+  end
+
   defp empty_store, do: NullStore.new() |> MemStore.new()
 end

--- a/test/ae_mdw_web/controllers/activities_controller_test.exs
+++ b/test/ae_mdw_web/controllers/activities_controller_test.exs
@@ -1000,7 +1000,7 @@ defmodule AeMdwWeb.ActivitiesControllerTest do
     end
   end
 
-  test "when ownership_only param given, it only returns owned by activities", %{conn: conn} do
+  test "when ownership_only param given, it returns owned by activities", %{conn: conn} do
     account_pk = TS.address(0)
     next_account_pk = TS.address(1)
     contract_pk = TS.address(2)
@@ -1062,8 +1062,6 @@ defmodule AeMdwWeb.ActivitiesControllerTest do
       |> Store.put(Model.Tx, Model.tx(index: 1, block_index: {height, mbi}, id: "tx-hash1"))
       |> Store.put(Model.Field, Model.field(index: {:contract_call_tx, 1, account_pk, 2}))
       |> Store.put(Model.Tx, Model.tx(index: 2, block_index: {height, mbi}, id: "tx-hash2"))
-      # Skipped
-      |> Store.put(Model.Field, Model.field(index: {:spend_tx, 2, account_pk, 6}))
       |> Store.put(
         Model.Field,
         Model.field(index: {:contract_create_tx, nil, next_account_pk, 4})
@@ -1130,6 +1128,66 @@ defmodule AeMdwWeb.ActivitiesControllerTest do
                "type" => "Aex9TransferEvent",
                "payload" => %{"amount" => 1}
              } = tx3
+    end
+  end
+
+  test "when ownership_only param given, it skips non-initiated activities", %{conn: conn} do
+    account_pk = TS.address(0)
+    contract_pk = TS.address(2)
+    account = Enc.encode(:account_pubkey, account_pk)
+    account_id = :aeser_id.create(:account, account_pk)
+    next_account_pk = TS.address(1)
+    next_account_id = :aeser_id.create(:account, next_account_pk)
+    height = 398
+    mbi = 2
+    kb_hash = TS.key_block_hash(0)
+    mb_hash = TS.micro_block_hash(0)
+
+    store =
+      empty_store()
+      |> Store.put(Model.Field, Model.field(index: {:spend_tx, 2, account_pk, 1}))
+      |> Store.put(
+        Model.Field,
+        Model.field(index: {:contract_create_tx, nil, next_account_pk, 2})
+      )
+      |> Store.put(Model.Block, Model.block(index: {height, -1}, hash: kb_hash))
+      |> Store.put(Model.Block, Model.block(index: {height, mbi}, hash: mb_hash))
+      |> Store.put(Model.Tx, Model.tx(index: 1, block_index: {height, mbi}, id: "tx-hash1"))
+
+    assert %{"prev" => nil, "data" => [], "next" => _next_url} =
+             conn
+             |> with_store(store)
+             |> get("/v2/accounts/#{account}/activities", owned_only: 1, direction: "forward")
+             |> json_response(200)
+
+    {:ok, aetx} =
+      :aec_spend_tx.new(%{
+        sender_id: account_id,
+        recipient_id: next_account_id,
+        amount: 2,
+        fee: 3,
+        nonce: 4,
+        payload: ""
+      })
+
+    {:spend_tx, tx} = :aetx.specialize_type(aetx)
+
+    # Checking it returns results without the filter
+    with_mocks [
+      {Db, [],
+       [
+         get_tx_data: fn
+           "tx-hash1" -> {"", :spend_tx, aetx, tx}
+         end
+       ]},
+      {:aec_db, [], [get_header: fn _block_hash -> :header end]},
+      {:aetx_sign, [], [serialize_for_client: fn :header, ^aetx -> %{} end]}
+    ] do
+      assert %{"prev" => nil, "data" => [_activity1], "next" => _next_url} =
+               conn
+               |> with_store(store)
+               |> get("/v2/accounts/#{account}/activities", direction: "forward")
+               |> json_response(200)
     end
   end
 


### PR DESCRIPTION
We consider "owned" activities as those that are explicitly created by the account.