### PR TITLE
perf: use header block time

### DIFF
--- a/lib/ae_mdw/db/util.ex
+++ b/lib/ae_mdw/db/util.ex
@@ -329,7 +329,7 @@ defmodule AeMdw.Db.Util do
   @spec block_time(Blocks.block_hash()) :: time()
   def block_time(block_hash) do
     block_hash
-    |> :aec_db.get_block()
-    |> :aec_blocks.time_in_msecs()
+    |> :aec_db.get_header()
+    |> :aec_headers.time_in_msecs()
   end
 end

--- a/lib/ae_mdw/node/db.ex
+++ b/lib/ae_mdw/node/db.ex
@@ -260,7 +260,7 @@ defmodule AeMdw.Node.Db do
 
   @spec get_block_time(Blocks.block_hash()) :: key_block() | micro_block()
   def get_block_time(block_hash),
-    do: block_hash |> :aec_db.get_block() |> :aec_blocks.time_in_msecs()
+    do: block_hash |> :aec_db.get_header() |> :aec_headers.time_in_msecs()
 
   defp block_accounts_tree(mb_hash) do
     {:value, micro_block} = :aec_db.find_block(mb_hash)

--- a/test/ae_mdw_web/controllers/name_controller_test.exs
+++ b/test/ae_mdw_web/controllers/name_controller_test.exs
@@ -227,8 +227,8 @@ defmodule AeMdwWeb.NameControllerTest do
            ownership: fn _state, _mname -> %{current: nil, original: nil} end,
            stream_nested_resource: fn _state, _table, _plain_name, _active -> [] end
          ]},
-        {:aec_db, [], [get_block: fn ^key_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn ^key_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names, "next" => next} =
                  conn
@@ -299,8 +299,8 @@ defmodule AeMdwWeb.NameControllerTest do
            ownership: fn _state, _mname -> %{current: nil, original: nil} end,
            stream_nested_resource: fn _state, _table, _plain_name, _active -> [] end
          ]},
-        {:aec_db, [], [get_block: fn ^key_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn ^key_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names} =
                  conn
@@ -364,8 +364,8 @@ defmodule AeMdwWeb.NameControllerTest do
            ownership: fn _state, _mname -> %{current: nil, original: nil} end,
            stream_nested_resource: fn _state, _table, _plain_name, _active -> [] end
          ]},
-        {:aec_db, [], [get_block: fn ^key_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn ^key_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names} =
                  conn
@@ -560,8 +560,8 @@ defmodule AeMdwWeb.NameControllerTest do
            ownership: fn _state, _mname -> %{current: nil, original: nil} end,
            stream_nested_resource: fn _state, _table, _plain_name, _active -> [] end
          ]},
-        {:aec_db, [], [get_block: fn ^key_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn ^key_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names, "next" => next} =
                  conn
@@ -619,8 +619,8 @@ defmodule AeMdwWeb.NameControllerTest do
             stream_nested_resource: fn _state, _table, _plain_name, _active -> [] end
           ]
         },
-        {:aec_db, [], [get_block: fn ^key_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn ^key_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names} =
                  conn
@@ -666,8 +666,8 @@ defmodule AeMdwWeb.NameControllerTest do
            ownership: fn _state, _mname -> %{current: nil, original: nil} end,
            stream_nested_resource: fn _state, _table, _plain_name, _active -> [] end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names} =
                  conn
@@ -952,8 +952,8 @@ defmodule AeMdwWeb.NameControllerTest do
          [
            proto_vsn: fn _height -> 1 end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> kb_time end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> kb_time end]}
       ] do
         assert %{"data" => auction_bids, "next" => next} =
                  conn
@@ -1026,8 +1026,8 @@ defmodule AeMdwWeb.NameControllerTest do
          [
            proto_vsn: fn _height -> 1 end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> kb_time end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> kb_time end]}
       ] do
         assert %{"data" => auction_bids, "next" => next} =
                  conn
@@ -1098,8 +1098,8 @@ defmodule AeMdwWeb.NameControllerTest do
          [
            proto_vsn: fn _height -> 1 end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => [auction_bid1 | _rest] = auctions} =
                  conn
@@ -1172,8 +1172,8 @@ defmodule AeMdwWeb.NameControllerTest do
            pointers: fn _state, _mnme -> %{} end,
            ownership: fn _state, _mname -> %{current: nil, original: nil} end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names, "next" => _next} =
                  conn
@@ -1222,8 +1222,8 @@ defmodule AeMdwWeb.NameControllerTest do
            pointers: fn _state, _mnme -> %{} end,
            ownership: fn _state, _mname -> %{current: nil, original: nil} end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names, "next" => _next} =
                  conn
@@ -1273,8 +1273,8 @@ defmodule AeMdwWeb.NameControllerTest do
            ownership: fn _state, _mname -> %{current: nil, original: nil} end,
            stream_nested_resource: fn _state, _table, _plain_name, _active -> [] end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names} =
                  conn
@@ -1347,8 +1347,8 @@ defmodule AeMdwWeb.NameControllerTest do
            ownership: fn _state, _mname -> %{current: nil, original: nil} end,
            stream_nested_resource: fn _state, _table, _plain_name, _active -> [] end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => [name1, name2, name3], "next" => _next} =
                  conn
