### PR TITLE
feat: filter contract calls by entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,6 +765,7 @@ The types for freestanding fields are:
 - channel_id - channel_close_mutual, channel_close_solo, channel_deposit, channel_force_progress, channel_offchain, channel_settle, channel_slash, channel_snapshot_solo, channel_withdraw
 - commitment_id - name_preclaim
 - contract_id - contract_call
+- entrypoint - contract_call
 - from_id - channel_close_mutual, channel_close_solo, channel_deposit, channel_force_progress, channel_settle, channel_slash, channel_snapshot_solo
 - ga_id - ga_meta
 - initiator_id - channel_create

--- a/docs/swagger_v2/txs.spec.yaml
+++ b/docs/swagger_v2/txs.spec.yaml
@@ -152,6 +152,13 @@ paths:
           required: false
           schema:
             type: string
+        - name: entrypoint
+          description: Entrypoint of a contract call
+          example: put_listing
+          in: query
+          required: false
+          schema:
+            type: string
         - $ref: '#/components/parameters/LimitParam'
         - $ref: '#/components/parameters/ScopeParam'
         - $ref: '#/components/parameters/DirectionParam'

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -6,6 +6,7 @@ defmodule AeMdw.Db.Contract do
   alias AeMdw.AexnContracts
   alias AeMdw.Collection
   alias AeMdw.Contract
+  alias AeMdw.Fields
   alias AeMdw.Db.Model
   alias AeMdw.Db.Origin
   alias AeMdw.Db.State
@@ -190,7 +191,12 @@ defmodule AeMdw.Db.Contract do
         return: return
       )
 
-    State.put(state, Model.ContractCall, m_call)
+    field_pos = Fields.mdw_field_pos("entrypoint")
+    m_entrypoint_field = Model.field(index: {:contract_call_tx, field_pos, fname, txi})
+
+    state
+    |> State.put(Model.ContractCall, m_call)
+    |> State.put(Model.Field, m_entrypoint_field)
   end
 
   @spec logs_write(state(), txi(), txi(), Contract.call()) :: state()

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -146,7 +146,7 @@ defmodule AeMdw.Db.Model do
   @type type_count() :: record(:type_count, index: type_count_index(), count: non_neg_integer())
 
   # txs fields      :
-  #     index = {tx_type, tx_field_pos, object_pubkey, tx_index},
+  #     index = {tx_type, tx_field_pos, object_pubkey | binary, tx_index},
   @field_defaults [index: {nil, -1, nil, -1}, unused: nil]
   defrecord :field, @field_defaults
 

--- a/lib/ae_mdw/db/stream/query/parser.ex
+++ b/lib/ae_mdw/db/stream/query/parser.ex
@@ -6,13 +6,13 @@ defmodule AeMdw.Db.Stream.Query.Parser do
 
   @type validate_func :: (String.t() -> binary())
 
-  @spec classify_ident(String.t()) :: {false, validate_func()} | {true, validate_func()}
-  def classify_ident("account"), do: {false, &Validate.id!(&1, [:account_pubkey])}
-  def classify_ident("contract"), do: {false, &Validate.id!(&1, [:contract_pubkey])}
-  def classify_ident("channel"), do: {false, &Validate.id!(&1, [:channel])}
-  def classify_ident("oracle"), do: {false, &Validate.id!(&1, [:oracle_pubkey])}
-  def classify_ident("name"), do: {false, &Validate.name_id!/1}
-  def classify_ident(_ident), do: {true, &Validate.id!/1}
+  @spec classify_ident(String.t()) :: validate_func()
+  def classify_ident("account"), do: &Validate.id!(&1, [:account_pubkey])
+  def classify_ident("contract"), do: &Validate.id!(&1, [:contract_pubkey])
+  def classify_ident("channel"), do: &Validate.id!(&1, [:channel])
+  def classify_ident("oracle"), do: &Validate.id!(&1, [:oracle_pubkey])
+  def classify_ident("name"), do: &Validate.name_id!/1
+  def classify_ident(_ident), do: &Validate.id!/1
 
   @spec parse_field(String.t()) :: map()
   def parse_field(field) do
@@ -32,9 +32,8 @@ defmodule AeMdw.Db.Stream.Query.Parser do
     end
   end
 
-  defp add_pos(acc, type, field), do: Map.put(acc, type, [AE.tx_ids(type)[field]])
-
-  defp field_types(field) do
+  @spec field_types(atom()) :: MapSet.t()
+  def field_types(field) do
     base_types = AE.tx_field_types(field)
 
     case field do
@@ -56,4 +55,6 @@ defmodule AeMdw.Db.Stream.Query.Parser do
         base_types
     end
   end
+
+  defp add_pos(acc, type, field), do: Map.put(acc, type, [AE.tx_ids(type)[field]])
 end

--- a/lib/ae_mdw/fields.ex
+++ b/lib/ae_mdw/fields.ex
@@ -29,6 +29,9 @@ defmodule AeMdw.Fields do
     {:spend_tx, 2}
   ]
 
+  @base_wraptx_field_pos 1 <<< 10
+  @base_mdw_field_pos 1 <<< 15
+
   @spec account_fields_stream(state(), pubkey(), direction(), txi_scope(), cursor(), boolean()) ::
           Enumerable.t()
   def account_fields_stream(state, account_pk, direction, txi_scope, cursor, ownership_only?) do
@@ -61,9 +64,12 @@ defmodule AeMdw.Fields do
   end
 
   @spec field_pos_mask(Node.tx_type(), pos()) :: pos()
-  def field_pos_mask(:ga_meta_tx, pos), do: pos <<< 10
-  def field_pos_mask(:paying_for_tx, pos), do: pos <<< 10
+  def field_pos_mask(:ga_meta_tx, pos), do: pos - 1 + @base_wraptx_field_pos
+  def field_pos_mask(:paying_for_tx, pos), do: pos - 1 + @base_wraptx_field_pos
   def field_pos_mask(_tx_type, pos), do: pos
+
+  @spec mdw_field_pos(String.t()) :: pos()
+  def mdw_field_pos("entrypoint"), do: @base_mdw_field_pos
 
   defp tx_types_pos do
     Node.tx_types()

--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -5,6 +5,7 @@ defmodule AeMdwWeb.TxController do
   alias AeMdw.Node
   alias AeMdw.Validate
   alias AeMdw.Db.Model
+  alias AeMdw.Db.Stream.Query.Parser
   alias AeMdw.Txs
   alias AeMdwWeb.FallbackController
   alias AeMdwWeb.Plugs.PaginatedPlug
@@ -135,8 +136,10 @@ defmodule AeMdwWeb.TxController do
     end
   end
 
+  defp extract_group("entrypoint", val, group), do: {:ok, MapSet.put(group, {"entrypoint", val})}
+
   defp extract_group(key, val, group) do
-    {_is_base_id?, validator} = AeMdw.Db.Stream.Query.Parser.classify_ident(key)
+    validator = Parser.classify_ident(key)
 
     try do
       {:ok, MapSet.put(group, {key, validator.(val)})}


### PR DESCRIPTION
## What

Introduce query by virtual field (which is not part of transaction record but merged into it)

## Why

Support to marketplace use cases and AEX9 based DApps with additional entrypoints as one to provide liquidity.