### PR TITLE
fix: add address to Burn event

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -436,7 +436,10 @@ defmodule AeMdw.Db.Contract do
     end
   end
 
-  defp write_aex141_records(state, :burn, contract_pk, _txi, _log_idx, [<<token_id::256>>]) do
+  defp write_aex141_records(state, :burn, contract_pk, _txi, _log_idx, [
+         _owner_pk,
+         <<token_id::256>>
+       ]) do
     state = delete_aex141_ownership(state, contract_pk, token_id)
 
     case State.get(state, Model.NftTokenTemplate, {contract_pk, token_id}) do

--- a/test/ae_mdw/db/contract_call_mutation_test.exs
+++ b/test/ae_mdw/db/contract_call_mutation_test.exs
@@ -1270,7 +1270,7 @@ defmodule AeMdw.Db.ContractCallMutationTest do
 
       call_rec =
         call_rec("logs", contract_pk, height, nil, [
-          {contract_pk, [aexn_event_hash(:burn), <<token_id1::256>>], ""}
+          {contract_pk, [aexn_event_hash(:burn), owner_pk, <<token_id1::256>>], ""}
         ])
 
       mutation =


### PR DESCRIPTION
The function receives only the amount but the event has the owner address just for logging (should not be used for actual update to avoid ilegit burning)