### PR TITLE
chore: Enable MIX_ENV=prod mix release to be run locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ ae_mdw-*.tar
 .DS_Store
 .elixir_ls/
 log/
-AEMDW_REVISION
 REVISION
 VERSION
 *~

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ COPY ./docker/aeternity.yaml /home/aeternity/aeternity.yaml
 # Set build git revision
 RUN mkdir /home/aeternity/node/ae_mdw
 COPY .git .git
-RUN BUILD_REV="$(git log -1 --format=%h)" && echo $BUILD_REV > /home/aeternity/node/ae_mdw/AEMDW_REVISION
 
 WORKDIR /home/aeternity/node
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,6 +1,8 @@
 import Config
 
-config :ae_mdw, build_revision: String.trim(File.read!("AEMDW_REVISION"))
+# Stat
+{revision, 0} = System.cmd("git", ["log", "-1", "--format=%h"])
+config :ae_mdw, build_revision: String.trim(revision)
 
 # Logging
 config :logger,

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "ae_plugin": {:git, "https://github.com/aeternity/ae_plugin.git", "f5438d957d871f6a32b10a2be8f6e7c4d3550534", []},
+  "ae_plugin": {:git, "https://github.com/aeternity/ae_plugin.git", "49c6541dbd6c82f0ce00718c288077823661986f", []},
   "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
   "blankable": {:hex, :blankable, "1.0.0", "89ab564a63c55af117e115144e3b3b57eb53ad43ba0f15553357eb283e0ed425", [:mix], [], "hexpm", "7cf11aac0e44f4eedbee0c15c1d37d94c090cb72a8d9fddf9f7aec30f9278899"},
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},


### PR DESCRIPTION
The goal of this PR is to be able to create a fully transferable release containing all code from the node as well as the mdw code without relying on docker

To run, assuming a local checkout of the aeternity node in `../aeternity`:

`NODEROOT=local INCLUDE_LOCAL_NODE=true MIX_ENV=prod mix release`

This PR was sponsored by the ACF