### PR TITLE
fix: call aexn metainfo on contract creation block

### DIFF
--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -133,7 +133,7 @@ defmodule AeMdw.Db.Sync.Transaction do
 
       aexn_create_contract_mutation =
         if call_rec != nil and :ok == :aect_call.return_type(call_rec) do
-          SyncContract.aexn_create_contract_mutation(contract_pk, block_index, txi)
+          SyncContract.aexn_create_contract_mutation(contract_pk, block_hash, block_index, txi)
         end
 
       Enum.concat([
@@ -169,6 +169,7 @@ defmodule AeMdw.Db.Sync.Transaction do
       if call_rec != nil and :aect_call.return_type(call_rec) == :ok do
         SyncContract.child_contract_mutations(
           fun_arg_res,
+          block_hash,
           block_index,
           txi,
           tx_hash

--- a/test/ae_mdw/aexn_contracts_test.exs
+++ b/test/ae_mdw/aexn_contracts_test.exs
@@ -12,108 +12,149 @@ defmodule AeMdw.AexnContractsTest do
   describe "call_meta_info/2" do
     test "succeeds with regular aex9 meta_info" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              meta_info_tuple = {"name", "SYMBOL", 18}
              {:ok, {:tuple, meta_info_tuple}}
            end
          ]}
       ] do
-        assert {:ok, {"name", "SYMBOL", 18}} = AexnContracts.call_meta_info(:aex9, contract_pk)
+        assert {:ok, {"name", "SYMBOL", 18}} =
+                 AexnContracts.call_meta_info(:aex9, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with rearranged aex9 meta_info 1" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              meta_info_tuple = {"Abc", 18, "ABC"}
              {:ok, {:tuple, meta_info_tuple}}
            end
          ]}
       ] do
-        assert {:ok, {"Abc", "ABC", 18}} = AexnContracts.call_meta_info(:aex9, contract_pk)
+        assert {:ok, {"Abc", "ABC", 18}} =
+                 AexnContracts.call_meta_info(:aex9, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with rearranged aex9 meta_info 2" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              meta_info_tuple = {"ABC", "Abc", 18}
              {:ok, {:tuple, meta_info_tuple}}
            end
          ]}
       ] do
-        assert {:ok, {"Abc", "ABC", 18}} = AexnContracts.call_meta_info(:aex9, contract_pk)
+        assert {:ok, {"Abc", "ABC", 18}} =
+                 AexnContracts.call_meta_info(:aex9, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with rearranged aex9 meta_info 3" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              meta_info_tuple = {"ABC", 18, "Abc"}
              {:ok, {:tuple, meta_info_tuple}}
            end
          ]}
       ] do
-        assert {:ok, {"Abc", "ABC", 18}} = AexnContracts.call_meta_info(:aex9, contract_pk)
+        assert {:ok, {"Abc", "ABC", 18}} =
+                 AexnContracts.call_meta_info(:aex9, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with rearranged aex9 meta_info 4" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              meta_info_tuple = {18, "Abc", "ABC"}
              {:ok, {:tuple, meta_info_tuple}}
            end
          ]}
       ] do
-        assert {:ok, {"Abc", "ABC", 18}} = AexnContracts.call_meta_info(:aex9, contract_pk)
+        assert {:ok, {"Abc", "ABC", 18}} =
+                 AexnContracts.call_meta_info(:aex9, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with rearranged aex9 meta_info 5" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              meta_info_tuple = {18, "ABC", "Abc"}
              {:ok, {:tuple, meta_info_tuple}}
            end
          ]}
       ] do
-        assert {:ok, {"Abc", "ABC", 18}} = AexnContracts.call_meta_info(:aex9, contract_pk)
+        assert {:ok, {"Abc", "ABC", 18}} =
+                 AexnContracts.call_meta_info(:aex9, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with meta info from previous nft draft (hackaton)" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
       base_url = "https://some-base-url.com"
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              variant_url = {:variant, [0, 1], 1, base_url}
              variant_type = {:variant, [0, 0, 0, 0], 0, {}}
              meta_info_tuple = {"name", "SYMBOL", variant_url, variant_type}
@@ -122,17 +163,22 @@ defmodule AeMdw.AexnContractsTest do
          ]}
       ] do
         assert {:ok, {"name", "SYMBOL", ^base_url, :url}} =
