### PR TITLE
refactor: enqueue a block only once to ws broadcasting

### DIFF
--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -60,8 +60,8 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
     {:ok, hash} = block |> :aec_blocks.to_header() |> :aec_headers.hash_header()
 
     if not already_processed?({:txs, version, hash, source}) &&
-         (Subscriptions.has_subscribers(version, "Transactions") ||
-            Subscriptions.has_object_subscribers(version)) do
+         (Subscriptions.has_subscribers?(version, "Transactions") ||
+            Subscriptions.has_object_subscribers?(version)) do
       GenServer.cast(__MODULE__, {:broadcast_txs, version, block, source})
       set_processed({:txs, version, hash, source})
     end

--- a/lib/ae_mdw_web/websocket/subscriptions.ex
+++ b/lib/ae_mdw_web/websocket/subscriptions.ex
@@ -73,8 +73,8 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
     end
   end
 
-  @spec has_subscribers(version(), channel) :: boolean()
-  def has_subscribers(version, channel) do
+  @spec has_subscribers?(version(), channel) :: boolean()
+  def has_subscribers?(version, channel) do
     {:ok, channel_key} = channel_key(version, channel)
 
     case :ets.match(@subs_channel_pid, {channel_key, :"$1"}, 1) do
@@ -83,8 +83,8 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
     end
   end
 
-  @spec has_object_subscribers(version()) :: boolean()
-  def has_object_subscribers(version) do
+  @spec has_object_subscribers?(version()) :: boolean()
+  def has_object_subscribers?(version) do
     case :ets.match(@subs_channel_pid, {{version, :"$1"}, :_}, 4) do
       {channels, _continuation} ->
         channels |> List.flatten() |> Enum.any?(&(&1 not in @known_channels))

--- a/lib/ae_mdw_web/websocket/subscriptions.ex
+++ b/lib/ae_mdw_web/websocket/subscriptions.ex
@@ -73,6 +73,27 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
     end
   end
 
+  @spec has_subscribers(version(), channel) :: boolean()
+  def has_subscribers(version, channel) do
+    {:ok, channel_key} = channel_key(version, channel)
+
+    case :ets.match(@subs_channel_pid, {channel_key, :"$1"}, 1) do
+      {_some, _continuation} -> true
+      @eot -> false
+    end
+  end
+
+  @spec has_object_subscribers(version()) :: boolean()
+  def has_object_subscribers(version) do
+    case :ets.match(@subs_channel_pid, {{version, :"$1"}, :_}, 4) do
+      {channels, _continuation} ->
+        channels |> List.flatten() |> Enum.any?(&(&1 not in @known_channels))
+
+      @eot ->
+        false
+    end
+  end
+
   @spec subscribers(version(), channel()) :: [pid()]
   def subscribers(version, channel) do
     {:ok, channel_key} = channel_key(version, channel)

--- a/test/ae_mdw/websocket/subscriptions_test.exs
+++ b/test/ae_mdw/websocket/subscriptions_test.exs
@@ -143,6 +143,9 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
       on_exit(fn -> unsubscribe_all([pid1, pid2, pid3]) end)
 
+      unsubscribe_all(:v1)
+      unsubscribe_all(:v2)
+
       channel = encode(:oracle_pubkey, :crypto.strong_rand_bytes(32))
       assert {:ok, [^channel]} = Subscriptions.subscribe(pid1, :v1, channel)
       channel = encode(:contract_pubkey, :crypto.strong_rand_bytes(32))
@@ -158,6 +161,9 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
       pid2 = new_pid()
 
       on_exit(fn -> unsubscribe_all([pid1, pid2]) end)
+
+      unsubscribe_all(:v1)
+      unsubscribe_all(:v2)
 
       channel1 = encode(:account_pubkey, :crypto.strong_rand_bytes(32))
 

--- a/test/ae_mdw/websocket/subscriptions_test.exs
+++ b/test/ae_mdw/websocket/subscriptions_test.exs
@@ -21,11 +21,27 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
       assert {:ok, ["KeyBlocks", "Transactions"]} =
                Subscriptions.subscribe(pid1, :v1, "Transactions")
 
-      channel = encode(:account_pubkey, <<11::256>>)
+      channel = encode(:account_pubkey, :crypto.strong_rand_bytes(32))
       assert {:ok, [^channel]} = Subscriptions.subscribe(pid3, :v1, channel)
 
