### PR TITLE
fix: skip importing hardfork accounts for custom networks

### DIFF
--- a/lib/ae_mdw/db/hardfork_presets.ex
+++ b/lib/ae_mdw/db/hardfork_presets.ex
@@ -24,28 +24,19 @@ defmodule AeMdw.Db.HardforkPresets do
   end
 
   defp do_import_account_presets() do
-    iris_height =
-      :aeu_env.user_map()
-      |> get_in(["chain", "hard_forks", "#{:aec_hard_forks.protocol_vsn(:iris)}"])
-
-    minerva_accounts =
-      if iris_height != 0 do
-        [hardfork_mutation(:minerva, &:aec_fork_block_settings.minerva_accounts/0)]
-      else
-        []
-      end
-
-    State.commit(
-      State.new(),
-      [hardfork_mutation(:genesis, &:aec_fork_block_settings.genesis_accounts/0)] ++
-        minerva_accounts ++
+    if :aec_governance.get_network_id() in ["ae_uat", "ae_mainnet"] do
+      State.commit(
+        State.new(),
         [
+          hardfork_mutation(:genesis, &:aec_fork_block_settings.genesis_accounts/0),
+          hardfork_mutation(:minerva, &:aec_fork_block_settings.minerva_accounts/0),
           hardfork_mutation(:fortuna, &:aec_fork_block_settings.fortuna_accounts/0),
           hardfork_mutation(:lima, &:aec_fork_block_settings.lima_accounts/0),
           lima_contracts_mutation(),
           lima_extra_accounts_mutation()
         ]
-    )
+      )
+    end
   end
 
   defp hardfork_mutation(hardfork, fork_settings_accounts_fn) do

--- a/mix.exs
+++ b/mix.exs
@@ -92,6 +92,7 @@ defmodule AeMdw.MixProject do
           :aetx,
           :aetx_env,
           :aetx_sign,
+          :aeu_env,
           :aeu_info,
           :aeu_mtrees,
           :app_ctrl,

--- a/test/ae_mdw/db/hardfork_presets_test.exs
+++ b/test/ae_mdw/db/hardfork_presets_test.exs
@@ -6,6 +6,8 @@ defmodule AeMdw.Db.HardforkPresetsTest do
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
 
+  import Mock
+
   describe "import_account_presets" do
     test "saves genesis, minerva, fortuna and lima migrated accounts" do
       HardforkPresets.import_account_presets()
@@ -17,6 +19,88 @@ defmodule AeMdw.Db.HardforkPresetsTest do
                |> Enum.count()
 
       assert 325 ==