-                 AexnContracts.call_meta_info(:aex141, contract_pk)
+                 AexnContracts.call_meta_info(:aex141, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with nft standard meta info without base url" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              variant_url = {:variant, [0, 1], 0, {}}
              variant_type = {:variant, [0, 0, 0], 2, {}}
              meta_info_tuple = {"name", "SYMBOL", variant_url, variant_type}
@@ -141,17 +187,22 @@ defmodule AeMdw.AexnContractsTest do
          ]}
       ] do
         assert {:ok, {"name", "SYMBOL", nil, :map}} =
-                 AexnContracts.call_meta_info(:aex141, contract_pk)
+                 AexnContracts.call_meta_info(:aex141, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with nft standard meta info with base url" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              variant_url = {:variant, [0, 1], 1, "http://baseurl"}
              variant_type = {:variant, [0, 0, 0], 2, {}}
              meta_info_tuple = {"name", "SYMBOL", variant_url, variant_type}
@@ -160,17 +211,22 @@ defmodule AeMdw.AexnContractsTest do
          ]}
       ] do
         assert {:ok, {"name", "SYMBOL", "http://baseurl", :map}} =
-                 AexnContracts.call_meta_info(:aex141, contract_pk)
+                 AexnContracts.call_meta_info(:aex141, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with nft rearranged meta info 1" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              variant_url = {:variant, [0, 1], 0, ""}
              variant_type = {:variant, [0, 0, 0], 2, {}}
              meta_info_tuple = {"name", variant_url, "SYMBOL", variant_type}
@@ -179,17 +235,22 @@ defmodule AeMdw.AexnContractsTest do
          ]}
       ] do
         assert {:ok, {"name", "SYMBOL", nil, :map}} =
-                 AexnContracts.call_meta_info(:aex141, contract_pk)
+                 AexnContracts.call_meta_info(:aex141, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with nft rearranged meta info 2" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              variant_url = {:variant, [0, 1], 0, ""}
              variant_type = {:variant, [0, 0, 0], 2, {}}
              meta_info_tuple = {"name", variant_url, variant_type, "SYMBOL"}
@@ -198,17 +259,22 @@ defmodule AeMdw.AexnContractsTest do
          ]}
       ] do
         assert {:ok, {"name", "SYMBOL", nil, :map}} =
-                 AexnContracts.call_meta_info(:aex141, contract_pk)
+                 AexnContracts.call_meta_info(:aex141, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with nft rearranged meta info 3" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              variant_url = {:variant, [0, 1], 0, ""}
              variant_type = {:variant, [0, 0, 0], 2, {}}
              meta_info_tuple = {"SYMBOL", "name", variant_url, variant_type}
@@ -217,17 +283,22 @@ defmodule AeMdw.AexnContractsTest do
          ]}
       ] do
         assert {:ok, {"name", "SYMBOL", nil, :map}} =
-                 AexnContracts.call_meta_info(:aex141, contract_pk)
+                 AexnContracts.call_meta_info(:aex141, contract_pk, mb_hash)
       end
     end
 
     test "succeeds with nft rearranged meta info 4" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              variant_url = {:variant, [0, 1], 0, ""}
              variant_type = {:variant, [0, 0, 0], 2, {}}
              meta_info_tuple = {"SYMBOL", variant_url, variant_type, "name"}
@@ -236,17 +307,22 @@ defmodule AeMdw.AexnContractsTest do
          ]}
       ] do
         assert {:ok, {"name", "SYMBOL", nil, :map}} =
-                 AexnContracts.call_meta_info(:aex141, contract_pk)
+                 AexnContracts.call_meta_info(:aex141, contract_pk, mb_hash)
       end
     end
 
     test "returns :unknown metadata type when does not comply to nft standard" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              variant_url = {:variant, [0, 1], 0, ""}
              variant_type = {:variant, [0, 0], 0, {}}
              meta_info_tuple = {"name", "SYMBOL", variant_url, variant_type}
@@ -255,39 +331,49 @@ defmodule AeMdw.AexnContractsTest do
          ]}
       ] do
         assert {:ok, {"name", "SYMBOL", nil, :unknown}} =
-                 AexnContracts.call_meta_info(:aex141, contract_pk)
+                 AexnContracts.call_meta_info(:aex141, contract_pk, mb_hash)
       end
     end
 
     test "returns format error values when tuple format is unexpected" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              {:ok, {:tuple, {"name", "symbol"}}}
            end
          ]}
       ] do
         assert {:ok, {:format_error, :format_error, nil}} =
-                 AexnContracts.call_meta_info(:aex9, contract_pk)
+                 AexnContracts.call_meta_info(:aex9, contract_pk, mb_hash)
       end
     end
 
     test "returns out of gas error when call_contract fails" do
       contract_pk = :crypto.strong_rand_bytes(32)
