### PR TITLE
fix: add base case for txs from gen

### DIFF
--- a/lib/ae_mdw/blocks.ex
+++ b/lib/ae_mdw/blocks.ex
@@ -166,7 +166,7 @@ defmodule AeMdw.Blocks do
         tx_index_end =
           case State.get(state, @table, {height + 1, -1}) do
             {:ok, Model.block(tx_index: tx_index_end)} -> tx_index_end - 1
-            :not_found -> last_txi(state, 0)
+            :not_found -> last_txi(state, -1)
           end
 
         if tx_index_end >= tx_index_start do

--- a/test/ae_mdw/blocks_test.exs
+++ b/test/ae_mdw/blocks_test.exs
@@ -11,6 +11,16 @@ defmodule AeMdw.BlocksTest do
   require Model
 
   describe "fetch_txis_from_gen/2" do
+    test "returns empty list when there are no transactions" do
+      state =
+        NullStore.new()
+        |> MemStore.new()
+        |> Store.put(Model.Block, Model.block(index: {0, -1}, tx_index: 0))
+        |> State.new()
+
+      assert [] = Enum.to_list(Blocks.fetch_txis_from_gen(state, 0))
+    end
+
     test "returns the range of txis from any two blocks" do
       state =
         NullStore.new()


### PR DESCRIPTION
Fix for issue found on HC tests when there is no transaction found:
```
hc_mdw_1           | 10:06:43.587 [error] CRASH REPORT Process <0.7859.0> with 0 neighbours exited with reason: {{{{#{'__exception__' => true,'__struct__' => 'Elixir.MatchError',term => {error,#{'__exception__' => true,'__struct__' => 'Elixir.AeMdw.Error.Input',message => <<"not found: 0">>,reason => 'Elixir.AeMdw.Error.Input.NotFound'}}},[{'Elixir.AeMdw.Txs','fetch!',3,[{file,"lib/ae_mdw/txs.ex"},{line,425}]},{'Elixir.AeMdw.Blocks','-render_blocks/3-fun-4-',2,[{file,"lib/ae_mdw/blocks.ex"},{line,270}]},{'Elixir.Enum','-map/2-fun-0-',3,[{file,"lib/enum.ex"},{line,1597}]},{'Elixir.Enum',reduce_range,...},...]},...},...},...}
hc_mdw_1           | 10:06:43.593 [error] Cowboy stream 5 with ranch listener 'Elixir.AeMdwWeb.Endpoint.HTTP' and connection process <0.6554.0> had its request process exit with reason: {{{#{'__exception__' => true,'__struct__' => 'Elixir.MatchError',term => {error,#{'__exception__' => true,'__struct__' => 'Elixir.AeMdw.Error.Input',message => <<"not found: 0">>,reason => 'Elixir.AeMdw.Error.Input.NotFound'}}},[{'Elixir.AeMdw.Txs','fetch!',3,[{file,"lib/ae_mdw/txs.ex"},{line,425}]},{'Elixir.AeMdw.Blocks','-render_blocks/3-fun-4-',2,[{file,"lib/ae_mdw/blocks.ex"},{line,270}]},{'Elixir.Enum','-map/2-fun-0-',3,[{file,"lib/enum.ex"},{line,1597}]},{'Elixir.Enum',reduce_range,5,...},...]},...},...}
hc_mdw_1           | 10:06:48.660 [error] CRASH REPORT Process <0.8111.0> with 0 neighbours exited with reason: {{{{#{'__exception__' => true,'__struct__' => 'Elixir.MatchError',term => {error,#{'__exception__' => true,'__struct__' => 'Elixir.AeMdw.Error.Input',message => <<"not found: 0">>,reason => 'Elixir.AeMdw.Error.Input.NotFound'}}},[{'Elixir.AeMdw.Txs','fetch!',3,[{file,"lib/ae_mdw/txs.ex"},{line,425}]},{'Elixir.AeMdw.Blocks','-render_blocks/3-fun-4-',2,[{file,"lib/ae_mdw/blocks.ex"},{line,270}]},{'Elixir.Enum','-map/2-fun-0-',3,[{file,"lib/enum.ex"},{line,1597}]},{'Elixir.Enum',reduce_range,...},...]},...},...},...}
hc_mdw_1           | 10:06:48.668 [error] Cowboy stream 1 with ranch listener 'Elixir.AeMdwWeb.Endpoint.HTTP' and connection process <0.8106.0> had its request process exit with reason: {{{#{'__exception__' => true,'__struct__' => 'Elixir.MatchError',term => {error,#{'__exception__' => true,'__struct__' => 'Elixir.AeMdw.Error.Input',message => <<"not found: 0">>,reason => 'Elixir.AeMdw.Error.Input.NotFound'}}},[{'Elixir.AeMdw.Txs','fetch!',3,[{file,"lib/ae_mdw/txs.ex"},{line,425}]},{'Elixir.AeMdw.Blocks','-render_blocks/3-fun-4-',2,[{file,"lib/ae_mdw/blocks.ex"},{line,270}]},{'Elixir.Enum','-map/2-fun-0-',3,[{file,"lib/enum.ex"},{line,1597}]},{'Elixir.Enum',reduce_range,5,...},...]},...},...}
```