### PR TITLE
docs: add missed required in PaginatedResponse

### DIFF
--- a/docs/swagger_v2/base.yaml
+++ b/docs/swagger_v2/base.yaml
@@ -73,3 +73,6 @@ components:
           type: string
           example: '/blocks?cursor=234'
           nullable: true
+      required:
+        - next
+        - prev


### PR DESCRIPTION
It was missed while fixing https://github.com/aeternity/ae_mdw/issues/1361

This PR is supported by the Æternity Crypto Foundation