### PR TITLE
docs: use /api and /v2/api path for swagger spec files to match node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,14 +82,15 @@ COPY lib lib
 COPY scripts scripts
 COPY docs docs
 
-# Generate swagger V2 file
-RUN scripts/swagger-docs.py >priv/static/swagger/swagger_v2.yaml
-
 # Compile the release
 RUN mix compile
 
 # Changes to config/runtime.exs don't require recompiling the code
 COPY config/runtime.exs config/
+
+# Generate swagger V2 file
+RUN mix run --no-start -e 'IO.puts(Mix.Project.config[:version])' >AEMDW_VERSION
+RUN scripts/swagger-docs.py >priv/static/swagger/swagger_v2.yaml
 
 COPY rel rel
 ENV RELEASE_NODE=aeternity@localhost

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ GET /status                              - middleware status
 
 There are two files providing a swagger specificiation of the endpoints for respective api versions:
 
-- https://petstore.swagger.io/?url=https://mainnet.aeternity.io/mdw/swagger/swagger_v1.yaml
-- https://petstore.swagger.io/?url=https://mainnet.aeternity.io/mdw/swagger/swagger_v2.yaml
+- https://petstore.swagger.io/?url=https://mainnet.aeternity.io/mdw/api
+- https://petstore.swagger.io/?url=https://mainnet.aeternity.io/mdw/v2/api
 
 This npm package can be used for a self-hosted app to visualize these specs:
 https://www.npmjs.com/package/swagger-ui

--- a/lib/ae_mdw_web/controllers/util_controller.ex
+++ b/lib/ae_mdw_web/controllers/util_controller.ex
@@ -8,11 +8,18 @@ defmodule AeMdwWeb.UtilController do
   alias AeMdw.Error.Input
   alias Plug.Conn
 
-  @spec status(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  @spec status(Conn.t(), map()) :: Conn.t()
   def status(%Conn{assigns: %{state: state}} = conn, _params),
     do: json(conn, Status.node_and_mdw_status(state))
 
-  @spec no_route(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  @spec no_route(Conn.t(), map()) :: Conn.t()
   def no_route(conn, _params),
     do: AeMdwWeb.Util.send_error(conn, Input.NotFound, "no such route")
+
+  @spec static_file(Conn.t(), map()) :: Conn.t()
+  def static_file(%Conn{assigns: %{filepath: filepath}} = conn, _params) do
+    filepath = Application.app_dir(:ae_mdw, Path.join("priv", filepath))
+
+    send_file(conn, 200, filepath)
+  end
 end

--- a/lib/ae_mdw_web/controllers/util_controller.ex
+++ b/lib/ae_mdw_web/controllers/util_controller.ex
@@ -18,7 +18,7 @@ defmodule AeMdwWeb.UtilController do
 
   @spec static_file(Conn.t(), map()) :: Conn.t()
   def static_file(%Conn{assigns: %{filepath: filepath}} = conn, _params) do
-    filepath = Application.app_dir(:ae_mdw, Path.join("priv", filepath))
+    filepath = Path.join(:code.priv_dir(:ae_mdw), filepath)
 
     send_file(conn, 200, filepath)
   end

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -104,6 +104,9 @@ defmodule AeMdwWeb.Router do
       get "/deltastats", StatsController, :delta_stats
       get "/stats", StatsController, :stats
       get "/minerstats", StatsController, :miners
+
+      get "/api", UtilController, :static_file,
+        assigns: %{filepath: "static/swagger/swagger_v2.yaml"}
     end
 
     Enum.each(@shared_routes, fn {path, controller, fun} ->
@@ -191,6 +194,9 @@ defmodule AeMdwWeb.Router do
         live_dashboard "/dashboard", metrics: AeMdw.APM.Telemetry
       end
     end
+
+    get "/api", UtilController, :static_file,
+      assigns: %{filepath: "static/swagger/swagger_v1.yaml"}
 
     match :*, "/*path", UtilController, :no_route
   end

--- a/priv/static/swagger/swagger_v2.yaml
+++ b/priv/static/swagger/swagger_v2.yaml
@@ -1,0 +1,10 @@
+basePath: /
+consumes:
+  - application/json
+produces:
+  - application/json
+schemes:
+  - http
+swagger: '2.0'
+description: >
+  THIS FILE WILL BE OVERRIDDEN BY THE RELEASE PROCESS. DO NOT EDIT.

--- a/scripts/swagger-docs.py
+++ b/scripts/swagger-docs.py
@@ -6,7 +6,7 @@ from glob import glob
 from pathlib import Path
 
 SWAGGER_DOCS_DIR = 'docs/swagger_v2/'
-MDW_VERSION_FILE = 'AEMDW_REVISION'
+MDW_VERSION_FILE = 'AEMDW_VERSION'
 
 # Read YAML file
 schemas = {}

--- a/test/ae_mdw_web/controllers/util_controller_test.exs
+++ b/test/ae_mdw_web/controllers/util_controller_test.exs
@@ -1,0 +1,17 @@
+defmodule AeMdwWeb.UtilControllerTest do
+  use AeMdwWeb.ConnCase
+
+  describe "static_file" do
+    test "gets v1/v2 swagger files from priv directory", %{conn: conn} do
+      assert <<"basePath: ", _rest::binary>> =
+               conn
+               |> get("/api")
+               |> response(200)
+
+      assert <<"basePath: ", _rest::binary>> =
+               conn
+               |> get("/v2/api")
+               |> response(200)
+    end
+  end
+end

--- a/test/integration/ae_mdw_web/controllers/util_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/util_controller_test.exs
@@ -41,4 +41,18 @@ defmodule Integration.AeMdwWeb.UtilControllerTest do
       assert is_integer(producer_buffer) and is_integer(total_pending)
     end
   end
+
+  describe "static_file" do
+    test "gets v1/v2 swagger files from priv directory", %{conn: conn} do
+      assert <<"basePath: ", _rest::binary>> =
+               conn
+               |> get("/api")
+               |> response(200)
+
+      assert <<"basePath: ", _rest::binary>> =
+               conn
+               |> get("/v2/api")
+               |> response(200)
+    end
+  end
 end


### PR DESCRIPTION
refs #108
refs #674