### PR TITLE
chore: remove console info log for dev environment

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -22,7 +22,7 @@ config :ae_mdw, AeMdwWeb.WebsocketEndpoint,
 
 # Logging
 config :logger,
-  backends: [:console, {LoggerFileBackend, :info}]
+  backends: [{LoggerFileBackend, :info}]
 
 # Phoenix
 config :phoenix, :stacktrace_depth, 20


### PR DESCRIPTION
When using interactive shells for dev development these logs interfere with the general usage.