-      assert {:ok, [^channel, "Transactions"]} =
-               Subscriptions.subscribe(pid3, :v1, "Transactions")
+      channel = encode(:oracle_pubkey, :crypto.strong_rand_bytes(32))
+      assert {:ok, subs} = Subscriptions.subscribe(pid3, :v1, channel)
+      assert channel in subs
+
+      channel = encode(:contract_pubkey, :crypto.strong_rand_bytes(32))
+      assert {:ok, subs} = Subscriptions.subscribe(pid3, :v1, channel)
+      assert channel in subs
+
+      channel = encode(:channel, :crypto.strong_rand_bytes(32))
+      assert {:ok, subs} = Subscriptions.subscribe(pid3, :v1, channel)
+      assert channel in subs
+
+      channel = encode(:name, :crypto.strong_rand_bytes(32))
+      assert {:ok, subs} = Subscriptions.subscribe(pid3, :v1, channel)
+      assert channel in subs
+
+      assert {:ok, subs} = Subscriptions.subscribe(pid3, :v1, "Transactions")
+      assert channel in subs
     end
 
     test "returns invalid channel when unknown and not a valid id" do
@@ -36,6 +52,7 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
     test "returns error on duplicate subscriptions" do
       pid = new_pid()
+      on_exit(fn -> unsubscribe_all([pid]) end)
       channel = encode(:account_pubkey, <<12::256>>)
       assert {:ok, [^channel]} = Subscriptions.subscribe(pid, :v1, channel)
       assert {:error, :already_subscribed} = Subscriptions.subscribe(pid, :v1, channel)
@@ -43,6 +60,7 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
     test "does not allow duplicate subscription of account and oracle with same pubkey" do
       pid = new_pid()
+      on_exit(fn -> unsubscribe_all([pid]) end)
       channel = encode(:account_pubkey, <<13::256>>)
       assert {:ok, [^channel]} = Subscriptions.subscribe(pid, :v2, channel)
 
@@ -87,6 +105,67 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
       channel = encode(:oracle_pubkey, <<14::256>>)
       assert {:ok, []} = Subscriptions.unsubscribe(pid, :v2, channel)
       assert {:error, :not_subscribed} = Subscriptions.unsubscribe(pid, :v2, channel)
+    end
+  end
+
+  describe "has_subscribers/2" do
+    test "checks if there is any subscriber for a known versioned channel" do
+      pid1 = new_pid()
+      pid2 = new_pid()
+      pid3 = new_pid()
+
+      on_exit(fn -> unsubscribe_all([pid1, pid2, pid3]) end)
+
+      unsubscribe_all(:v1)
+      unsubscribe_all(:v2)
+
+      channel = encode(:oracle_pubkey, :crypto.strong_rand_bytes(32))
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid1, :v2, channel)
+      assert {:ok, [^channel, "KeyBlocks"]} = Subscriptions.subscribe(pid1, :v1, "KeyBlocks")
+      assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, :v2, "MicroBlocks")
+      assert {:ok, ["Transactions"]} = Subscriptions.subscribe(pid3, :v2, "Transactions")
+
+      assert Subscriptions.has_subscribers(:v1, "KeyBlocks")
+      assert Subscriptions.has_subscribers(:v2, "MicroBlocks")
+      assert Subscriptions.has_subscribers(:v2, "Transactions")
+
+      refute Subscriptions.has_subscribers(:v2, "KeyBlocks")
+      refute Subscriptions.has_subscribers(:v1, "MicroBlocks")
+      refute Subscriptions.has_subscribers(:v1, "Transactions")
+    end
+  end
+
+  describe "has_object_subscribers/1" do
+    test "returns true if there is any object channel subscribed for a version" do
+      pid1 = new_pid()
+      pid2 = new_pid()
+      pid3 = new_pid()
+
+      on_exit(fn -> unsubscribe_all([pid1, pid2, pid3]) end)
+
+      channel = encode(:oracle_pubkey, :crypto.strong_rand_bytes(32))
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid1, :v1, channel)
+      channel = encode(:contract_pubkey, :crypto.strong_rand_bytes(32))
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid2, :v2, channel)
+      assert {:ok, _list} = Subscriptions.subscribe(pid3, :v2, "Transactions")
+
+      assert Subscriptions.has_object_subscribers(:v1)
+      assert Subscriptions.has_object_subscribers(:v2)
+    end
+
+    test "returns false if there are no object channel subscribed for a version" do
+      pid1 = new_pid()
+      pid2 = new_pid()
+
+      on_exit(fn -> unsubscribe_all([pid1, pid2]) end)
+
+      channel1 = encode(:account_pubkey, :crypto.strong_rand_bytes(32))
+
+      assert {:ok, [^channel1]} = Subscriptions.subscribe(pid1, :v1, channel1)
+      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid2, :v2, "KeyBlocks")
+
+      assert Subscriptions.has_object_subscribers(:v1)
+      refute Subscriptions.has_object_subscribers(:v2)
     end
   end
 

