### PR TITLE
refactor: remove duplicated v2 ws enqueuing

### DIFF
--- a/lib/ae_mdw/sync/server.ex
+++ b/lib/ae_mdw/sync/server.ex
@@ -329,21 +329,14 @@ defmodule AeMdw.Sync.Server do
     Enum.each(gens_mutations, fn {height, blocks_mutations} ->
       {mbs_mutations, [{{^height, -1}, key_block, _mutations}]} = Enum.split(blocks_mutations, -1)
 
-      # v1
-      Enum.each(mbs_mutations, fn {_block_index, micro_block, _mutations} ->
-        Broadcaster.broadcast_micro_block(micro_block, :v1, :mdw)
-        Broadcaster.broadcast_txs(micro_block, :v1, :mdw)
-      end)
-
-      Broadcaster.broadcast_key_block(key_block, :v1, :mdw)
-
-      # v2
       Broadcaster.broadcast_key_block(key_block, :v2, :mdw)
 
       Enum.each(mbs_mutations, fn {_block_index, micro_block, _mutations} ->
-        Broadcaster.broadcast_micro_block(micro_block, :v2, :mdw)
-        Broadcaster.broadcast_txs(micro_block, :v2, :mdw)
+        Broadcaster.broadcast_micro_block(micro_block, :mdw)
+        Broadcaster.broadcast_txs(micro_block, :mdw)
       end)
+
+      Broadcaster.broadcast_key_block(key_block, :v1, :mdw)
     end)
   end
 end

--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -68,8 +68,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
     {:ok, hash} = block |> :aec_blocks.to_header() |> :aec_headers.hash_header()
 
     if not already_processed?({:txs, hash, source}) do
-      versions = if broadcast_transaction?(:v1), do: [:v1], else: []
-      versions = if broadcast_transaction?(:v2), do: versions ++ [:v2], else: versions
+      versions = Enum.filter(~w(v1 v2)a, &broadcast_transaction?/1)
 
       if Enum.any?(versions) do
         GenServer.cast(__MODULE__, {:broadcast_txs, block, source, versions})
@@ -291,13 +290,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
   end
 
   defp get_subscribed_versions(channel) do
-    Enum.reduce([:v1, :v2], [], fn version, acc ->
-      if Subscriptions.has_subscribers?(version, channel) do
-        [version | acc]
-      else
-        acc
-      end
-    end)
+    Enum.filter([:v1, :v2], &Subscriptions.has_subscribers?(&1, channel))
   end
 
   defp already_processed?(type_hash), do: EtsCache.member(@hashes_table, type_hash)

--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -35,35 +35,47 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
     {:ok, hash} = :aec_headers.hash_header(header)
 
     if not already_processed?({:key, version, hash, source}) do
-      GenServer.cast(__MODULE__, {:broadcast_key_block, version, header, source})
+      if Subscriptions.has_subscribers?(version, "KeyBlocks") do
+        GenServer.cast(__MODULE__, {:broadcast_key_block, version, header, source})
+      end
+
       set_processed({:key, version, hash, source})
     end
 
     :ok
   end
 
-  @spec broadcast_micro_block(Db.micro_block(), version(), source()) :: :ok
-  def broadcast_micro_block(block, version, source) do
+  @spec broadcast_micro_block(Db.micro_block(), source()) :: :ok
+  def broadcast_micro_block(block, source) do
     header = :aec_blocks.to_header(block)
     {:ok, hash} = :aec_headers.hash_header(header)
 
-    if not already_processed?({:micro, version, hash, source}) do
-      GenServer.cast(__MODULE__, {:broadcast_micro_block, version, header, source})
-      set_processed({:micro, version, hash, source})
+    if not already_processed?({:micro, hash, source}) do
+      versions = get_subscribed_versions("MicroBlocks")
+
+      if Enum.any?(versions) do
+        GenServer.cast(__MODULE__, {:broadcast_micro_block, header, source, versions})
+      end
+
+      set_processed({:micro, hash, source})
     end
 
     :ok
   end
 
-  @spec broadcast_txs(Db.micro_block(), version(), source()) :: :ok
-  def broadcast_txs(block, version, source) do
+  @spec broadcast_txs(Db.micro_block(), source()) :: :ok
+  def broadcast_txs(block, source) do
     {:ok, hash} = block |> :aec_blocks.to_header() |> :aec_headers.hash_header()
 
-    if not already_processed?({:txs, version, hash, source}) &&
-         (Subscriptions.has_subscribers?(version, "Transactions") ||
-            Subscriptions.has_object_subscribers?(version)) do
-      GenServer.cast(__MODULE__, {:broadcast_txs, version, block, source})
-      set_processed({:txs, version, hash, source})
+    if not already_processed?({:txs, hash, source}) do
+      versions = if broadcast_transaction?(:v1), do: [:v1], else: []
+      versions = if broadcast_transaction?(:v2), do: versions ++ [:v2], else: versions
+
+      if Enum.any?(versions) do
+        GenServer.cast(__MODULE__, {:broadcast_txs, block, source, versions})
+      end
+
+      set_processed({:txs, hash, source})
     end
 
     :ok
