### PR TITLE
docs: add missed `schema` around `allOf`

### DIFF
--- a/docs/swagger_v2/aexn.spec.yaml
+++ b/docs/swagger_v2/aexn.spec.yaml
@@ -813,14 +813,15 @@ paths:
           description: Returns all the balances of an account
           content:
             application/json:
-              allOf:
-                - $ref: '#/components/schemas/PaginatedResponse'
-                - type: object
-                  properties:
-                    data:
-                      type: array
-                      items:
-                        $ref: '#/components/schemas/Aex9BalanceResponse'
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PaginatedResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Aex9BalanceResponse'
         '400':
           description: Bad request
           content:


### PR DESCRIPTION
fixes a typo introduced in https://github.com/aeternity/ae_mdw/commit/1c4275460b0a9902976969691e390220dad539dc#diff-6011f814194f5b76625486da90f88e7a6dcf0bf15519f95da185d099398172b4L748-R810

> error   | schema_violation | Schema violation: must NOT have additional properties (paths > /v2/aex9/account-balances/{account_id} > get > responses > 200 > content > application/json)
  additionalProperty: allOf

This PR is supported by the Æternity Crypto Foundation