+               State.new()
+               |> Collection.stream(Model.KindIntTransferTx, {"accounts_minerva", nil, nil, nil})
+               |> Stream.take_while(&match?({"accounts_minerva", _bi, _target, _txi}, &1))
+               |> Enum.count()
+
+      assert 304 ==
+               State.new()
+               |> Collection.stream(Model.KindIntTransferTx, {"accounts_fortuna", nil, nil, nil})
+               |> Stream.take_while(&match?({"accounts_fortuna", _bi, _target, _txi}, &1))
+               |> Enum.count()
+
+      assert 702 ==
+               State.new()
+               |> Collection.stream(Model.KindIntTransferTx, {"accounts_lima", nil, nil, nil})
+               |> Stream.take_while(&match?({"accounts_lima", _bi, _target, _txi}, &1))
+               |> Enum.count()
+
+      assert 1 ==
+               State.new()
+               |> Collection.stream(
+                 Model.KindIntTransferTx,
+                 {"accounts_extra_lima", nil, nil, nil}
+               )
+               |> Stream.take_while(&match?({"accounts_extra_lima", _bi, _target, _txi}, &1))
+               |> Enum.count()
+
+      assert 1 ==
+               State.new()
+               |> Collection.stream(Model.KindIntTransferTx, {"contracts_lima", nil, nil, nil})
+               |> Stream.take_while(&match?({"contracts_lima", _bi, _target, _txi}, &1))
+               |> Enum.count()
+    end
+  end
+
+  test "saves genesis, fortuna and lima migrated accounts skipping minerva ones" do
+    State.new()
+    |> Collection.stream(
+      Model.KindIntTransferTx,
+      {"", nil, nil, nil}
+    )
+    |> Enum.to_list()
+    |> Enum.each(&Database.delete(Model.KindIntTransferTx, &1))
+
+    with_mocks [
+      {:aeu_env, [:passthrough],
+       [
+         user_map: fn ->
+           %{
+             "chain" => %{
+               "hard_forks" => %{
+                 "5" => 0
+               },
+               "garbage_collection" => %{
+                 "enabled" => false,
+                 "history" => 500,
+                 "interval" => 3
+               },
+               "persist" => true
+             },
+             "fork_management" => %{"network_id" => "ae_mainnet"},
+             "http" => %{"external" => %{"port" => 3013}, "internal" => %{"port" => 3113}},
+             "keys" => %{"dir" => "keys", "peer_password" => "secret"},
+             "mining" => %{
+               "autostart" => false,
+               "beneficiary" => "ak_2Dri7n9Bm2FgdN5ZFXzDn1ZAXUMox6roEWTfU1rCQ842pTdWiK"
+             },
+             "sync" => %{"log_peer_connection_count_interval" => 6_000_000, "port" => 3015},
+             "system" => %{"plugin_path" => "/home/aeternity/node/ae_mdw/plugins"},
+             "websocket" => %{"channel" => %{"port" => 3014}}
+           }
+         end
+       ]}
+    ] do
+      HardforkPresets.import_account_presets()
+
+      assert 716 ==
+               State.new()
+               |> Collection.stream(Model.KindIntTransferTx, {"accounts_genesis", nil, nil, nil})
+               |> Stream.take_while(&match?({"accounts_genesis", _bi, _target, _txi}, &1))
+               |> Enum.count()
+
+      assert 0 ==
                State.new()
                |> Collection.stream(Model.KindIntTransferTx, {"accounts_minerva", nil, nil, nil})
                |> Stream.take_while(&match?({"accounts_minerva", _bi, _target, _txi}, &1))

--- a/test/ae_mdw/db/hardfork_presets_test.exs
+++ b/test/ae_mdw/db/hardfork_presets_test.exs
@@ -2,6 +2,7 @@ defmodule AeMdw.Db.HardforkPresetsTest do
   use ExUnit.Case, async: false
 
   alias AeMdw.Collection
+  alias AeMdw.Database
   alias AeMdw.Db.HardforkPresets
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
@@ -9,8 +10,12 @@ defmodule AeMdw.Db.HardforkPresetsTest do
   import Mock
 
   describe "import_account_presets" do
-    test "saves genesis, minerva, fortuna and lima migrated accounts" do
-      HardforkPresets.import_account_presets()
+    test "on mainnet saves genesis, minerva, fortuna and lima migrated accounts" do
+      delete_previous_import()
+
+      with_mocks [{:aec_governance, [:passthrough], get_network_id: fn -> "ae_mainnet" end}] do
+        HardforkPresets.import_account_presets()
+      end
 
       assert 716 ==
                State.new()
@@ -51,87 +56,45 @@ defmodule AeMdw.Db.HardforkPresetsTest do
                |> Stream.take_while(&match?({"contracts_lima", _bi, _target, _txi}, &1))
                |> Enum.count()
     end
+
+    test "on testnet saves genesis, minerva, fortuna and lima migrated accounts" do
+      delete_previous_import()
+
+      with_mocks [{:aec_governance, [:passthrough], get_network_id: fn -> "ae_uat" end}] do
+        HardforkPresets.import_account_presets()
+      end
+
+      assert 1 ==
+               State.new()
+               |> Collection.stream(Model.KindIntTransferTx, {"accounts_genesis", nil, nil, nil})
+               |> Stream.take_while(&match?({"accounts_genesis", _bi, _target, _txi}, &1))
+               |> Enum.count()
+
+      assert 3 ==
+               State.new()
+               |> Collection.stream(Model.KindIntTransferTx, {"accounts_minerva", nil, nil, nil})
+               |> Stream.take_while(&match?({"accounts_minerva", _bi, _target, _txi}, &1))
+               |> Enum.count()
+    end
+
+    test "on custom network skips importing accounts" do
+      delete_previous_import()
+
+      with_mocks [{:aec_governance, [:passthrough], get_network_id: fn -> "ae_custom" end}] do
+        HardforkPresets.import_account_presets()
+      end
+
+      assert Database.count(Model.KindIntTransferTx) == 0
+    end
   end
 
