### PR TITLE
chore: allow nft owner call for hackaton contracts

### DIFF
--- a/lib/ae_mdw/aex141.ex
+++ b/lib/ae_mdw/aex141.ex
@@ -50,15 +50,11 @@ defmodule AeMdw.Aex141 do
 
   @spec fetch_nft_owner(pubkey(), token_id()) :: {:ok, pubkey()} | {:error, Error.t()}
   def fetch_nft_owner(contract_pk, token_id) do
-    with :ok <- validate_aex141(contract_pk),
-         {:ok, {:variant, [0, 1], 1, {{:address, account_pk}}}} <-
-           AexnContracts.call_contract(contract_pk, "owner", [token_id]) do
-      {:ok, account_pk}
-    else
-      {:error, exception} ->
-        {:error, exception}
+    case AexnContracts.call_contract(contract_pk, "owner", [token_id]) do
+      {:ok, {:variant, [0, 1], 1, {{:address, account_pk}}}} ->
+        {:ok, account_pk}
 
-      _invalid_call_return ->
+      :error ->
         {:error, ErrInput.ContractReturn.exception(value: encode_contract(contract_pk))}
     end
   end
@@ -349,13 +345,5 @@ defmodule AeMdw.Aex141 do
         token_id: token_id
       }
     end)
-  end
-
-  defp validate_aex141(contract_pk) do
-    if AexnContracts.is_aex141?(contract_pk) do
-      :ok
-    else
-      {:error, ErrInput.NotAex141.exception(value: encode_contract(contract_pk))}
-    end
   end
 end

--- a/lib/ae_mdw_web/controllers/aex141_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex141_controller.ex
@@ -69,10 +69,13 @@ defmodule AeMdwWeb.Aex141Controller do
   end
 
   @spec nft_owner(Conn.t(), map()) :: Conn.t()
-  def nft_owner(conn, %{"contract_id" => contract_id, "token_id" => token_id}) do
+  def nft_owner(%Conn{assigns: %{state: state}} = conn, %{
+        "contract_id" => contract_id,
+        "token_id" => token_id
+      }) do
     with {:ok, contract_pk} <- Validate.id(contract_id, [:contract_pubkey]),
          {:int, {token_id, ""}} <- {:int, Integer.parse(token_id)},
-         {:ok, account_pk} <- Aex141.fetch_nft_owner(contract_pk, token_id) do
+         {:ok, account_pk} <- Aex141.fetch_nft_owner(state, contract_pk, token_id) do
       json(conn, %{data: encode_account(account_pk)})
     else
       :error ->


### PR DESCRIPTION
Removes validation as the signatures were different and checking both is as expensive than dry run.
Next: Contract validation will tag contracts that are not currently complaint.