### PR TITLE
chore: remove oracle query response check

### DIFF
--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -335,7 +335,7 @@ defmodule AeMdw.Db.Model do
             index: oracle_query_index(),
             txi: txi(),
             sender_pk: pubkey(),
-            fee: non_neg_integer(),
+            fee: IntTransfer.amount(),
             expire: height()
           )
 

--- a/lib/ae_mdw/db/mutations/oracle_query_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracle_query_mutation.ex
@@ -9,11 +9,12 @@ defmodule AeMdw.Db.OracleQueryMutation do
   alias AeMdw.Db.State
   alias AeMdw.Node.Db
   alias AeMdw.Oracles
+  alias AeMdw.Txs
 
   require Model
 
   @derive AeMdw.Db.Mutation
-  defstruct [:oracle_pk, :query_id, :sender_pk, :fee, :expiration_height]
+  defstruct [:oracle_pk, :query_id, :txi, :sender_pk, :fee, :expiration_height]
 
   @typep height() :: Blocks.height()
   @typep amount() :: IntTransfer.amount()
@@ -21,16 +22,18 @@ defmodule AeMdw.Db.OracleQueryMutation do
   @opaque t() :: %__MODULE__{
             oracle_pk: Db.pubkey(),
             query_id: query_id(),
+            txi: Txs.txi(),
             sender_pk: Db.pubkey(),
             fee: amount(),
             expiration_height: height()
           }
 
-  @spec new(Db.pubkey(), query_id(), Db.pubkey(), amount(), height()) :: t()
-  def new(oracle_pk, query_id, sender_pk, fee, expiration_height) do
+  @spec new(Db.pubkey(), query_id(), Txs.txi(), Db.pubkey(), amount(), height()) :: t()
+  def new(oracle_pk, query_id, txi, sender_pk, fee, expiration_height) do
     %__MODULE__{
       oracle_pk: oracle_pk,
       query_id: query_id,
+      txi: txi,
       sender_pk: sender_pk,
       fee: fee,
       expiration_height: expiration_height
@@ -42,6 +45,7 @@ defmodule AeMdw.Db.OracleQueryMutation do
         %__MODULE__{
           oracle_pk: oracle_pk,
           query_id: query_id,
+          txi: txi,
           sender_pk: sender_pk,
           fee: fee,
           expiration_height: expiration_height
@@ -51,6 +55,7 @@ defmodule AeMdw.Db.OracleQueryMutation do
     oracle_query =
       Model.oracle_query(
         index: {oracle_pk, query_id},
+        txi: txi,
         fee: fee,
         expire: expiration_height,
         sender_pk: sender_pk

--- a/lib/ae_mdw/db/mutations/oracle_query_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracle_query_mutation.ex
@@ -3,17 +3,14 @@ defmodule AeMdw.Db.OracleQueryMutation do
   Processes oracle_query_tx.
   """
 
-  alias :aeser_api_encoder, as: Enc
   alias AeMdw.Blocks
   alias AeMdw.Db.IntTransfer
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
-  alias AeMdw.Log
   alias AeMdw.Node.Db
   alias AeMdw.Oracles
 
   require Model
-  require Logger
 
   @derive AeMdw.Db.Mutation
   defstruct [:oracle_pk, :query_id, :sender_pk, :fee, :expiration_height]
@@ -51,26 +48,18 @@ defmodule AeMdw.Db.OracleQueryMutation do
         },
         state
       ) do
-    if State.exists?(state, Model.OracleQuery, {oracle_pk, query_id}) do
-      oracle = Enc.encode(:oracle_pubkey, oracle_pk)
-      query_id = Enc.encode(:oracle_query_id, query_id)
+    oracle_query =
+      Model.oracle_query(
+        index: {oracle_pk, query_id},
+        fee: fee,
+        expire: expiration_height,
+        sender_pk: sender_pk
+      )
 
-      Log.info("[OracleQueryMutation] Query ID #{query_id} for oracle #{oracle} already exists")
-      state
-    else
-      oracle_query =
-        Model.oracle_query(
-          index: {oracle_pk, query_id},
-          fee: fee,
-          expire: expiration_height,
-          sender_pk: sender_pk
-        )
+    expiration = Model.oracle_query_expiration(index: {expiration_height, oracle_pk, query_id})
 
-      expiration = Model.oracle_query_expiration(index: {expiration_height, oracle_pk, query_id})
-
-      state
-      |> State.put(Model.OracleQuery, oracle_query)
-      |> State.put(Model.OracleQueryExpiration, expiration)
-    end
+    state
+    |> State.put(Model.OracleQuery, oracle_query)
+    |> State.put(Model.OracleQueryExpiration, expiration)
   end
 end

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -152,7 +152,7 @@ defmodule AeMdw.Db.Sync.Contract do
         Oracle.response_mutation(tx, block_index, call_txi)
 
       {_local_idx, "Oracle.query", :oracle_query_tx, _aetx, tx} ->
-        Oracle.query_mutation(tx, height)
+        Oracle.query_mutation(tx, height, call_txi)
 
       {local_idx, "AENS.claim", :name_claim_tx, _aetx, tx} ->
         Name.name_claim_mutations(tx, tx_hash, block_index, {call_txi, local_idx})

--- a/lib/ae_mdw/db/sync/oracle.ex
+++ b/lib/ae_mdw/db/sync/oracle.ex
@@ -39,8 +39,8 @@ defmodule AeMdw.Db.Sync.Oracle do
     ]
   end
 
-  @spec query_mutation(Node.tx(), height()) :: OracleQueryMutation.t()
-  def query_mutation(tx, height) do
+  @spec query_mutation(Node.tx(), height(), Txs.txi()) :: OracleQueryMutation.t()
+  def query_mutation(tx, height, txi) do
     oracle_pk = Validate.id!(:aeo_query_tx.oracle_id(tx))
 
     expiration_height =
@@ -53,7 +53,7 @@ defmodule AeMdw.Db.Sync.Oracle do
     fee = :aeo_query_tx.query_fee(tx)
     sender_pk = :aeo_query_tx.sender_pubkey(tx)
 
-    OracleQueryMutation.new(oracle_pk, query_id, sender_pk, fee, expiration_height)
+    OracleQueryMutation.new(oracle_pk, query_id, txi, sender_pk, fee, expiration_height)
   end
 
   @spec response_mutation(Node.tx(), Blocks.block_index(), Txs.txi()) ::

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -365,10 +365,11 @@ defmodule AeMdw.Db.Sync.Transaction do
   defp tx_mutations(%TxContext{
          type: :oracle_query_tx,
          tx: tx,
+         txi: txi,
          block_index: {height, _mbi}
        }) do
     [
-      Oracle.query_mutation(tx, height)
+      Oracle.query_mutation(tx, height, txi)
     ]
   end
 


### PR DESCRIPTION
This change will require a new sync due to oracle query IDs being invalid before 1.40