@@ -77,15 +89,15 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
   end
 
   @impl GenServer
-  def handle_cast({:broadcast_micro_block, version, header, source}, state) do
-    do_broadcast_micro_block(header, version, source)
+  def handle_cast({:broadcast_micro_block, header, source, versions}, state) do
+    Enum.each(versions, &do_broadcast_micro_block(header, &1, source))
 
     {:noreply, state}
   end
 
   @impl GenServer
-  def handle_cast({:broadcast_txs, version, block, source}, state) do
-    do_broadcast_txs(block, version, source)
+  def handle_cast({:broadcast_txs, micro_block, source, versions}, state) do
+    Enum.each(versions, &do_broadcast_txs(micro_block, &1, source))
 
     {:noreply, state}
   end
@@ -278,7 +290,22 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
     |> Enum.uniq()
   end
 
+  defp get_subscribed_versions(channel) do
+    Enum.reduce([:v1, :v2], [], fn version, acc ->
+      if Subscriptions.has_subscribers?(version, channel) do
+        [version | acc]
+      else
+        acc
+      end
+    end)
+  end
+
   defp already_processed?(type_hash), do: EtsCache.member(@hashes_table, type_hash)
 
   defp set_processed(type_hash), do: EtsCache.put(@hashes_table, type_hash, true)
+
+  defp broadcast_transaction?(version) do
+    Subscriptions.has_subscribers?(version, "Transactions") ||
+      Subscriptions.has_object_subscribers?(version)
+  end
 end

--- a/lib/ae_mdw_web/websocket/chain_listener.ex
+++ b/lib/ae_mdw_web/websocket/chain_listener.ex
@@ -23,10 +23,8 @@ defmodule AeMdwWeb.Websocket.ChainListener do
   def handle_info({:gproc_ps_event, :top_changed, %{info: %{block_type: :micro} = info}}, state) do
     case :aehttp_logic.get_micro_block_by_hash(info.block_hash) do
       {:ok, block} ->
-        Broadcaster.broadcast_micro_block(block, :v1, :node)
-        Broadcaster.broadcast_micro_block(block, :v2, :node)
-        Broadcaster.broadcast_txs(block, :v1, :node)
-        Broadcaster.broadcast_txs(block, :v2, :node)
+        Broadcaster.broadcast_micro_block(block, :node)
+        Broadcaster.broadcast_txs(block, :node)
 
       {:error, :block_not_found} ->
         Log.warn("gproc_ps_event with block not found: block_hash = #{inspect(info.block_hash)}")

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -19,6 +19,6 @@ case $1 in
     ;;
 
   "test")
-    MIX_ENV=test elixir --sname $NAME -S mix test
+    elixir --sname $NAME -S mix test
     ;;
 esac

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -19,6 +19,6 @@ case $1 in
     ;;
 
   "test")
-    elixir --sname $NAME -S mix test
+    MIX_ENV=test elixir --sname $NAME -S mix test
     ;;
 esac

--- a/test/ae_mdw/websocket/subscriptions_test.exs
+++ b/test/ae_mdw/websocket/subscriptions_test.exs
@@ -159,16 +159,20 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
     test "returns false if there are no object channel subscribed for a version" do
       pid1 = new_pid()
       pid2 = new_pid()
+      pid3 = new_pid()
 
-      on_exit(fn -> unsubscribe_all([pid1, pid2]) end)
+      on_exit(fn -> unsubscribe_all([pid1, pid2, pid3]) end)
 
       unsubscribe_all(:v1)
       unsubscribe_all(:v2)
 
       channel1 = encode(:account_pubkey, :crypto.strong_rand_bytes(32))
 
-      assert {:ok, [^channel1]} = Subscriptions.subscribe(pid1, :v1, channel1)
-      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid2, :v2, "KeyBlocks")
+      assert {:ok, _subs} = Subscriptions.subscribe(pid1, :v1, channel1)
+      assert {:ok, _subs} = Subscriptions.subscribe(pid2, :v2, "KeyBlocks")
+      assert {:ok, _subs} = Subscriptions.subscribe(pid2, :v2, "MicroBlocks")
+      assert {:ok, _subs} = Subscriptions.subscribe(pid3, :v2, "MicroBlocks")
+      assert {:ok, _subs} = Subscriptions.subscribe(pid3, :v2, "Transactions")
 
       assert Subscriptions.has_object_subscribers?(:v1)
       refute Subscriptions.has_object_subscribers?(:v2)


### PR DESCRIPTION
- Specialize only the order of key blocks (before or after micro blocks+transactions)
- Skips enqueuing micro blocks when there is no subscription