### PR TITLE
fix: expire memory stores based on v1 heavy endpoints

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -15,6 +15,7 @@ period = String.to_integer(System.get_env("TELEMETRY_POLLER_PERIOD") || "10000")
 config :ae_mdw, AeMdw.APM.TelemetryPoller, period: period
 
 config :ae_mdw, enable_v3?: env in ~w(dev test)a
+config :ae_mdw, memstore_lifetime_secs: 15
 
 # Endpoint
 if env != :test do


### PR DESCRIPTION
Restore time based garbage collection of memory stores due to legacy/v1 heavy endpoints.

Note: Next, 500 will demand handling for heavier cases to return a timeout.