### PR TITLE
chore: offload startup by async keys loading

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -10,7 +10,6 @@ defmodule AeMdw.Application do
   """
   alias AeMdw.Contract
   alias AeMdw.Db.Model
-  alias AeMdw.Db.State
   alias AeMdw.EtsCache
   alias AeMdw.Extract
   alias AeMdw.NodeHelper
@@ -193,7 +192,7 @@ defmodule AeMdw.Application do
   end
 
   defp init(:formatters) do
-    with [custom_events_args: custom_args] <- Application.get_env(:ae_mdw, AeMdwWeb.LogsView) do
+    with [custom_events_args: custom_args] <- Application.get_env(:ae_mdw, AeMdwWeb.LogsView, :ok) do
       :persistent_term.put({AeMdwWeb.LogsView, :custom_events_args}, true)
 
       Enum.each(custom_args, fn {event_name, index_map} ->
@@ -224,7 +223,7 @@ defmodule AeMdw.Application do
   end
 
   def start_phase(:load_obj_keys, _start_type, []) do
-    ObjectKeys.init(State.new())
+    ObjectKeys.start()
   end
 
   def start_phase(:start_sync, _start_type, []) do

--- a/lib/ae_mdw/sync/supervisor.ex
+++ b/lib/ae_mdw/sync/supervisor.ex
@@ -5,6 +5,7 @@ defmodule AeMdw.Sync.Supervisor do
 
   use Supervisor
 
+  alias AeMdw.Db.Sync.ObjectKeys
   alias AeMdw.Sync.MemStoreCreator
   alias AeMdw.Sync.Server
   alias AeMdw.Sync.Watcher
@@ -18,6 +19,7 @@ defmodule AeMdw.Sync.Supervisor do
   @impl true
   def init(_args) do
     children = [
+      ObjectKeys,
       MemStoreCreator,
       Server,
       Watcher,


### PR DESCRIPTION
Improves Endpoint availability during startup by loading object keys asynchronously.