### PR TITLE
feat: filter inner txs fields with ga_meta type

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -89,8 +89,6 @@ defmodule AeMdw.Application do
         {tx_field_types, put_in(tx_fields[type], fields), put_in(tx_ids[type], ids)}
       end)
 
-    IO.inspect(tx_ids)
-
     inner_field_positions =
       tx_ids
       |> Map.values()

--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -89,7 +89,24 @@ defmodule AeMdw.Application do
         {tx_field_types, put_in(tx_fields[type], fields), put_in(tx_ids[type], ids)}
       end)
 
-    tx_ids_values =
+    IO.inspect(tx_ids)
+
+    inner_field_positions =
+      tx_ids
+      |> Map.values()
+      |> Enum.flat_map(fn fields_pos_map ->
+        Enum.map(fields_pos_map, fn
+          {:ga_id, pos} -> {:ga_id, pos}
+          {:payer_id, pos} -> {:payer_id, pos}
+          {field, pos} -> {field, AeMdw.Fields.field_pos_mask(:ga_meta_tx, pos)}
+        end)
+      end)
+      |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+      |> Enum.into(%{}, fn {field, positions} ->
+        {field, Enum.uniq(positions)}
+      end)
+
+    tx_ids_positions =
       Enum.into(tx_ids, %{}, fn {type, field_ids} ->
         {type, Map.values(field_ids)}
       end)
@@ -124,7 +141,8 @@ defmodule AeMdw.Application do
         tx_type: Util.inverse(type_name_map),
         tx_fields: tx_fields,
         tx_ids: tx_ids,
-        tx_ids_values: tx_ids_values,
+        tx_ids_positions: tx_ids_positions,
+        inner_field_positions: inner_field_positions,
         id_prefix: id_prefix_type_map,
         id_field_type: id_field_type_map |> Enum.concat([{[:_], nil}]),
         id_fields: [{[], MapSet.new(id_fields)}],

--- a/lib/ae_mdw/db/mutations/int_calls_mutation.ex
+++ b/lib/ae_mdw/db/mutations/int_calls_mutation.ex
@@ -65,7 +65,7 @@ defmodule AeMdw.Db.IntCallsMutation do
         |> State.put(Model.FnameGrpIntContractCall, m_fname_grp_call)
 
       tx_type
-      |> Node.tx_ids_values()
+      |> Node.tx_ids_positions()
       |> Enum.reduce(state2, fn field_pos, state ->
         pk = Validate.id!(elem(tx, field_pos))
         m_id_call = Model.id_int_contract_call(index: {pk, field_pos, call_txi, local_idx})

--- a/lib/ae_mdw/node.ex
+++ b/lib/ae_mdw/node.ex
@@ -195,8 +195,13 @@ defmodule AeMdw.Node do
     %{}
   end
 
-  @spec tx_ids_values(atom()) :: [non_neg_integer()]
-  def tx_ids_values(_tx_type) do
+  @spec tx_ids_positions(atom()) :: [non_neg_integer()]
+  def tx_ids_positions(_tx_type) do
+    []
+  end
+
+  @spec inner_field_positions(atom()) :: [non_neg_integer()]
+  def inner_field_positions(_tx_field) do
     []
   end
 

--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -119,7 +119,7 @@ defmodule AeMdwWeb.TxController do
 
   defp count_id_type(state, pubkey, tx_type) do
     tx_type
-    |> Node.tx_ids_values()
+    |> Node.tx_ids_positions()
     |> Enum.reduce(0, fn field_pos, sum ->
       case State.get(state, Model.IdCount, {tx_type, field_pos, pubkey}) do
         :not_found -> sum

--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -264,7 +264,7 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
     {tx_type, naked_tx} = :aetx.specialize_type(wrapped_tx)
 
     tx_type
-    |> AeMdw.Node.tx_ids_values()
+    |> AeMdw.Node.tx_ids_positions()
     |> Enum.map(&elem(naked_tx, &1))
     |> Enum.uniq()
   end

--- a/priv/migrations/20230329160010_index_inner_tx.ex
+++ b/priv/migrations/20230329160010_index_inner_tx.ex
@@ -1,0 +1,43 @@
+defmodule AeMdw.Migrations.IndexGameta do
+  @moduledoc """
+  Index GaMetaTx.
+  """
+
+  alias AeMdw.Db.WriteMutation
+  alias AeMdw.Db.WriteFieldsMutation
+  alias AeMdw.Collection
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Sync.InnerTx
+  alias AeMdw.Node.Db
+  alias AeMdw.Db.State
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    write_mutations =
+      [:ga_meta_tx, :paying_for_tx]
+      |> Stream.flat_map(fn tx_type ->
+        key_boundary = {{tx_type, 1, <<>>, 0}, {tx_type, 1, AeMdw.Util.max_256bit_bin(), nil}}
+
+        state
+        |> Collection.stream(Model.Field, :forward, key_boundary, nil)
+        |> Stream.flat_map(fn {_tx_type, _pos, _pubkey, txi} ->
+          Model.tx(block_index: block_index, id: hash) = State.fetch!(state, Model.Tx, txi)
+          {_block_hash, ^tx_type, _signed_tx, tx_rec} = Db.get_tx_data(hash)
+          inner_signed_tx = InnerTx.signed_tx(tx_type, tx_rec)
+          {inner_type, inner_tx} = :aetx.specialize_type(:aetx_sign.tx(inner_signed_tx))
+
+          [
+            WriteMutation.new(Model.Type, Model.type(index: {tx_type, txi})),
+            WriteFieldsMutation.new(inner_type, inner_tx, block_index, txi, tx_type)
+          ]
+        end)
+      end)
+      |> Enum.to_list()
+
+    _state = State.commit(state, write_mutations)
+
+    {:ok, length(write_mutations)}
+  end
+end


### PR DESCRIPTION
## What

* Index inner transaction fields by associating to outer one (`ga_meta_tx` or `paying_for`)
* Apply mask to differentiate `ga_id` from other fields with same field position id (field position 1 is reserved for `ga_id`)

## Why

Allow filtering transaction by inner fields along with `type=ga_meta` or `type=paying_for`