### PR TITLE
fix: adjust the order for contract call event mutations

### DIFF
--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -105,8 +105,10 @@ defmodule AeMdw.Db.Sync.Contract do
     int_calls_mutation = IntCallsMutation.new(contract_pk, call_txi, int_calls)
 
     chain_mutations ++
-      oracle_and_name_mutations(int_calls, block_index, call_txi, call_tx_hash) ++
-      [int_calls_mutation]
+      [
+        int_calls_mutation
+        | oracle_and_name_mutations(int_calls, block_index, call_txi, call_tx_hash)
+      ]
   end
 
   @spec aexn_create_contract_mutation(Db.pubkey(), Blocks.block_index(), Txs.txi()) ::

--- a/test/ae_mdw/db/sync/contract_test.exs
+++ b/test/ae_mdw/db/sync/contract_test.exs
@@ -233,6 +233,11 @@ defmodule AeMdw.Db.Sync.ContractTest do
       tx_type = :oracle_register_tx
 
       assert [
+               %IntCallsMutation{
+                 call_txi: ^call_txi,
+                 contract_pk: ^contract_pk,
+                 int_calls: [{0, "Oracle.register", ^tx_type, ^aetx, ^tx}]
+               },
                %WriteMutation{
                  table: Model.Origin,
                  record: Model.origin(index: {^tx_type, ^pubkey, ^call_txi})
@@ -247,12 +252,7 @@ defmodule AeMdw.Db.Sync.ContractTest do
                  tx_type: ^tx_type,
                  txi: ^call_txi
                },
-               %OracleRegisterMutation{oracle_pk: ^pubkey, expire: ^expire},
-               %IntCallsMutation{
-                 call_txi: ^call_txi,
-                 contract_pk: ^contract_pk,
-                 int_calls: [{0, "Oracle.register", ^tx_type, ^aetx, ^tx}]
-               }
+               %OracleRegisterMutation{oracle_pk: ^pubkey, expire: ^expire}
              ] = mutations
     end
 
@@ -291,16 +291,16 @@ defmodule AeMdw.Db.Sync.ContractTest do
 
       assert(
         [
+          %IntCallsMutation{
+            call_txi: ^call_txi,
+            contract_pk: ^contract_pk,
+            int_calls: [{0, "Oracle.extend", :oracle_extend_tx, ^aetx, ^tx}]
+          },
           %OracleExtendMutation{
             oracle_pk: ^pubkey,
             block_index: ^block_index,
             txi_idx: {^call_txi, 0},
             delta_ttl: ^delta_ttl
-          },
-          %IntCallsMutation{
-            call_txi: ^call_txi,
-            contract_pk: ^contract_pk,
-            int_calls: [{0, "Oracle.extend", :oracle_extend_tx, ^aetx, ^tx}]
           }
         ] = mutations
       )


### PR DESCRIPTION
Internal calls always need to be processed first before any contract call is processed.

This was causing issues when a function call needed internal calls from the same transaction.