### PR TITLE
chore: use mix releases for prod docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,37 +1,24 @@
-# The directory Mix will write compiled artifacts to.
-/_build/
+.dockerignore
 
-# If you run "mix test --cover", coverage assets end up here.
+# Common development/test artifacts
 /cover/
-
-# The directory Mix downloads your dependencies sources to.
-/deps/
-
-# Where 3rd-party dependencies like ExDoc output generated docs.
 /doc/
+/test/
+/tmp/
+.elixir_ls
 
-# Ignore .fetch files in case you like to edit your project deps locally.
-/.fetch
-
-# If the VM crashes, it generates a dump, let's ignore it too.
-erl_crash.dump
-
-# Also ignore archive artifacts (built via "mix archive.build").
+# Mix artifacts
+/_build/
+/deps/
 *.ez
 
-# Ignore package tarball (built via "mix hex.build").
-ae_mdw-*.tar
+# Generated on crash by the VM
+erl_crash.dump
 
-# If NPM crashes, it generates a log, let's ignore it too.
-npm-debug.log
-
-.DS_Store
-.elixir_ls/
-log/
-
-/priv/
-!/priv/migrations
-!/priv/static
+# Static artifacts - These should be fetched and built inside the Docker image
+/assets/node_modules/
+/priv/static/assets/
+/priv/static/cache_manifest.json
 
 # MDW's produced blockchain database should be ignored
 /data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN mix release
 # the compiled release and other runtime necessities
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales libncurses5 libsodium-dev jq libgmp10 curl \
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales libncurses5 libsodium-dev libgmp10 \
   && ldconfig \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,30 @@
-FROM hexpm/elixir:1.13.4-erlang-23.3.4.17-debian-buster-20220801
-# Add required files to download and compile only the dependencies
+# Find eligible builder and runner images on Docker Hub. We use Ubuntu/Debian instead of
+# Alpine to avoid DNS resolution issues in production.
+#
+# https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=ubuntu
+# https://hub.docker.com/_/ubuntu?tab=tags
+#
+#
+# This file is based on these images:
+#
+#   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20220801-slim - for the release image
+#   - https://pkgs.org/ - resource for finding needed packages
+#   - Ex: hexpm/elixir:1.13.4-erlang-23.3.4.17-debian-bullseye-20210902-slim
+#
+ARG ELIXIR_VERSION=1.13.4
+ARG OTP_VERSION=23.3.4.17
+ARG DEBIAN_VERSION=bullseye-20220801-slim
 