--- a/test/ae_mdw/websocket/subscriptions_test.exs
+++ b/test/ae_mdw/websocket/subscriptions_test.exs
@@ -108,7 +108,7 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
     end
   end
 
-  describe "has_subscribers/2" do
+  describe "has_subscribers?/2" do
     test "checks if there is any subscriber for a known versioned channel" do
       pid1 = new_pid()
       pid2 = new_pid()
@@ -125,17 +125,17 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
       assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, :v2, "MicroBlocks")
       assert {:ok, ["Transactions"]} = Subscriptions.subscribe(pid3, :v2, "Transactions")
 
-      assert Subscriptions.has_subscribers(:v1, "KeyBlocks")
-      assert Subscriptions.has_subscribers(:v2, "MicroBlocks")
-      assert Subscriptions.has_subscribers(:v2, "Transactions")
+      assert Subscriptions.has_subscribers?(:v1, "KeyBlocks")
+      assert Subscriptions.has_subscribers?(:v2, "MicroBlocks")
+      assert Subscriptions.has_subscribers?(:v2, "Transactions")
 
-      refute Subscriptions.has_subscribers(:v2, "KeyBlocks")
-      refute Subscriptions.has_subscribers(:v1, "MicroBlocks")
-      refute Subscriptions.has_subscribers(:v1, "Transactions")
+      refute Subscriptions.has_subscribers?(:v2, "KeyBlocks")
+      refute Subscriptions.has_subscribers?(:v1, "MicroBlocks")
+      refute Subscriptions.has_subscribers?(:v1, "Transactions")
     end
   end
 
-  describe "has_object_subscribers/1" do
+  describe "has_object_subscribers?/1" do
     test "returns true if there is any object channel subscribed for a version" do
       pid1 = new_pid()
       pid2 = new_pid()
@@ -149,8 +149,8 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
       assert {:ok, [^channel]} = Subscriptions.subscribe(pid2, :v2, channel)
       assert {:ok, _list} = Subscriptions.subscribe(pid3, :v2, "Transactions")
 
-      assert Subscriptions.has_object_subscribers(:v1)
-      assert Subscriptions.has_object_subscribers(:v2)
+      assert Subscriptions.has_object_subscribers?(:v1)
+      assert Subscriptions.has_object_subscribers?(:v2)
     end
 
     test "returns false if there are no object channel subscribed for a version" do
@@ -164,8 +164,8 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
       assert {:ok, [^channel1]} = Subscriptions.subscribe(pid1, :v1, channel1)
       assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid2, :v2, "KeyBlocks")
 
-      assert Subscriptions.has_object_subscribers(:v1)
-      refute Subscriptions.has_object_subscribers(:v2)
+      assert Subscriptions.has_object_subscribers?(:v1)
+      refute Subscriptions.has_object_subscribers?(:v2)
     end
   end
 

--- a/test/support/ws_util.ex
+++ b/test/support/ws_util.ex
@@ -1,6 +1,10 @@
 defmodule Support.WsUtil do
   # credo:disable-for-this-file
 
+  def unsubscribe_all(version) when is_atom(version) do
+    :ets.match_delete(:subs_channel_pid, {{version, :_}, :_})
+  end
+
   def unsubscribe_all(pids) when is_list(pids) do
     Enum.each(pids, &do_unsubscribe_all/1)
   end
@@ -9,8 +13,8 @@ defmodule Support.WsUtil do
     :ets.delete(:subs_pids, pid)
 
     :subs_pid_channel
-    |> :ets.match_object({pid, :"$1"})
-    |> Enum.each(fn {^pid, channel_key} ->
+    |> :ets.match_object({pid, :"$1", :_})
+    |> Enum.each(fn {^pid, channel_key, _channel} ->
       :ets.delete_object(:subs_pid_channel, {pid, channel_key})
       :ets.delete_object(:subs_channel_pid, {channel_key, pid})
     end)


### PR DESCRIPTION
## What

- Enqueue a block or block + transactions only once to avoid filling GenServer mailbox with data to be discarded (same block that is synced multiple times is enqueued once).
- Enqueue only the microblock header (without transactions) for "MicroBlocks" subscription
- Skips fetching and serializing multiple transactions when there is no "Transactions" or "Object" subscription
- Simplify blocks serialization by reusing `Db.prev_block_type`

## Why

refs #1122 

- Faster delivery (it takes less time to get to broadcast the last blocks specially when the Mdw height lags behind Node height when recovering or on a full sync)
- Smaller websocket footprint 