### PR TITLE
chore(ci): always enable semver tags

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -35,7 +35,7 @@ jobs:
           tags: |
             type=raw,value=master,enable={{is_default_branch}}
             type=sha,prefix=,enable={{is_default_branch}}
-            type=semver,pattern={{version}},enable={{is_default_branch}}
+            type=semver,pattern={{version}},enable=true
 
       - name: Login to Dockerhub
         uses: docker/login-action@v2


### PR DESCRIPTION
Fix for yet another issue with version tags. Looks like for some reason on `push tag` the meta-extractor does not see the branch in the github context and can't resolve properly `{{is_default_branch}}`, although that case isn't documented in their docs