+      mb_hash = <<Enum.random(100_000..999_999)::256>>
 
       with_mocks [
+        {AeMdw.Node.Db, [:passthrough],
+         [
+           find_block_height: fn ^mb_hash -> {:ok, 123} end
+         ]},
         {AeMdw.DryRun.Runner, [:passthrough],
          [
-           call_contract: fn ^contract_pk, _hash, "meta_info", [] ->
+           call_contract: fn ^contract_pk, {:micro, 123, ^mb_hash}, "meta_info", [] ->
              {:error, :dry_run_error}
            end
          ]}
       ] do
         assert {:ok, {:out_of_gas_error, :out_of_gas_error, :out_of_gas_error, nil}} =
-                 AexnContracts.call_meta_info(:aex141, contract_pk)
+                 AexnContracts.call_meta_info(:aex141, contract_pk, mb_hash)
       end
     end
   end

--- a/test/ae_mdw/db/contract_create_mutation_test.exs
+++ b/test/ae_mdw/db/contract_create_mutation_test.exs
@@ -30,7 +30,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
           [:passthrough],
           [
             is_aex9?: fn ct_pk -> ct_pk == contract_pk end,
-            call_meta_info: fn _type, ct_pk -> ct_pk == contract_pk && {:ok, meta_info} end,
+            call_meta_info: fn _type, ^contract_pk, <<0::256>> -> {:ok, meta_info} end,
             call_extensions: fn _type, _pk -> {:ok, []} end
           ]
         }
