### PR TITLE
feat: cache mem sync mutations

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -16,6 +16,7 @@ defmodule AeMdw.Application do
   alias AeMdw.Sync.Watcher
   alias AeMdw.Util
   alias AeMdwWeb.Websocket.BroadcasterCache
+  alias AeMdw.Sync.MutationsCache
 
   require Model
 
@@ -177,6 +178,7 @@ defmodule AeMdw.Application do
 
   defp init(:tables) do
     BroadcasterCache.init()
+    MutationsCache.init()
 
     AeMdw.Sync.AsyncTasks.Stats.init()
     AeMdw.Sync.AsyncTasks.Store.init()

--- a/lib/ae_mdw/sync/mutations_cache.ex
+++ b/lib/ae_mdw/sync/mutations_cache.ex
@@ -1,0 +1,43 @@
+defmodule AeMdw.Sync.MutationsCache do
+  @moduledoc """
+  Keeps the already processed microblocks changes.
+  """
+
+  alias AeMdw.Db.Mutation
+
+  @hashes_table :sync_hashes
+
+  @typep hash :: AeMdw.Blocks.block_hash()
+
+  @spec init() :: :ok
+  def init do
+    :ets.new(@hashes_table, [:named_table, :set, :public])
+  end
+
+  @spec get_mbs_mutations(hash()) :: {[Mutation.t()], AeMdw.Txs.txi()} | nil
+  def get_mbs_mutations(mb_hash) do
+    {time, result} =
+      :timer.tc(fn ->
+        case :ets.lookup(@hashes_table, mb_hash) do
+          [{^mb_hash, mutations_txi}] -> mutations_txi
+          [] -> nil
+        end
+      end)
+
+    if div(time, 1000) > 10, do: IO.inspect(div(time, 1000), label: :mbs_lookup)
+
+    result
+  end
+
+  @spec put_mbs_mutations(hash(), {[Mutation.t()], AeMdw.Txs.txi()}) :: :ok
+  def put_mbs_mutations(mb_hash, mutations_txi) do
+    :ets.insert(@hashes_table, {mb_hash, mutations_txi})
+    :ok
+  end
+
+  @spec clear() :: :ok
+  def clear do
+    :ets.delete_all_objects(@hashes_table)
+    :ok
+  end
+end

--- a/lib/ae_mdw/sync/mutations_cache.ex
+++ b/lib/ae_mdw/sync/mutations_cache.ex
@@ -16,17 +16,10 @@ defmodule AeMdw.Sync.MutationsCache do
 
   @spec get_mbs_mutations(hash()) :: {[Mutation.t()], AeMdw.Txs.txi()} | nil
   def get_mbs_mutations(mb_hash) do
-    {time, result} =
-      :timer.tc(fn ->
-        case :ets.lookup(@hashes_table, mb_hash) do
-          [{^mb_hash, mutations_txi}] -> mutations_txi
-          [] -> nil
-        end
-      end)
-
-    if div(time, 1000) > 10, do: IO.inspect(div(time, 1000), label: :mbs_lookup)
-
-    result
+    case :ets.lookup(@hashes_table, mb_hash) do
+      [{^mb_hash, mutations_txi}] -> mutations_txi
+      [] -> nil
+    end
   end
 
   @spec put_mbs_mutations(hash(), {[Mutation.t()], AeMdw.Txs.txi()}) :: :ok

--- a/lib/ae_mdw/sync/server.ex
+++ b/lib/ae_mdw/sync/server.ex
@@ -40,6 +40,7 @@ defmodule AeMdw.Sync.Server do
   alias AeMdw.Sync.AsyncTasks.WealthRankAccounts
   alias AeMdwWeb.Websocket.Broadcaster
   alias AeMdwWeb.Websocket.BroadcasterCache
+  alias AeMdw.Sync.MutationsCache
 
   require Logger
 
@@ -260,6 +261,8 @@ defmodule AeMdw.Sync.Server do
         :timer.tc(fn ->
           Block.blocks_mutations(from_height, from_mbi, from_txi, to_height)
         end)
+
+      MutationsCache.clear()
 
       {exec_time, new_state} =
         :timer.tc(fn -> exec_db_mutations(gens_mutations, db_state, clear_mem?) end)

--- a/test/ae_mdw/db/sync/block_test.exs
+++ b/test/ae_mdw/db/sync/block_test.exs
@@ -1,4 +1,4 @@
-defmodule AeMdw.Sync.BlockTest do
+defmodule AeMdw.Db.Sync.BlockTest do
   use ExUnit.Case
 
   alias AeMdw.Db.Model

--- a/test/ae_mdw/sync/block_test.exs
+++ b/test/ae_mdw/sync/block_test.exs
@@ -13,23 +13,27 @@ defmodule AeMdw.BlocksTest do
 
   describe "blocks_mutations/4" do
     test "returns the mutations for a generation with many transactions" do
