### PR TITLE
docs: add missed content type in aex9/{id}

### DIFF
--- a/docs/swagger_v2/aexn.spec.yaml
+++ b/docs/swagger_v2/aexn.spec.yaml
@@ -608,8 +608,10 @@ paths:
       responses:
         '200':
           description: Returns AEX-9 information by contract id
-          schema:
-            $ref: '#/components/schemas/Aex9Response'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Aex9Response'
         '400':
           description: Bad request
           content:


### PR DESCRIPTION
It was missed while fixing https://github.com/aeternity/ae_mdw/issues/1351

This PR is supported by the Æternity Crypto Foundation