### PR TITLE
docs: add missed type object in NameClaimEvent

### DIFF
--- a/docs/swagger_v2/activities.spec.yaml
+++ b/docs/swagger_v2/activities.spec.yaml
@@ -63,6 +63,7 @@ schemas:
         example: "th_2FciwUNyT7WRGee35KnNMhuoLFSCyiquVLFP3kATjwrFJh4Cfh"
   NameClaimEvent:
     description: Name claim
+    type: object
     properties:
       tx_hash:
         description: The hash of the transaction (either a name claim or a contract call transaction)


### PR DESCRIPTION
It was missed while fixing https://github.com/aeternity/ae_mdw/issues/1363

This PR is supported by the Æternity Crypto Foundation