### PR TITLE
feat: filter logs by both contract and event

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -211,6 +211,7 @@ defmodule AeMdw.Db.Contract do
 
       m_data_log = Model.data_contract_log(index: {data, txi, create_txi, evt_hash, log_idx})
       m_evt_log = Model.evt_contract_log(index: {evt_hash, txi, create_txi, log_idx})
+      m_ctevt_log = Model.ctevt_contract_log(index: {evt_hash, create_txi, txi, log_idx})
       m_idx_log = Model.idx_contract_log(index: {txi, log_idx, create_txi, evt_hash})
 
       state2 =
@@ -218,6 +219,7 @@ defmodule AeMdw.Db.Contract do
         |> State.put(Model.ContractLog, m_log)
         |> State.put(Model.DataContractLog, m_data_log)
         |> State.put(Model.EvtContractLog, m_evt_log)
+        |> State.put(Model.CtEvtContractLog, m_ctevt_log)
         |> State.put(Model.IdxContractLog, m_idx_log)
         |> maybe_index_remote_log(contract_pk, txi, log)
 
@@ -662,10 +664,12 @@ defmodule AeMdw.Db.Contract do
       )
 
     m_evt_log = Model.evt_contract_log(index: {evt_hash, txi, remote_contract_txi, idx})
+    m_ctevt_log = Model.ctevt_contract_log(index: {evt_hash, remote_contract_txi, txi, idx})
 
     state
     |> State.put(Model.ContractLog, m_log_remote)
     |> State.put(Model.EvtContractLog, m_evt_log)
+    |> State.put(Model.CtEvtContractLog, m_ctevt_log)
   end
 
   defp write_aexn_transfer(

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -675,6 +675,17 @@ defmodule AeMdw.Db.Model do
   ]
   defrecord :evt_contract_log, @evt_contract_log_defaults
 
+  @type ctevt_contract_log_index() :: {Contract.event_hash(), txi(), txi(), non_neg_integer()}
+  @type ctevt_contract_log() :: record(:ctevt_contract_log, index: evt_contract_log_index())
+
+  # ctevt contract log:
+  #     index: {event hash, create txi, call txi, log idx}
+  @ctevt_contract_log_defaults [
+    index: {nil, -1, -1, -1},
+    unused: nil
+  ]
+  defrecord :ctevt_contract_log, @ctevt_contract_log_defaults
+
   @type evt_contract_log_index() :: {Contract.event_hash(), txi(), txi(), non_neg_integer()}
   @type evt_contract_log() :: record(:evt_contract_log, index: evt_contract_log_index())
 
@@ -1133,6 +1144,7 @@ defmodule AeMdw.Db.Model do
       AeMdw.Db.Model.ContractLog,
       AeMdw.Db.Model.DataContractLog,
       AeMdw.Db.Model.EvtContractLog,
+      AeMdw.Db.Model.CtEvtContractLog,
       AeMdw.Db.Model.IdxContractLog,
       AeMdw.Db.Model.IntContractCall,
       AeMdw.Db.Model.GrpIntContractCall,
@@ -1236,6 +1248,7 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.ContractLog), do: :contract_log
   def record(AeMdw.Db.Model.DataContractLog), do: :data_contract_log
   def record(AeMdw.Db.Model.EvtContractLog), do: :evt_contract_log
+  def record(AeMdw.Db.Model.CtEvtContractLog), do: :ctevt_contract_log
   def record(AeMdw.Db.Model.IdxContractLog), do: :idx_contract_log
   def record(AeMdw.Db.Model.IntContractCall), do: :int_contract_call
   def record(AeMdw.Db.Model.GrpIntContractCall), do: :grp_int_contract_call

