### PR TITLE
chore: return nil for invalid amount of aex9 holders

### DIFF
--- a/docs/swagger_v2/aexn.spec.yaml
+++ b/docs/swagger_v2/aexn.spec.yaml
@@ -162,7 +162,7 @@ schemas:
         items:
           type: string
       holders:
-        description: Count of accounts having balance
+        description: Count of accounts having balance (nil when contract is not complaint)
         type: integer
       name:
         description: The name of AEX9 token

--- a/lib/ae_mdw_web/views/aexn_view.ex
+++ b/lib/ae_mdw_web/views/aexn_view.ex
@@ -135,7 +135,7 @@ defmodule AeMdwWeb.AexnView do
 
     num_holders =
       with num when num < 0 <- Stats.fetch_aex9_holders_count(state, contract_pk) do
-        "NA"
+        nil
       end
 
     %{

--- a/lib/ae_mdw_web/views/aexn_view.ex
+++ b/lib/ae_mdw_web/views/aexn_view.ex
@@ -133,6 +133,11 @@ defmodule AeMdwWeb.AexnView do
         :not_found -> 0
       end
 
+    num_holders =
+      with num when num < 0 <- Stats.fetch_aex9_holders_count(state, contract_pk) do
+        "NA"
+      end
+
     %{
       name: name,
       symbol: symbol,
@@ -142,7 +147,7 @@ defmodule AeMdwWeb.AexnView do
       extensions: extensions,
       initial_supply: initial_supply,
       event_supply: event_supply,
-      holders: Stats.fetch_aex9_holders_count(state, contract_pk)
+      holders: num_holders
     }
   end
 

--- a/test/ae_mdw_web/views/aexn_view_test.exs
+++ b/test/ae_mdw_web/views/aexn_view_test.exs
@@ -41,7 +41,7 @@ defmodule AeMdwWeb.AexnViewTest do
                contract_txi: ^txi,
                contract_id: ^contract_id,
                extensions: ^extensions,
-               holders: "NA"
+               holders: nil
              } = AexnView.render_contract(state, m_aex9)
     end
   end

--- a/test/ae_mdw_web/views/aexn_view_test.exs
+++ b/test/ae_mdw_web/views/aexn_view_test.exs
@@ -1,0 +1,48 @@
+defmodule AeMdwWeb.AexnViewTest do
+  use ExUnit.Case
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.MemStore
+  alias AeMdw.Db.NullStore
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Sync.Stats
+  alias AeMdwWeb.AexnView
+
+  import AeMdw.Util.Encoding
+
+  require Model
+
+  describe "render_contract/3" do
+    test "returns NA for invalid amount of holders" do
+      contract_pk = :crypto.strong_rand_bytes(32)
+      contract_id = encode_contract(contract_pk)
+      aex9_meta_info = {name, symbol, decimals} = {"Token1", "TK1", 18}
+      txi = 1_123_456_789
+      extensions = ["ext1", "ext2"]
+
+      state =
+        NullStore.new()
+        |> MemStore.new()
+        |> State.new()
+        |> Stats.decrement_aex9_holders(contract_pk)
+
+      m_aex9 =
+        Model.aexn_contract(
+          index: {:aex9, contract_pk},
+          txi: txi,
+          meta_info: aex9_meta_info,
+          extensions: extensions
+        )
+
+      assert %{
+               name: ^name,
+               symbol: ^symbol,
+               decimals: ^decimals,
+               contract_txi: ^txi,
+               contract_id: ^contract_id,
+               extensions: ^extensions,
+               holders: "NA"
+             } = AexnView.render_contract(state, m_aex9)
+    end
+  end
+end


### PR DESCRIPTION
What/Why

Negative number is confusing for users: https://github.com/aeternity/ae_mdw/pull/1260#issuecomment-1591093770
Returns nil (for non-applicable) instead.
refs #1257 