-  test "saves genesis, fortuna and lima migrated accounts skipping minerva ones" do
+  defp delete_previous_import do
     State.new()
     |> Collection.stream(
       Model.KindIntTransferTx,
       {"", nil, nil, nil}
     )
     |> Enum.to_list()
-    |> Enum.each(&Database.delete(Model.KindIntTransferTx, &1))
-
-    with_mocks [
-      {:aeu_env, [:passthrough],
-       [
-         user_map: fn ->
-           %{
-             "chain" => %{
-               "hard_forks" => %{
-                 "5" => 0
-               },
-               "garbage_collection" => %{
-                 "enabled" => false,
-                 "history" => 500,
-                 "interval" => 3
-               },
-               "persist" => true
-             },
-             "fork_management" => %{"network_id" => "ae_mainnet"},
-             "http" => %{"external" => %{"port" => 3013}, "internal" => %{"port" => 3113}},
-             "keys" => %{"dir" => "keys", "peer_password" => "secret"},
-             "mining" => %{
-               "autostart" => false,
-               "beneficiary" => "ak_2Dri7n9Bm2FgdN5ZFXzDn1ZAXUMox6roEWTfU1rCQ842pTdWiK"
-             },
-             "sync" => %{"log_peer_connection_count_interval" => 6_000_000, "port" => 3015},
-             "system" => %{"plugin_path" => "/home/aeternity/node/ae_mdw/plugins"},
-             "websocket" => %{"channel" => %{"port" => 3014}}
-           }
-         end
-       ]}
-    ] do
-      HardforkPresets.import_account_presets()
-
-      assert 716 ==
-               State.new()
-               |> Collection.stream(Model.KindIntTransferTx, {"accounts_genesis", nil, nil, nil})
-               |> Stream.take_while(&match?({"accounts_genesis", _bi, _target, _txi}, &1))
-               |> Enum.count()
-
-      assert 0 ==
-               State.new()
-               |> Collection.stream(Model.KindIntTransferTx, {"accounts_minerva", nil, nil, nil})
-               |> Stream.take_while(&match?({"accounts_minerva", _bi, _target, _txi}, &1))
-               |> Enum.count()
-
-      assert 304 ==
-               State.new()
-               |> Collection.stream(Model.KindIntTransferTx, {"accounts_fortuna", nil, nil, nil})
-               |> Stream.take_while(&match?({"accounts_fortuna", _bi, _target, _txi}, &1))
-               |> Enum.count()
-
-      assert 702 ==
-               State.new()
-               |> Collection.stream(Model.KindIntTransferTx, {"accounts_lima", nil, nil, nil})
-               |> Stream.take_while(&match?({"accounts_lima", _bi, _target, _txi}, &1))
-               |> Enum.count()
-
-      assert 1 ==
-               State.new()
-               |> Collection.stream(
-                 Model.KindIntTransferTx,
-                 {"accounts_extra_lima", nil, nil, nil}
-               )
-               |> Stream.take_while(&match?({"accounts_extra_lima", _bi, _target, _txi}, &1))
-               |> Enum.count()
-
-      assert 1 ==
-               State.new()
-               |> Collection.stream(Model.KindIntTransferTx, {"contracts_lima", nil, nil, nil})
-               |> Stream.take_while(&match?({"contracts_lima", _bi, _target, _txi}, &1))
-               |> Enum.count()
-    end
+    |> Enum.each(&State.delete(State.new(), Model.KindIntTransferTx, &1))
   end
 end


### PR DESCRIPTION
closes #1127 