### PR TITLE
Add NODE_URL docker build argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,10 @@ WORKDIR /home/aeternity/node
 
 # Download, and unzip latest aeternity release archive
 ARG NODE_VERSION=6.7.0
+ARG NODE_URL=https://github.com/aeternity/aeternity/releases/download/v${NODE_VERSION}/aeternity-v${NODE_VERSION}-ubuntu-x86_64.tar.gz
 ENV NODEDIR=/home/aeternity/node/local/rel/aeternity
 RUN mkdir -p ./local/rel/aeternity/data/mnesia
-RUN curl -L --output aeternity.tar.gz https://github.com/aeternity/aeternity/releases/download/v${NODE_VERSION}/aeternity-v${NODE_VERSION}-ubuntu-x86_64.tar.gz && tar -C ./local/rel/aeternity -xf aeternity.tar.gz
+RUN curl -L --output aeternity.tar.gz ${NODE_URL} && tar -C ./local/rel/aeternity -xf aeternity.tar.gz
 
 RUN chmod +x ${NODEDIR}/bin/aeternity
 RUN cp -r ./local/rel/aeternity/lib local/


### PR DESCRIPTION
More often than not, the mdw docker image needs to be build with dev/unreleased node versions i.e. master (https://builds.aeternity.io/aeternity-latest-ubuntu-x86_64.tar.gz). 

This change allows that as otherwise default URL pattern (NODE_VERSION) does not.