### PR TITLE
chore: ignore oracle responses that don't have associated query

### DIFF
--- a/lib/ae_mdw/db/mutations/oracle_response_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracle_response_mutation.ex
@@ -3,16 +3,19 @@ defmodule AeMdw.Db.OracleResponseMutation do
   Processes oracle_response_tx.
   """
 
+  alias :aeser_api_encoder, as: Enc
   alias AeMdw.Blocks
   alias AeMdw.Db.IntTransfer
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
   alias AeMdw.Db.Util, as: DbUtil
+  alias AeMdw.Log
   alias AeMdw.Node.Db
   alias AeMdw.Oracles
   alias AeMdw.Txs
 
   require Model
+  require Logger
 
   @derive AeMdw.Db.Mutation
   defstruct [:block_index, :txi, :oracle_pk, :query_id]
@@ -45,12 +48,21 @@ defmodule AeMdw.Db.OracleResponseMutation do
         },
         state
       ) do
-    Model.oracle_query(txi_idx: txi_idx) =
-      State.fetch!(state, Model.OracleQuery, {oracle_pk, query_id})
+    case State.get(state, Model.OracleQuery, {oracle_pk, query_id}) do
+      {:ok, Model.oracle_query(txi_idx: txi_idx)} ->
+        oracle_query_tx = DbUtil.read_node_tx(state, txi_idx)
+        fee = :aeo_query_tx.query_fee(oracle_query_tx)
 
-    oracle_query_tx = DbUtil.read_node_tx(state, txi_idx)
-    fee = :aeo_query_tx.query_fee(oracle_query_tx)
+        IntTransfer.write(state, {height, txi}, "reward_oracle", oracle_pk, txi, fee)
 
-    IntTransfer.write(state, {height, txi}, "reward_oracle", oracle_pk, txi, fee)
+      :not_found ->
+        Log.info("""
+          [OracleResponseMutation] Oracle response not found on txi #{txi} for #{Enc.encode(:oracle_pubkey, oracle_pk)}
+          (query #{Enc.encode(:oracle_query_id, query_id)}).
+          Probably due to ga_meta transaction not calculating nonce correcctly.
+        """)
+
+        state
+    end
   end
 end


### PR DESCRIPTION
This is due to gameta oracle query transactions having the wrong nonce when returned by the node.