+      # credo:disable-for-next-line
       accounts = Map.new(0..100, fn i -> {String.to_atom("user#{i}"), 100_000_000} end)
 
       first_microblock = {
         :mb0,
         List.flatten(
           Enum.map(1..30, fn i ->
+            # credo:disable-for-next-line
             tx_tag = String.to_atom("tx#{i}")
             user = String.to_existing_atom("user#{i}")
             name = "name#{i}.chain"
             {tx_tag, name_tx(:name_claim_tx, user, name)}
           end) ++
             Enum.map(31..40, fn i ->
+              # credo:disable-for-next-line
               tx_tag = String.to_atom("tx#{i}")
               user = String.to_existing_atom("user#{i}")
               {tx_tag, tx(:oracle_register_tx, user, %{})}
             end) ++
             Enum.map(41..100, fn i ->
+              # credo:disable-for-next-line
               tx_tag = String.to_atom("tx#{i}")
               user = String.to_existing_atom("user#{i}")
               {tx_tag, spend_tx(user, user, 1_000)}
@@ -39,6 +43,7 @@ defmodule AeMdw.BlocksTest do
 
       microblocks =
         Enum.map(1..10, fn i ->
+          # credo:disable-for-next-line
           mb_tag = String.to_atom("mb#{i}")
           user = String.to_existing_atom("user#{i}")
           oracle_id = :aeser_id.create(:oracle, <<i::256>>)
@@ -53,7 +58,7 @@ defmodule AeMdw.BlocksTest do
               tx2: {:oracle_query_tx, user, oracle_id, %{}}
             ] ++
               Enum.map(3..50, fn i ->
-                tx_tag = String.to_atom("tx#{i}")
+                tx_tag = String.to_existing_atom("tx#{i}")
                 user = String.to_existing_atom("user#{i}")
                 {tx_tag, spend_tx(user, user, 1_000)}
               end)

--- a/test/ae_mdw/sync/block_test.exs
+++ b/test/ae_mdw/sync/block_test.exs
@@ -1,0 +1,76 @@
+defmodule AeMdw.BlocksTest do
+  use ExUnit.Case
+
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Sync.Block
+
+  import AeMdwWeb.BlockchainSim,
+    only: [with_blockchain: 3, tx: 3, spend_tx: 3, name_tx: 3, name_tx: 4]
+
+  import Mock
+
+  require Model
+
+  describe "blocks_mutations/4" do
+    test "returns the mutations for a generation with many transactions" do
+      accounts = Map.new(0..100, fn i -> {String.to_atom("user#{i}"), 100_000_000} end)
+
+      first_microblock = {
+        :mb0,
+        List.flatten(
+          Enum.map(1..30, fn i ->
+            tx_tag = String.to_atom("tx#{i}")
+            user = String.to_existing_atom("user#{i}")
+            name = "name#{i}.chain"
+            {tx_tag, name_tx(:name_claim_tx, user, name)}
+          end) ++
+            Enum.map(31..40, fn i ->
+              tx_tag = String.to_atom("tx#{i}")
+              user = String.to_existing_atom("user#{i}")
+              {tx_tag, tx(:oracle_register_tx, user, %{})}
+            end) ++
+            Enum.map(41..100, fn i ->
+              tx_tag = String.to_atom("tx#{i}")
+              user = String.to_existing_atom("user#{i}")
+              {tx_tag, spend_tx(user, user, 1_000)}
+            end)
+        )
+      }
+
+      microblocks =
+        Enum.map(1..10, fn i ->
+          mb_tag = String.to_atom("mb#{i}")
+          user = String.to_existing_atom("user#{i}")
+          oracle_id = :aeser_id.create(:oracle, <<i::256>>)
+
+          {
+            mb_tag,
+            [
+              tx1:
+                name_tx(:name_update_tx, user, "name#{i}.chain", %{
+                  pointers: [{:pointer, "account_pubkey", user}]
+                }),
+              tx2: {:oracle_query_tx, user, oracle_id, %{}}
+            ] ++
+              Enum.map(3..50, fn i ->
+                tx_tag = String.to_atom("tx#{i}")
+                user = String.to_existing_atom("user#{i}")
+                {tx_tag, spend_tx(user, user, 1_000)}
+              end)
+          }
+        end)
+
+      with_blockchain accounts, [first_microblock | microblocks] do
+        %{hash: last_mb_hash, height: 10} = blocks[:mb10]
+        last_mb_hash = AeMdw.Validate.id!(last_mb_hash)
+
+        assert mem1 = :ets.info(:sync_hashes, :memory)
+        assert {height_blocks, txi} = Block.blocks_mutations(0, 0, 0, last_mb_hash)
+        assert {^height_blocks, ^txi} = Block.blocks_mutations(0, 0, 0, last_mb_hash)
+        assert length(height_blocks) == 11
+        assert mem2 = :ets.info(:sync_hashes, :memory)
+        assert mem2 > mem1
+      end
+    end
+  end
+end

--- a/test/integration/ae_mdw_web/websocket_test.exs
+++ b/test/integration/ae_mdw_web/websocket_test.exs
@@ -433,7 +433,7 @@ defmodule Integration.AeMdwWeb.WebsocketTest do
       assert_receive [^recipient_id], 200
 
       {key_block, micro_blocks} = get_blocks(state, 311_860)
-      Broadcaster.broadcast_key_block(key_block, :v1, :mdw, 0)
+      Broadcaster.broadcast_key_block(key_block, :v1, :mdw, 0, 0)
       Process.send_after(client1, {:kb, self()}, 100)
 
       kb_payload = @key_block_mdw

--- a/test/support/blockchain_sim.ex
+++ b/test/support/blockchain_sim.ex
@@ -66,7 +66,9 @@ defmodule AeMdwWeb.BlockchainSim do
             end
 
           nil ->
-            []
+            [
+              {:aec_chain, [:passthrough], genesis_block: fn -> mock_blocks[0][:block] end}
+            ]
         end
 
       pf_mocks =


### PR DESCRIPTION
## Why

refs #1389 and event dry-running might take some seconds

## What

It caches not only the events but the mutations to avoid reprocessing during mem sync.