### PR TITLE
chore: count holders based on events

### DIFF
--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -102,6 +102,16 @@ defmodule AeMdw.Aex9 do
     end
   end
 
+  @spec fetch_holders_count(State.t(), pubkey()) :: non_neg_integer()
+  def fetch_holders_count(state, contract_pk) do
+    key_boundary = {{contract_pk, <<>>}, {contract_pk, Util.max_256bit_bin()}}
+
+    state
+    |> Collection.stream(Model.Aex9EventBalance, :forward, key_boundary, nil)
+    |> Stream.map(&State.fetch!(state, Model.Aex9EventBalance, &1))
+    |> Enum.count(fn Model.aex9_event_balance(amount: amount) -> amount > 0 end)
+  end
+
   @spec fetch_balance(pubkey(), pubkey(), height_hash() | nil) ::
           {:ok, aex9_balance()} | {:error, Error.t()}
   def fetch_balance(contract_pk, account_pk, height_hash) do

--- a/lib/ae_mdw_web/views/aexn_view.ex
+++ b/lib/ae_mdw_web/views/aexn_view.ex
@@ -8,6 +8,7 @@ defmodule AeMdwWeb.AexnView do
   alias AeMdw.Db.Util
   alias AeMdw.Node.Db, as: NodeDb
   alias AeMdw.Stats
+  alias AeMdw.Aex9
   alias AeMdw.Aex141
   alias AeMdw.Txs
 
@@ -133,10 +134,7 @@ defmodule AeMdwWeb.AexnView do
         :not_found -> 0
       end
 
-    num_holders =
-      with num when num < 0 <- Stats.fetch_aex9_holders_count(state, contract_pk) do
-        nil
-      end
+    num_holders = Aex9.fetch_holders_count(state, contract_pk)
 
     %{
       name: name,

--- a/test/ae_mdw_web/controllers/aexn_token_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aexn_token_controller_test.exs
@@ -42,10 +42,15 @@ defmodule AeMdwWeb.AexnTokenControllerTest do
         |> Store.put(Model.AexnContract, m_aex9)
         |> Store.put(Model.AexnContractName, m_aexn_name)
         |> Store.put(Model.AexnContractSymbol, m_aexn_symbol)
-        |> Store.put(
-          Model.Stat,
-          Model.stat(index: Stats.aex9_holder_count_key(<<i::256>>), payload: i)
-        )
+        |> then(fn store ->
+          Enum.reduce(1..i, store, fn _i, store ->
+            Store.put(
+              store,
+              Model.Aex9EventBalance,
+              Model.aex9_event_balance(index: {<<i::256>>, :crypto.strong_rand_bytes(32)})
+            )
+          end)
+        end)
         |> Store.put(
           Model.Stat,
           Model.stat(index: Stats.aex9_logs_count_key(<<i::256>>), payload: i)

--- a/test/ae_mdw_web/views/aexn_view_test.exs
+++ b/test/ae_mdw_web/views/aexn_view_test.exs
@@ -41,7 +41,7 @@ defmodule AeMdwWeb.AexnViewTest do
                contract_txi: ^txi,
                contract_id: ^contract_id,
                extensions: ^extensions,
-               holders: nil
+               holders: 0
              } = AexnView.render_contract(state, m_aex9)
     end
   end


### PR DESCRIPTION
Until #1410 is implemented, it changes the counting to be based on events in order to avoid validating multiple times if a contract is raising the events properly. 