### PR TITLE
fix: use proper names for transaction types for events and transactions

### DIFF
--- a/lib/ae_mdw/db/channels.ex
+++ b/lib/ae_mdw/db/channels.ex
@@ -62,7 +62,7 @@ defmodule AeMdw.Db.Channels do
 
   @spec settle_mutations(bi_txi(), Node.tx()) :: [Mutation.t()]
   def settle_mutations(bi_txi, tx) do
-    channel_pk = :aesc_close_settle_tx.channel_pubkey(tx)
+    channel_pk = :aesc_settle_tx.channel_pubkey(tx)
 
     %{"initiator_amount_final" => initiator_amount, "responder_amount_final" => responder_amount} =
       :aesc_settle_tx.for_client(tx)

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -5,6 +5,7 @@ defmodule AeMdw.Db.Sync.Contract do
   alias AeMdw.Blocks
   alias AeMdw.Contract
   alias AeMdw.AexnContracts
+  alias AeMdw.Db.Channels
   alias AeMdw.Db.IntCallsMutation
   alias AeMdw.Db.Model
   alias AeMdw.Db.Mutation
@@ -149,7 +150,7 @@ defmodule AeMdw.Db.Sync.Contract do
       {local_idx, "Oracle.register", :oracle_register_tx, _aetx, tx} ->
         Oracle.register_mutations(tx, tx_hash, block_index, {call_txi, local_idx})
 
-      {_local_idx, "Oracle.respond", :oracle_respond_tx, _aetx, tx} ->
+      {_local_idx, "Oracle.respond", :oracle_response_tx, _aetx, tx} ->
         Oracle.response_mutation(tx, block_index, call_txi)
 
       {_local_idx, "Oracle.query", :oracle_query_tx, _aetx, tx} ->
@@ -168,6 +169,12 @@ defmodule AeMdw.Db.Sync.Contract do
         tx
         |> :aens_revoke_tx.name_hash()
         |> NameRevokeMutation.new({call_txi, local_idx}, block_index)
+
+      {_local_idx, "Channel.withdraw", :channel_withdraw_tx, _aetx, tx} ->
+        Channels.withdraw_mutations({block_index, call_txi}, tx)
+
+      {_local_idx, "Channel.settle", :channel_settle_tx, _aetx, tx} ->
+        Channels.settle_mutations({block_index, call_txi}, tx)
 
       {_local_idx, _fname, _tx_type, _aetx, _tx} ->
         []

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -124,6 +124,7 @@ defmodule AeMdw.Db.Sync.Transaction do
     ]
   end
 
+  @spec tx_mutations(TxContext.t()) :: [Mutation.t()]
   defp tx_mutations(%TxContext{
          type: :contract_create_tx,
          tx: tx,
@@ -237,7 +238,7 @@ defmodule AeMdw.Db.Sync.Transaction do
   end
 
   defp tx_mutations(%TxContext{
-         type: :asec_close_solo_tx,
+         type: :channel_close_solo_tx,
          block_index: block_index,
          txi: txi,
          tx: tx
@@ -245,15 +246,20 @@ defmodule AeMdw.Db.Sync.Transaction do
        do: Channels.close_solo_mutations({block_index, txi}, tx)
 
   defp tx_mutations(%TxContext{
-         type: :asec_close_mutual_tx,
+         type: :channel_close_mutual_tx,
          block_index: block_index,
          txi: txi,
          tx: tx
        }),
        do: Channels.close_mutual_mutations({block_index, txi}, tx)
 
-  defp tx_mutations(%TxContext{type: :asec_settle_tx, block_index: block_index, txi: txi, tx: tx}),
-    do: Channels.settle_mutations({block_index, txi}, tx)
+  defp tx_mutations(%TxContext{
+         type: :channel_settle_tx,
+         block_index: block_index,
+         txi: txi,
+         tx: tx
+       }),
+       do: Channels.settle_mutations({block_index, txi}, tx)
 
   defp tx_mutations(%TxContext{
          type: :channel_deposit_tx,

--- a/mix.exs
+++ b/mix.exs
@@ -74,7 +74,6 @@ defmodule AeMdw.MixProject do
           :aeo_utils,
           :aesc_channels,
           :aesc_close_mutual_tx,
-          :aesc_close_settle_tx,
           :aesc_close_solo_tx,
           :aesc_create_tx,
           :aesc_deposit_tx,


### PR DESCRIPTION
In addition, include support for Channel.withdraw and settle events.

NOTE: This change will require a full resync.