@@ -45,7 +45,12 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
           |> State.new()
           |> State.commit_mem([
             ContractCreateMutation.new(create_txi1, call_rec1),
-            SyncContract.aexn_create_contract_mutation(contract_pk, block_index, create_txi1),
+            SyncContract.aexn_create_contract_mutation(
+              contract_pk,
+              <<0::256>>,
+              block_index,
+              create_txi1
+            ),
             Origin.origin_mutations(
               :contract_create_tx,
               nil,
@@ -78,7 +83,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
           [:passthrough],
           [
             is_aex9?: fn ct_pk -> ct_pk == contract_pk end,
-            call_meta_info: fn _type, ct_pk -> ct_pk == contract_pk && {:ok, meta_info} end,
+            call_meta_info: fn _type, ^contract_pk, <<0::256>> -> {:ok, meta_info} end,
             call_extensions: fn _type, _pk -> {:ok, []} end
           ]
         },
@@ -112,7 +117,12 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
           |> State.new()
           |> State.commit_mem([
             ContractCreateMutation.new(create_txi, call_rec),
-            SyncContract.aexn_create_contract_mutation(contract_pk, block_index, create_txi),
+            SyncContract.aexn_create_contract_mutation(
+              contract_pk,
+              <<0::256>>,
+              block_index,
+              create_txi
+            ),
             Origin.origin_mutations(
               :contract_create_tx,
               nil,
@@ -186,7 +196,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
         {AexnContracts, [:passthrough],
          [
            is_aex9?: fn _pk -> false end,
-           call_meta_info: fn _type, ^contract_pk ->
+           call_meta_info: fn _type, ^contract_pk, <<0::256>> ->
              {:ok, {"test1", "TEST1", "http://some-fake-url", :url}}
            end,
            has_aex141_signatures?: fn _height, pk -> pk == contract_pk end,
@@ -203,7 +213,12 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
           |> MemStore.new()
           |> State.new()
           |> State.commit_mem([
-            SyncContract.aexn_create_contract_mutation(contract_pk, block_index, create_txi),
+            SyncContract.aexn_create_contract_mutation(
+              contract_pk,
+              <<0::256>>,
+              block_index,
+              create_txi
+            ),
             Origin.origin_mutations(
               :contract_create_tx,
               nil,
@@ -276,7 +291,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
         {AexnContracts, [:passthrough],
          [
            is_aex9?: fn ^contract_pk -> false end,
-           call_meta_info: fn _type, ^contract_pk ->
+           call_meta_info: fn _type, ^contract_pk, <<0::256>> ->
              {:ok, {"test1", "TEST1", "http://some-fake-url", :url}}
            end,
            has_aex141_signatures?: fn _height, ^contract_pk -> true end,
@@ -289,7 +304,12 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
          ]}
       ] do
         mutations = [
-          SyncContract.aexn_create_contract_mutation(contract_pk, {height, 0}, create_txi),
+          SyncContract.aexn_create_contract_mutation(
+            contract_pk,
+            <<0::256>>,
+            {height, 0},
+            create_txi
+          ),
           Origin.origin_mutations(
             :contract_create_tx,
             nil,
@@ -348,7 +368,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
         {AexnContracts, [:passthrough],
          [
            is_aex9?: fn ^contract_pk -> false end,
-           call_meta_info: fn _type, ^contract_pk ->
+           call_meta_info: fn _type, ^contract_pk, <<0::256>> ->
              {:ok, {"test1", "TEST1", "http://some-fake-url", :url}}
            end,
            has_aex141_signatures?: fn _height, ^contract_pk -> true end,
@@ -361,7 +381,12 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
          ]}
       ] do
         mutations = [
-          SyncContract.aexn_create_contract_mutation(contract_pk, {height, 0}, create_txi),
+          SyncContract.aexn_create_contract_mutation(
+            contract_pk,
+            <<0::256>>,
+            {height, 0},
+            create_txi
+          ),
           Origin.origin_mutations(
             :contract_create_tx,
             nil,

--- a/test/ae_mdw/db/sync/contract_test.exs
+++ b/test/ae_mdw/db/sync/contract_test.exs
@@ -205,7 +205,7 @@ defmodule AeMdw.Db.Sync.ContractTest do
     end
 
     test "create aex9 contract with Chain.clone" do
-      block_hash = <<0::256>>
+      block_hash = :crypto.strong_rand_bytes(32)
 
       owner_pk =
         <<119, 188, 109, 120, 250, 56, 247, 180, 131, 241, 75, 129, 38, 118, 119, 224, 142, 113,
@@ -242,9 +242,8 @@ defmodule AeMdw.Db.Sync.ContractTest do
         {AexnContracts, [],
          [
            is_aex9?: fn ct_pk -> ct_pk == aex9_contract_pk end,
-           call_meta_info: fn _type, ct_pk ->
-             if ct_pk == aex9_contract_pk,
-               do: {:ok, {"TestAEX9-A vs Wrapped Aeternity", "TAEX9-A/WAE", 18}}
+           call_meta_info: fn _type, _pk, ^block_hash ->
+             {:ok, {"TestAEX9-A vs Wrapped Aeternity", "TAEX9-A/WAE", 18}}
            end,
            call_extensions: fn _type, _pk -> {:ok, []} end
          ]},

--- a/test/ae_mdw/db/sync/transaction_test.exs
+++ b/test/ae_mdw/db/sync/transaction_test.exs
@@ -137,7 +137,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
         {AexnContracts, [],
          [
            is_aex9?: fn pk -> pk == child_contract_pk end,
-           call_meta_info: fn _type, pk -> pk == child_contract_pk && {:ok, aex9_meta_info} end,
+           call_meta_info: fn _type, _pk, ^block_hash -> {:ok, aex9_meta_info} end,
            call_extensions: fn _type, _pk -> {:ok, []} end
          ]}
       ] do
@@ -199,7 +199,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
         {AexnContracts, [],
          [
            is_aex9?: fn _pk -> false end,
-           call_meta_info: fn _type, pk -> pk == contract_pk && {:ok, aex141_meta_info} end,
+           call_meta_info: fn _type, _pk, ^block_hash -> {:ok, aex141_meta_info} end,
            has_aex141_signatures?: fn _height, pk -> pk == contract_pk end,
            call_extensions: fn :aex141, _pk -> {:ok, ["mintable"]} end,
            has_valid_aex141_extensions?: fn _extensions, _pk -> true end
@@ -266,7 +266,7 @@ defmodule AeMdw.Db.Sync.TransactionTest do
         {AexnContracts, [],
          [
            is_aex9?: fn _pk -> false end,
-           call_meta_info: fn _type, _pk -> {:ok, aex141_meta_info} end,
+           call_meta_info: fn _type, _pk, ^block_hash -> {:ok, aex141_meta_info} end,
            has_aex141_signatures?: fn _height, pk -> pk == contract_pk end,
            call_extensions: fn :aex141, _pk -> {:ok, ["mintable"]} end,
            has_valid_aex141_extensions?: fn _extensions, _pk -> true end


### PR DESCRIPTION
## What
Calls `meta_info` entrypoint using the contract creation block which is less likely to change than the top block. 

## Why
refs #1502 

## Notes
- Still forks might be detected until 10 generations so microblocks might be invalidated and become valid again so a retry might be still needed (if the dry run fails for invalidated microblocks).
- AEX-N extensions will be retrieved from bytecode on a following PR