--- a/priv/migrations/20230515090000_contract_event_logs.ex
+++ b/priv/migrations/20230515090000_contract_event_logs.ex
@@ -1,0 +1,29 @@
+defmodule AeMdw.Migrations.ContractEventLogs do
+  # credo:disable-for-this-file
+  @moduledoc """
+  Index logs by contract and event.
+  """
+
+  alias AeMdw.Collection
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.WriteMutation
+  alias AeMdw.Db.State
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    write_mutations =
+      state
+      |> Collection.stream(Model.EvtContractLog, :forward, nil, nil)
+      |> Stream.map(fn {event_hash, call_txi, create_txi, log_idx} ->
+        m_ctevt_log = Model.ctevt_contract_log(index: {event_hash, create_txi, call_txi, log_idx})
+        WriteMutation.new(Model.CtEvtContractLog, m_ctevt_log)
+      end)
+      |> Enum.to_list()
+
+    _state = State.commit(state, write_mutations)
+
+    {:ok, length(write_mutations)}
+  end
+end

--- a/test/ae_mdw/db/contract_test.exs
+++ b/test/ae_mdw/db/contract_test.exs
@@ -69,6 +69,7 @@ defmodule AeMdw.Db.ContractTest do
              )
 
       assert State.exists?(state, Model.EvtContractLog, {evt_hash0, call_txi, create_txi, 0})
+      assert State.exists?(state, Model.CtEvtContractLog, {evt_hash0, create_txi, call_txi, 0})
       assert State.exists?(state, Model.IdxContractLog, {call_txi, 0, create_txi, evt_hash0})
 
       m_log1 =
@@ -89,6 +90,7 @@ defmodule AeMdw.Db.ContractTest do
              )
 
       assert State.exists?(state, Model.EvtContractLog, {evt_hash1, call_txi, create_txi, 1})
+      assert State.exists?(state, Model.CtEvtContractLog, {evt_hash1, create_txi, call_txi, 1})
       assert State.exists?(state, Model.IdxContractLog, {call_txi, 1, create_txi, evt_hash1})
     end
 
@@ -152,6 +154,7 @@ defmodule AeMdw.Db.ContractTest do
              )
 
       assert State.exists?(state, Model.EvtContractLog, {evt_hash0, call_txi, create_txi, 0})
+      assert State.exists?(state, Model.CtEvtContractLog, {evt_hash0, create_txi, call_txi, 0})
       assert State.exists?(state, Model.IdxContractLog, {call_txi, 0, create_txi, evt_hash0})
 
       m_log =
@@ -183,6 +186,7 @@ defmodule AeMdw.Db.ContractTest do
              )
 
       assert State.exists?(state, Model.EvtContractLog, {evt_hash1, call_txi, create_txi, 1})
+      assert State.exists?(state, Model.CtEvtContractLog, {evt_hash1, create_txi, call_txi, 1})
       assert State.exists?(state, Model.IdxContractLog, {call_txi, 1, create_txi, evt_hash1})
     end
 

--- a/test/ae_mdw_web/views/aexn_log_view_test.exs
+++ b/test/ae_mdw_web/views/aexn_log_view_test.exs
@@ -390,6 +390,7 @@ defmodule AeMdwWeb.AexnLogViewTest do
 
       m_data_log = Model.data_contract_log(index: {data, txi, create_txi, evt_hash, idx})
       m_evt_log = Model.evt_contract_log(index: {evt_hash, txi, create_txi, idx})
+      m_ctevt_log = Model.ctevt_contract_log(index: {evt_hash, txi, create_txi, idx})
       m_idx_log = Model.idx_contract_log(index: {txi, idx, create_txi, evt_hash})
 
       store =
@@ -398,6 +399,7 @@ defmodule AeMdwWeb.AexnLogViewTest do
         |> Store.put(Model.ContractLog, m_log)
         |> Store.put(Model.DataContractLog, m_data_log)
         |> Store.put(Model.EvtContractLog, m_evt_log)
+        |> Store.put(Model.CtEvtContractLog, m_ctevt_log)
         |> Store.put(Model.IdxContractLog, m_idx_log)
 
       {contract_log_index, store}


### PR DESCRIPTION
- Allows filtering NFT or AEX-9 contract events
- Applicable to non-standard contracts as well