### PR TITLE
chore: use builtin term to binary conv for values

### DIFF
--- a/priv/migrations/20230629130000_contract_call_entrypoint.ex
+++ b/priv/migrations/20230629130000_contract_call_entrypoint.ex
@@ -48,7 +48,6 @@ defmodule AeMdw.Migrations.ContractCallEntrypoint do
       write_mutations =
         tasks
         |> Task.await_many(60_000 * 30)
-        |> IO.inspect()
         |> List.flatten()
 
       _state = State.commit(state, write_mutations)


### PR DESCRIPTION
Replaces use of `sext` with built in conversion since for big values as found on contract logs it's much more performatic (record value doesn't need the `sext` conversion):
```
sext: {431389,
 <<16, 0, 0, 0, 4, 18, 129, 213, 33, 20, 169, 167, 218, 225, 112, 229, 90, 160,
   50, 218, 31, 223, 65, 124, 178, 210, 36, 126, 223, 71, 139, 115, 254, 184,
   253, 106, 186, 10, 36, 54, 197, 210, 0, 8, 17, 18, 204, 73, ...>>}
termbin: {7,
 <<131, 104, 4, 109, 0, 0, 0, 32, 3, 84, 8, 74, 52, 246, 112, 112, 202, 106, 1,
   45, 67, 247, 160, 124, 101, 72, 35, 237, 232, 226, 185, 254, 113, 245, 85,
   160, 68, 13, 98, 210, 108, 0, 0, 0, 3, 109, 0, 0, ...>>}
sext: {434452,
 <<16, 0, 0, 0, 4, 12, 183, 90, 109, 128, 8, 17, 18, 138, 217, 46, 28, 170, 44,
   19, 105, 134, 134, 255, 46, 55, 142, 118, 143, 155, 40, 191, 238, 54, 127,
   252, 84, 246, 141, 43, 251, 74, 245, 51, 249, 52, 102, 129, ...>>}
termbin: {7,
 <<131, 104, 4, 100, 0, 3, 110, 105, 108, 108, 0, 0, 0, 2, 109, 0, 0, 0, 32, 21,
   100, 112, 202, 69, 4, 180, 134, 13, 252, 113, 120, 206, 163, 205, 40, 127,
   184, 179, 255, 138, 61, 70, 43, 246, 43, 169, 63, 38, ...>>}
commit: {240000, 15292402}
sext: {277348,
 <<16, 0, 0, 0, 4, 12, 183, 90, 109, 128, 8, 17, 18, 177, 249, 63, 251, 123, 46,
   62, 81, 110, 132, 114, 254, 86, 25, 77, 22, 37, 8, 161, 97, 246, 219, 30, 87,
   50, 255, 130, 213, 219, 237, 244, 108, 212, 91, 75, ...>>}
termbin: {6,
 <<131, 104, 4, 100, 0, 3, 110, 105, 108, 108, 0, 0, 0, 2, 109, 0, 0, 0, 32, 99,
   228, 255, 183, 101, 143, 40, 110, 8, 203, 242, 97, 41, 69, 18, 8, 66, 135,
   182, 177, 202, 204, 127, 130, 171, 111, 111, 70, 154, ...>>}
commit: {240000, 14288082}
sext: {139671,
 <<16, 0, 0, 0, 4, 18, 129, 213, 33, 20, 169, 167, 218, 225, 112, 229, 90, 160,
   50, 218, 31, 223, 65, 124, 178, 210, 36, 126, 223, 71, 139, 115, 254, 184,
   253, 106, 186, 10, 36, 54, 197, 210, 0, 8, 17, 18, 204, 73, ...>>}
termbin: {6,
 <<131, 104, 4, 109, 0, 0, 0, 32, 3, 84, 8, 74, 52, 246, 112, 112, 202, 106, 1,
   45, 67, 247, 160, 124, 101, 72, 35, 237, 232, 226, 185, 254, 113, 245, 85,
   160, 68, 13, 98, 210, 108, 0, 0, 0, 3, 109, 0, 0, ...>>}
sext: {138510,
 <<16, 0, 0, 0, 4, 12, 183, 90, 109, 128, 8, 17, 18, 181, 211, 245, 55, 174, 23,
   67, 51, 250, 236, 116, 60, 93, 170, 78, 194, 199, 64, 191, 251, 109, 125, 14,
   5, 199, 229, 75, 218, 194, 233, 145, 72, 76, 211, 159, ...>>}
termbin: {5,
 <<131, 104, 4, 100, 0, 3, 110, 105, 108, 108, 0, 0, 0, 3, 109, 0, 0, 0, 32,
   107, 79, 169, 122, 194, 208, 153, 250, 216, 208, 226, 218, 73, 176, 99, 64,
   127, 237, 107, 208, 192, 113, 242, 75, 181, 11, 76, 20, 9, ...>>}
sext: {128441,
 <<16, 0, 0, 0, 4, 12, 183, 90, 109, 128, 8, 17, 18, 186, 69, 51, 27, 219, 141,
   34, 83, 155, 132, 237, 182, 213, 251, 36, 102, 173, 65, 244, 98, 164, 53, 74,
   183, 159, 193, 226, 164, 97, 63, 49, 222, 204, 3, 149, ...>>}
termbin: {6,
 <<131, 104, 4, 100, 0, 3, 110, 105, 108, 108, 0, 0, 0, 3, 109, 0, 0, 0, 32,
   116, 20, 152, 189, 113, 72, 41, 155, 9, 182, 182, 95, 100, 25, 86, 65, 232,
   138, 33, 84, 86, 231, 224, 226, 72, 132, 249, 29, 217, ...>>}
``` 