@@ -1411,8 +1411,8 @@ defmodule AeMdwWeb.NameControllerTest do
            pointers: fn _state, _mnme -> %{} end,
            ownership: fn _state, _mname -> %{current: nil, original: nil} end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names, "next" => _next} =
                  conn
@@ -1461,8 +1461,8 @@ defmodule AeMdwWeb.NameControllerTest do
            pointers: fn _state, _mnme -> %{} end,
            ownership: fn _state, _mname -> %{current: nil, original: nil} end
          ]},
-        {:aec_db, [], [get_block: fn ^key_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn ^key_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => names, "next" => _next} =
                  conn
@@ -1525,8 +1525,8 @@ defmodule AeMdwWeb.NameControllerTest do
              %{current: orig, original: orig}
            end
          ]},
-        {:aec_db, [], [get_block: fn ^key_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn ^key_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => owned_names} =
                  conn
@@ -1597,8 +1597,8 @@ defmodule AeMdwWeb.NameControllerTest do
              %{current: orig, original: orig}
            end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => owned_names} =
                  conn

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -61,8 +61,8 @@ defmodule AeMdwWeb.OracleControllerTest do
       with_mocks [
         {Oracle, [], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
-        {:aec_db, [], [get_block: fn ^block_hash1 -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> last_time end]}
+        {:aec_db, [], [get_header: fn ^block_hash1 -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> last_time end]}
       ] do
         assert %{"data" => [oracle2, oracle1], "next" => nil} =
                  conn
@@ -154,13 +154,13 @@ defmodule AeMdwWeb.OracleControllerTest do
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
         {:aec_db, [],
          [
-           get_block: fn
+           get_header: fn
              ^block_hash1 -> :block1
              ^block_hash2 -> :block2
              ^block_hash3 -> :block3
            end
          ]},
-        {:aec_blocks, [],
+        {:aec_headers, [],
          [
            time_in_msecs: fn
              :block1 -> block_time1
@@ -248,8 +248,8 @@ defmodule AeMdwWeb.OracleControllerTest do
       with_mocks [
         {Oracle, [], [oracle_tree!: fn ^block_hash -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
-        {:aec_db, [], [get_block: fn ^block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn ^block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => [oracle2, oracle1], "next" => nil} =
                  conn
@@ -310,8 +310,8 @@ defmodule AeMdwWeb.OracleControllerTest do
         {Oracle, [], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
         {Blocks, [], [block_hash: fn _state, _height -> "asd" end]},
-        {:aec_db, [], [get_block: fn ^block_hash -> :block1 end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block1 -> 123 end]}
+        {:aec_db, [], [get_header: fn ^block_hash -> :block1 end]},
+        {:aec_headers, [], [time_in_msecs: fn :block1 -> 123 end]}
       ] do
         assert %{"data" => [oracle1, _oracle2], "next" => nil} =
                  conn
@@ -348,8 +348,8 @@ defmodule AeMdwWeb.OracleControllerTest do
         {Oracle, [], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},
         {:aeo_state_tree, [:passthrough], [get_oracle: fn _pk, _tree -> TS.core_oracle() end]},
         {Blocks, [], [block_hash: fn _state, _height -> "asd" end]},
-        {:aec_db, [], [get_block: fn ^block_hash -> :block1 end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block1 -> 123 end]}
+        {:aec_db, [], [get_header: fn ^block_hash -> :block1 end]},
+        {:aec_headers, [], [time_in_msecs: fn :block1 -> 123 end]}
       ] do
         assert %{"next" => next_uri} = conn |> get("/oracles/active") |> json_response(200)
 
@@ -463,8 +463,8 @@ defmodule AeMdwWeb.OracleControllerTest do
                {oracle_query_tx3, :oracle_query_tx, tx_hash3, :oracle_query_tx, block_hash}
            end
          ]},
-        {:aec_db, [], [get_block: fn _block_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _block_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => [oracle1, oracle2], "next" => next_url} =
                  conn
@@ -710,8 +710,8 @@ defmodule AeMdwWeb.OracleControllerTest do
                 block_hash2}
            end
          ]},
-        {:aec_db, [], [get_block: fn _key_hash -> :block end]},
-        {:aec_blocks, [], [time_in_msecs: fn :block -> 123 end]}
+        {:aec_db, [], [get_header: fn _key_hash -> :block end]},
+        {:aec_headers, [], [time_in_msecs: fn :block -> 123 end]}
       ] do
         assert %{"data" => [response1, response2], "next" => next_url} =
                  conn


### PR DESCRIPTION
For 100 blocks:
```
iex(aeternity@localhost)2> {ts, _} = :timer.tc(fn -> Enum.map(hashes, fn hash -> Validate.id!(hash) |> :aec_db.get_block() |> :aec_blocks.time_in_msecs() end) end); ts                                                                              
138999
iex(aeternity@localhost)3> {ts, _} = :timer.tc(fn -> Enum.map(hashes, fn hash -> Validate.id!(hash) |> :aec_db.get_header() |> :aec_headers.time_in_msecs() end) end); ts
13124
```