-# Install other required dependencies
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+
+FROM ${BUILDER_IMAGE} as builder
+
+# install build dependencies
+RUN apt-get update -y && apt-get install -y build-essential git \
+    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
 RUN apt-get -qq update && apt-get -qq -y install git curl libncurses5 libsodium-dev jq libgmp10 \
     && ldconfig \
     && rm -rf /var/lib/apt/lists/*
@@ -19,6 +42,7 @@ RUN rm -r .git
 WORKDIR /home/aeternity/node
 
 # Download, and unzip latest aeternity release archive
+ENV NODEROOT=/home/aeternity/node/local
 ARG NODE_VERSION=6.7.0
 ARG NODE_URL=https://github.com/aeternity/aeternity/releases/download/v${NODE_VERSION}/aeternity-v${NODE_VERSION}-ubuntu-x86_64.tar.gz
 ENV NODEDIR=/home/aeternity/node/local/rel/aeternity
@@ -31,26 +55,74 @@ RUN cp -r ./local/rel/aeternity/lib local/
 # Check if the config file is OK
 RUN ${NODEDIR}/bin/aeternity check_config /home/aeternity/aeternity.yaml
 
-# Copy all files, needed to build the project
-COPY config ./ae_mdw/config
-COPY lib ./ae_mdw/lib
-COPY priv ./ae_mdw/priv
-COPY mix.exs ae_mdw
-COPY mix.lock ae_mdw
-COPY docker/entrypoint.sh ae_mdw/entrypoint.sh
-
-# Start building the mdw
+# prepare build dir
 WORKDIR /home/aeternity/node/ae_mdw
-RUN  mix local.hex --force && mix local.rebar --force
 
-# Fetch the application dependencies and build it
-ARG MIX_ENV
-ENV MIX_ENV=${MIX_ENV}
-RUN mix deps.get
+# install hex + rebar
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
+# set build ENV
+ENV MIX_ENV="prod"
+
+# install mix dependencies
+COPY mix.exs mix.lock ./
+RUN mix deps.get --only $MIX_ENV
+RUN mkdir config
+
+# copy compile-time config files before we compile dependencies
+# to ensure any relevant config change will trigger the dependencies
+# to be re-compiled.
+COPY config/config.exs config/${MIX_ENV}.exs config/
 RUN mix deps.compile
-ENV NODEROOT=/home/aeternity/node/local
-RUN mix compile
-RUN mix phx.digest
 
-RUN chmod +x entrypoint.sh
-ENTRYPOINT [ "./entrypoint.sh" ]
+COPY priv priv
+
+COPY lib lib
+
+# Compile the release
+RUN mix compile
+
+# Changes to config/runtime.exs don't require recompiling the code
+COPY config/runtime.exs config/
+
+COPY rel rel
+ENV RELEASE_NODE=aeternity@localhost
+ENV RELEASE_DISTRIBUTION=name
+RUN mix release
+
+# start a new build stage so that the final image will only contain
+# the compiled release and other runtime necessities
+FROM ${RUNNER_IMAGE}
+
+RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales libncurses5 libsodium-dev jq libgmp10 curl \
+  && ldconfig \
+  && apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# Set the locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV NODEROOT=/home/aeternity/node/local
+ENV NODEDIR=/home/aeternity/node/local/rel/aeternity
+
+WORKDIR "/home/aeternity/node"
+
+# set runner ENV
+ENV MIX_ENV="prod"
+ENV AETERNITY_CONFIG=/home/aeternity/aeternity.yaml
+
+# Only copy the final release from the build stage
+COPY --from=builder --chown=nobody:root /home/aeternity/node/ae_mdw/_build/${MIX_ENV}/rel/ae_mdw ./
+COPY --from=builder --chown=nobody:root /home/aeternity/node/local ./local
+COPY ./docker/aeternity.yaml /home/aeternity/aeternity.yaml
+
+RUN mkdir -p ./local/rel/aeternity/data/mnesia
+
+RUN chown -R nobody /home/aeternity/node
+
+USER nobody
+
+CMD ["/home/aeternity/node/bin/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,9 @@ ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 FROM ${BUILDER_IMAGE} as builder
 
 # install build dependencies
-RUN apt-get update -y && apt-get install -y build-essential git \
-    && apt-get clean && rm -f /var/lib/apt/lists/*_*
-
-RUN apt-get -qq update && apt-get -qq -y install git curl libncurses5 libsodium-dev jq libgmp10 \
+RUN apt-get update -y && apt-get install -y build-essential git curl libncurses5 libsodium-dev jq libgmp10 \
     && ldconfig \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Prepare working folder

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,56 @@
+FROM hexpm/elixir:1.13.4-erlang-23.3.4.17-debian-buster-20220801
+# Add required files to download and compile only the dependencies
+
+# Install other required dependencies
+RUN apt-get -qq update && apt-get -qq -y install git curl libncurses5 libsodium-dev jq libgmp10 \
+    && ldconfig \
+    && rm -rf /var/lib/apt/lists/*
+
+# Prepare working folder
+RUN mkdir -p /home/aeternity/node
+COPY ./docker/aeternity.yaml /home/aeternity/aeternity.yaml
+
+# Set build git revision
+RUN mkdir /home/aeternity/node/ae_mdw
+COPY .git .git
+RUN BUILD_REV="$(git log -1 --format=%h)" && echo $BUILD_REV > /home/aeternity/node/ae_mdw/AEMDW_REVISION
+RUN rm -r .git
+
+WORKDIR /home/aeternity/node
+
+# Download, and unzip latest aeternity release archive
+ARG NODE_VERSION=6.7.0
+ARG NODE_URL=https://github.com/aeternity/aeternity/releases/download/v${NODE_VERSION}/aeternity-v${NODE_VERSION}-ubuntu-x86_64.tar.gz
+ENV NODEDIR=/home/aeternity/node/local/rel/aeternity
+RUN mkdir -p ./local/rel/aeternity/data/mnesia
+RUN curl -L --output aeternity.tar.gz ${NODE_URL} && tar -C ./local/rel/aeternity -xf aeternity.tar.gz
+
+RUN chmod +x ${NODEDIR}/bin/aeternity
+RUN cp -r ./local/rel/aeternity/lib local/
+
+# Check if the config file is OK
+RUN ${NODEDIR}/bin/aeternity check_config /home/aeternity/aeternity.yaml
+
+# Copy all files, needed to build the project
+COPY config ./ae_mdw/config
+COPY lib ./ae_mdw/lib
+COPY priv ./ae_mdw/priv
+COPY mix.exs ae_mdw
+COPY mix.lock ae_mdw
+COPY docker/entrypoint.sh ae_mdw/entrypoint.sh
+
+# Start building the mdw
+WORKDIR /home/aeternity/node/ae_mdw
+RUN  mix local.hex --force && mix local.rebar --force
+
+# Fetch the application dependencies and build it
+ARG MIX_ENV
+ENV MIX_ENV=${MIX_ENV}
+RUN mix deps.get
+RUN mix deps.compile
+ENV NODEROOT=/home/aeternity/node/local
+RUN mix compile
+RUN mix phx.digest
+
+RUN chmod +x entrypoint.sh
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,5 +1,7 @@
 import Config
 
+env = config_env()
+
 #
 # Telemetry
 #
@@ -7,7 +9,7 @@ period = String.to_integer(System.get_env("TELEMETRY_POLLER_PERIOD") || "10000")
 
 config :ae_mdw, AeMdw.APM.TelemetryPoller, period: period
 
-if config_env() in [:test, :prod] do
+if env in [:test, :prod] do
   if System.get_env("ENABLE_TELEMETRY", "false") in ["true", "1"] do
     {:ok, hostname} = :inet.gethostname()
     host = System.get_env("TELEMETRY_STATSD_HOST") || to_string(hostname)
@@ -36,5 +38,9 @@ if config_env() in [:test, :prod] do
     opts = if formatter == "datadog", do: opts ++ datadog_opts, else: opts
 
     config :logger_json, :backend, opts
+  end
+
+  if env == :prod do
+    config :ae_mdw, AeMdwWeb.Endpoint, server: true
   end
 end

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,7 +3,7 @@ services:
   ae_mdw:
     build:
       context: .
-      dockerfile: ./Dockerfile
+      dockerfile: ./Dockerfile.dev
       args:
         MIX_ENV: dev
     image: aeternity/ae_mdw_dev:latest

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -3,7 +3,7 @@ services:
   ae_mdw:
     build:
       context: .
-      dockerfile: ./Dockerfile
+      dockerfile: ./Dockerfile.dev
       args:
         MIX_ENV: test
     image: aeternity/ae_mdw_test:latest

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export RELEASE_MODE=interactive

--- a/rel/overlays/bin/server
+++ b/rel/overlays/bin/server
@@ -1,0 +1,3 @@
+#!/bin/sh
+cd -P -- "$(dirname -- "$0")"
+PHX_SERVER=true exec ./ae_mdw start

--- a/rel/overlays/bin/server.bat
+++ b/rel/overlays/bin/server.bat
@@ -1,0 +1,2 @@
+set PHX_SERVER=true
+call "%~dp0\ae_mdw" start


### PR DESCRIPTION
This is done using [Mix.Task.Release](https://hexdocs.pm/mix/Mix.Tasks.Release.html) together with the
[auto-generated Dockerfile](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Gen.Release.html)

This helped reduce the image size to half its size, and it might also help with BEAM code loading efficiency.