### PR TITLE
feat: consider existing oracles on inactive ones count

### DIFF
--- a/lib/ae_mdw/db/mutations/oracle_register_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracle_register_mutation.ex
@@ -51,7 +51,11 @@ defmodule AeMdw.Db.OracleRegisterMutation do
           {nil, state}
 
         {previous, Model.InactiveOracle} ->
-          state2 = SyncOracle.cache_through_delete_inactive(state, previous)
+          state2 =
+            state
+            |> SyncOracle.cache_through_delete_inactive(previous)
+            |> State.inc_stat(:old_oracles_registered)
+
           {previous, state2}
 
         {previous, Model.ActiveOracle} ->

--- a/lib/ae_mdw/db/mutations/oracles_expiration_mutation.ex
+++ b/lib/ae_mdw/db/mutations/oracles_expiration_mutation.ex
@@ -78,6 +78,7 @@ defmodule AeMdw.Db.OraclesExpirationMutation do
           |> SyncOracle.cache_through_write(Model.InactiveOracleExpiration, m_exp)
           |> SyncOracle.cache_through_delete(Model.ActiveOracle, pubkey)
           |> State.inc_stat(:oracles_expired)
+          |> maybe_increment_new_oracles_expired(Model.oracle(m_oracle, :previous) == nil)
         else
           Log.warn("[#{height}] ignored old oracle expiration for #{oracle_id}")
           state2
@@ -87,5 +88,13 @@ defmodule AeMdw.Db.OraclesExpirationMutation do
         Log.warn("[#{height}] ignored oracle expiration for #{oracle_id}")
         state2
     end
+  end
+
+  defp maybe_increment_new_oracles_expired(state, true) do
+    State.inc_stat(state, :new_oracles_expired)
+  end
+
+  defp maybe_increment_new_oracles_expired(state, false) do
+    state
   end
 end

--- a/lib/ae_mdw/db/mutations/stats_mutation.ex
+++ b/lib/ae_mdw/db/mutations/stats_mutation.ex
@@ -202,6 +202,8 @@ defmodule AeMdw.Db.StatsMutation do
 
     token_supply_delta = AeMdw.Node.token_supply_delta(height - 1)
     auctions_expired = get(state, :auctions_expired, 0)
+    new_oracles_expired = get(state, :new_oracles_expired, 0)
+    old_oracles_registered = get(state, :old_oracles_registered, 0)
 
     Model.total_stat(
       index: height,
@@ -212,7 +214,8 @@ defmodule AeMdw.Db.StatsMutation do
       active_names: max(0, prev_active_names + names_activated - (names_expired + names_revoked)),
       inactive_names: prev_inactive_names + names_expired + names_revoked,
       active_oracles: max(0, prev_active_oracles + oracles_registered - oracles_expired),
-      inactive_oracles: prev_inactive_oracles + oracles_expired,
+      inactive_oracles:
+        max(0, prev_inactive_oracles - old_oracles_registered + new_oracles_expired),
       contracts: prev_contracts + contracts_created,
       locked_in_auctions: prev_locked_in_auctions + locked_in_auctions,
       burned_in_auctions: prev_burned_in_acutions + burned_in_auctions,


### PR DESCRIPTION
Avoids double counting inactive oracles by checking if it was the first time the oracle was created (without previous).
Plus, decrements inactive ones that are reactivated.