### PR TITLE
chore: remove unused code

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Before running it, it's recommended to use a Node database snapshot for faster s
 1. Download one of the full backups from https://downloads.aeternity.io
 2. Create a 'data' directory under the root repo dir and extract the backup to it (it creates a mnesia directory).
 
-To start a docker container on mainnet, simply run: `docker-compose.yml up`.
+To start a docker container on mainnet, simply run: `docker-compose up`.
 
 You can check on `/status` page that the `node_height` is higher than 600000.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The middleware runs along with an Aeternity Node on the same docker container an
 
 Its configuration file is found at `docker/aeternity.yaml`. Under `fork_management` key, the `network_id` options are: `ae_mainnet` and `ae_uat` (testnet).
 
-You may also redefine other Aeternity node configurations. The `aeternity.yaml` is copied when the container is started and is used as a node configuration file. More information regarding configration can be found [here](https://docs.aeternity.io/en/stable/configuration/)
+You may also redefine other Aeternity node configurations. The `aeternity.yaml` is copied when the container is started and is used as a node configuration file. More information regarding configuration can be found [here](https://docs.aeternity.io/en/stable/configuration/)
 
 ### Docker setup for local dev
 

--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -32,7 +32,6 @@ defmodule AeMdw.Application do
 
     init(:meta)
     init_public(:contract_cache)
-    # init(:aesophia)
     init(:app_ctrl_server)
     init(:aecore_services)
     init(:aesync)
@@ -63,21 +62,12 @@ defmodule AeMdw.Application do
     {:ok, _apps3} = Application.ensure_all_started(:aemon)
   end
 
-  # def init(:aesophia) do
-  #   Path.join(Application.app_dir(:aesophia), "ebin/*.beam")
-  #   |> Path.wildcard
-  #   |> Enum.map(&:code.load_abs(to_charlist(Path.rootname(&1))))
-  # end
-
   defp init(:meta) do
     {:ok, chain_state_code} = Extract.AbsCode.module(:aec_chain_state)
     [:header, :hash, :type] = NodeHelper.record_keys(chain_state_code, :node)
 
     {:ok, aetx_code} = Extract.AbsCode.module(:aetx)
     {:ok, aeser_code} = Extract.AbsCode.module(:aeser_api_encoder)
-    {:ok, headers_code} = Extract.AbsCode.module(:aec_headers)
-    {:ok, aens_state_tree_code} = Extract.AbsCode.module(:aens_state_tree)
-    {:ok, aeo_state_tree_code} = Extract.AbsCode.module(:aeo_state_tree)
 
     type_mod_map = Extract.tx_mod_map(aetx_code)
     type_name_map = Extract.tx_name_map(aetx_code)
@@ -118,13 +108,6 @@ defmodule AeMdw.Application do
       String.slice(str, 0, String.length(str) - 3)
     end
 
-    field_pos_map = fn code, rec ->
-      code
-      |> NodeHelper.record_keys(rec)
-      |> Stream.zip(Stream.iterate(1, &(&1 + 1)))
-      |> Enum.into(%{})
-    end
-
     min_block_reward_height =
       :aec_block_genesis.height() + :aec_governance.beneficiary_reward_delay() + 1
 
@@ -147,12 +130,6 @@ defmodule AeMdw.Application do
         tx_groups: [{[], MapSet.new(Map.keys(tx_group_map))}],
         id_type: id_type_map,
         type_id: Util.inverse(id_type_map),
-        hdr_fields: %{
-          key: NodeHelper.record_keys(headers_code, :key_header),
-          micro: NodeHelper.record_keys(headers_code, :mic_header)
-        },
-        aens_tree_pos: field_pos_map.(aens_state_tree_code, :ns_tree),
-        aeo_tree_pos: field_pos_map.(aeo_state_tree_code, :oracle_tree),
         aex9_signatures: [{[], AeMdw.Node.aex9_signatures()}],
         aexn_event_hash_types: [{[], AeMdw.Node.aexn_event_hash_types()}],
         aexn_event_names: [{[], AeMdw.Node.aexn_event_names()}],

--- a/lib/ae_mdw/db/channels.ex
+++ b/lib/ae_mdw/db/channels.ex
@@ -42,15 +42,6 @@ defmodule AeMdw.Db.Channels do
     ]
   end
 
-  @spec close_slash_mutations(bi_txi(), Node.tx()) :: [Mutation.t()]
-  def close_slash_mutations(bi_txi, tx) do
-    channel_pk = :aesc_slash_tx.channel_pubkey(tx)
-
-    [
-      ChannelUpdateMutation.new(channel_pk, bi_txi)
-    ]
-  end
-
   @spec force_progress_mutations(bi_txi(), Node.tx()) :: [Mutation.t()]
   def force_progress_mutations(bi_txi, tx) do
     channel_pk = :aesc_force_progress_tx.channel_pubkey(tx)
@@ -63,15 +54,6 @@ defmodule AeMdw.Db.Channels do
   @spec slash_mutations(bi_txi(), Node.tx()) :: [Mutation.t()]
   def slash_mutations(bi_txi, tx) do
     channel_pk = :aesc_slash_tx.channel_pubkey(tx)
-
-    [
-      ChannelUpdateMutation.new(channel_pk, bi_txi)
-    ]
-  end
-
-  @spec offchain_mutations(bi_txi(), Node.tx()) :: [Mutation.t()]
-  def offchain_mutations(bi_txi, tx) do
-    channel_pk = :aesc_offchain_tx.channel_pubkey(tx)
 
     [
       ChannelUpdateMutation.new(channel_pk, bi_txi)

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -276,14 +276,6 @@ defmodule AeMdw.Db.Sync.Transaction do
        do: Channels.set_delegates_mutations({block_index, txi}, tx)
 
   defp tx_mutations(%TxContext{
-         type: :channel_offchain_tx,
-         block_index: block_index,
-         txi: txi,
-         tx: tx
-       }),
-       do: Channels.offchain_mutations({block_index, txi}, tx)
-
-  defp tx_mutations(%TxContext{
          type: :channel_force_progress_tx,
          block_index: block_index,
          txi: txi,

--- a/lib/ae_mdw/fields.ex
+++ b/lib/ae_mdw/fields.ex
@@ -20,7 +20,6 @@ defmodule AeMdw.Fields do
   @create_tx_types ~w(contract_create_tx channel_create_tx oracle_register_tx ga_attach_tx)a
   @non_owner_fields [
     {:channel_create_tx, 3},
-    {:channel_offchain_tx, 1},
     {:name_preclaim_tx, 3},
     {:name_transfer_tx, 4},
     {:spend_tx, 2}

--- a/lib/ae_mdw/node.ex
+++ b/lib/ae_mdw/node.ex
@@ -64,23 +64,6 @@ defmodule AeMdw.Node do
   @typep method_hash :: binary()
   @typep method_signature :: {list(), any()}
 
-  defmodule Oracle do
-    @moduledoc false
-
-    @spec get!(term(), term()) :: non_neg_integer()
-    def get!(_a, _b), do: 0
-  end
-
-  @spec aens_tree_pos(:cache | :mtree) :: non_neg_integer()
-  def aens_tree_pos(_tree_type) do
-    0
-  end
-
-  @spec aeo_tree_pos(:cache | :otree) :: non_neg_integer()
-  def aeo_tree_pos(_tree_type) do
-    0
-  end
-
   @spec aex9_signatures :: %{method_hash() => method_signature()}
   def aex9_signatures do
     Contract.aex9_signatures()

--- a/test/ae_mdw_web/controllers/activities_controller_test.exs
+++ b/test/ae_mdw_web/controllers/activities_controller_test.exs
@@ -1153,10 +1153,6 @@ defmodule AeMdwWeb.ActivitiesControllerTest do
       )
       |> Store.put(
         Model.Field,
-        Model.field(index: {:channel_offchain_tx, 1, account_pk, 4})
-      )
-      |> Store.put(
-        Model.Field,
         Model.field(index: {:name_preclaim_tx, 3, account_pk, 5})
       )
       |> Store.put(


### PR DESCRIPTION
- Removes indexation of `channel_offchain_tx` that is never present directly on chain (only via payload)
- Removes some initialization caching code that is not used
- Fixes a typo on README command