### PR TITLE
chore: generalize json/view rendering

### DIFF
--- a/lib/ae_mdw_web/controllers/active_entity_controller.ex
+++ b/lib/ae_mdw_web/controllers/active_entity_controller.ex
@@ -18,7 +18,7 @@ defmodule AeMdwWeb.ActiveEntityController do
 
     with {:ok, entities} <-
            ActiveEntities.fetch_entities(state, pagination, scope, query, cursor) do
-      Util.paginate(conn, entities)
+      Util.render(conn, entities)
     end
   end
 end

--- a/lib/ae_mdw_web/controllers/activity_controller.ex
+++ b/lib/ae_mdw_web/controllers/activity_controller.ex
@@ -23,7 +23,7 @@ defmodule AeMdwWeb.ActivityController do
              query,
              cursor
            ) do
-      Util.paginate(conn, paginated_activities)
+      Util.render(conn, paginated_activities)
     end
   end
 end

--- a/lib/ae_mdw_web/controllers/aex141_controller.ex
+++ b/lib/ae_mdw_web/controllers/aex141_controller.ex
@@ -10,7 +10,7 @@ defmodule AeMdwWeb.Aex141Controller do
   alias AeMdw.Validate
   alias AeMdwWeb.FallbackController
   alias AeMdwWeb.Plugs.PaginatedPlug
-  alias AeMdwWeb.Util, as: WebUtil
+  alias AeMdwWeb.Util
 
   alias Plug.Conn
 
@@ -30,7 +30,7 @@ defmodule AeMdwWeb.Aex141Controller do
     with {:ok, contract_pk} <- Validate.id(contract_id, [:contract_pubkey]),
          {:ok, {prev_cursor, nft_owners, next_cursor}} <-
            Aex141.fetch_collection_owners(state, contract_pk, cursor, pagination) do
-      WebUtil.paginate(conn, prev_cursor, nft_owners, next_cursor)
+      Util.render(conn, prev_cursor, nft_owners, next_cursor)
     end
   end
 
@@ -43,9 +43,9 @@ defmodule AeMdwWeb.Aex141Controller do
     } = assigns
 
     with {:ok, contract_pk} <- Validate.id(contract_id),
-         {:ok, {prev_cursor, templates, next_cursor}} <-
+         {:ok, paginated_templates} <-
            Aex141.fetch_templates(state, contract_pk, cursor, pagination) do
-      WebUtil.paginate(conn, prev_cursor, templates, next_cursor)
+      Util.render(conn, paginated_templates)
     end
   end
 
@@ -62,9 +62,9 @@ defmodule AeMdwWeb.Aex141Controller do
 
     with {:ok, contract_pk} <- Validate.id(contract_id),
          {template_id, ""} <- Integer.parse(template_id),
-         {:ok, {prev_cursor, template_tokens, next_cursor}} <-
+         {:ok, paginated_tokens} <-
            Aex141.fetch_template_tokens(state, contract_pk, template_id, cursor, pagination) do
-      WebUtil.paginate(conn, prev_cursor, template_tokens, next_cursor)
+      Util.render(conn, paginated_tokens)
     end
   end
 
@@ -119,7 +119,7 @@ defmodule AeMdwWeb.Aex141Controller do
          {:ok, contract_pk} <- validate_optional_pubkey(params, "contract"),
          {:ok, {prev_cursor, nfts, next_cursor}} <-
            Aex141.fetch_owned_nfts(state, account_pk, contract_pk, cursor, pagination) do
-      WebUtil.paginate(conn, prev_cursor, nfts, next_cursor)
+      Util.render(conn, prev_cursor, nfts, next_cursor)
     end
   end
 

--- a/lib/ae_mdw_web/controllers/aexn_token_controller.ex
+++ b/lib/ae_mdw_web/controllers/aexn_token_controller.ex
@@ -76,7 +76,7 @@ defmodule AeMdwWeb.AexnTokenController do
            Aex9.fetch_event_balances(state, contract_pk, pagination, cursor, order_by) do
       balances = Enum.map(balance_keys, &render_event_balance(state, &1))
 
-      Util.paginate(conn, {prev_cursor, balances, next_cursor})
+      Util.render(conn, {prev_cursor, balances, next_cursor})
     end
   end
 
@@ -103,7 +103,7 @@ defmodule AeMdwWeb.AexnTokenController do
     with {:ok, account_pk} <- Validate.id(account_id, [:account_pubkey]),
          {:ok, {prev_cursor, account_balances, next_cursor}} <-
            Aex9.fetch_account_balances(state, account_pk, cursor, pagination) do
-      Util.paginate(conn, {prev_cursor, account_balances, next_cursor})
+      Util.render(conn, {prev_cursor, account_balances, next_cursor})
     end
   end
 
@@ -118,7 +118,7 @@ defmodule AeMdwWeb.AexnTokenController do
          {:ok, account_pk} <- Validate.id(account_id, [:account_pubkey]),
          {:ok, {prev_cursor, balance_history_items, next_cursor}} <-
            Aex9.fetch_balance_history(state, contract_pk, account_pk, scope, cursor, pagination) do
-      Util.paginate(conn, {prev_cursor, balance_history_items, next_cursor})
+      Util.render(conn, {prev_cursor, balance_history_items, next_cursor})
     end
   end
 
@@ -137,7 +137,7 @@ defmodule AeMdwWeb.AexnTokenController do
          },
          aexn_type
        ) do
-    with {:ok, {prev_cursor, aexn_contracts, next_cursor}} <-
+    with {:ok, paginated_contracts} <-
            AexnTokens.fetch_contracts(
              state,
              pagination,
@@ -146,7 +146,7 @@ defmodule AeMdwWeb.AexnTokenController do
              order_by,
              cursor
            ) do
-      Util.paginate(conn, {prev_cursor, render_contracts(state, aexn_contracts), next_cursor})
+      Util.render(conn, paginated_contracts, &render_contract(state, &1))
     end
   end
 

--- a/lib/ae_mdw_web/controllers/block_controller.ex
+++ b/lib/ae_mdw_web/controllers/block_controller.ex
@@ -1,13 +1,14 @@
 defmodule AeMdwWeb.BlockController do
   use AeMdwWeb, :controller
 
+  import AeMdw.Util, only: [parse_int: 1]
+
   alias AeMdw.Blocks
   alias AeMdw.Validate
-  alias AeMdw.Util
   alias AeMdw.Error.Input, as: ErrInput
   alias AeMdwWeb.FallbackController
   alias AeMdwWeb.Plugs.PaginatedPlug
-  alias AeMdwWeb.Util, as: WebUtil
+  alias AeMdwWeb.Util
   alias Plug.Conn
 
   plug(PaginatedPlug)
@@ -42,7 +43,7 @@ defmodule AeMdwWeb.BlockController do
   """
   @spec block_v1(Conn.t(), map()) :: Conn.t()
   def block_v1(%Conn{assigns: %{state: state}} = conn, %{"hash_or_kbi" => hash_or_kbi} = params) do
-    case Util.parse_int(hash_or_kbi) do
+    case parse_int(hash_or_kbi) do
       {:ok, _kbi} ->
         blocki(conn, Map.put(params, "kbi", hash_or_kbi))
 
@@ -79,7 +80,7 @@ defmodule AeMdwWeb.BlockController do
     {prev_cursor, blocks, next_cursor} =
       Blocks.fetch_key_blocks(state, direction, scope, cursor, limit)
 
-    WebUtil.paginate(conn, prev_cursor, blocks, next_cursor)
+    Util.render(conn, prev_cursor, blocks, next_cursor)
   end
 
   @spec key_block(Conn.t(), map()) :: Conn.t()
@@ -99,7 +100,7 @@ defmodule AeMdwWeb.BlockController do
 
     with {:ok, paginated_blocks} <-
            Blocks.fetch_key_block_micro_blocks(state, hash_or_kbi, pagination, cursor) do
-      WebUtil.paginate(conn, paginated_blocks)
+      Util.render(conn, paginated_blocks)
     end
   end
 
@@ -125,7 +126,7 @@ defmodule AeMdwWeb.BlockController do
     {prev_cursor, blocks, next_cursor} =
       Blocks.fetch_blocks(state, direction, scope, cursor, limit, false)
 
-    WebUtil.paginate(conn, prev_cursor, blocks, next_cursor)
+    Util.render(conn, prev_cursor, blocks, next_cursor)
   end
 
   @doc """
@@ -143,6 +144,6 @@ defmodule AeMdwWeb.BlockController do
     {prev_cursor, blocks, next_cursor} =
       Blocks.fetch_blocks(state, direction, scope, cursor, limit, true)
 
-    WebUtil.paginate(conn, prev_cursor, blocks, next_cursor)
+    Util.render(conn, prev_cursor, blocks, next_cursor)
   end
 end

--- a/lib/ae_mdw_web/controllers/channel_controller.ex
+++ b/lib/ae_mdw_web/controllers/channel_controller.ex
@@ -17,7 +17,7 @@ defmodule AeMdwWeb.ChannelController do
 
     with {:ok, paginated_channels} <-
            Channels.fetch_channels(state, pagination, scope, query, cursor) do
-      Util.paginate(conn, paginated_channels)
+      Util.render(conn, paginated_channels)
     end
   end
 
@@ -38,7 +38,7 @@ defmodule AeMdwWeb.ChannelController do
 
     with {:ok, paginated_updates} <-
            Channels.fetch_channel_updates(state, id, pagination, scope, cursor) do
-      Util.paginate(conn, paginated_updates)
+      Util.render(conn, paginated_updates)
     end
   end
 

--- a/lib/ae_mdw_web/controllers/contract_controller.ex
+++ b/lib/ae_mdw_web/controllers/contract_controller.ex
@@ -18,7 +18,7 @@ defmodule AeMdwWeb.ContractController do
 
     with {:ok, contracts} <-
            Contracts.fetch_contracts(state, pagination, scope, cursor) do
-      Util.paginate(conn, contracts)
+      Util.render(conn, contracts)
     end
   end
 
@@ -38,7 +38,7 @@ defmodule AeMdwWeb.ContractController do
            Contracts.fetch_logs(state, pagination, scope, query, cursor) do
       logs = Enum.map(logs, &LogsView.render_log(state, &1, encode_args))
 
-      Util.paginate(conn, prev_cursor, logs, next_cursor)
+      Util.render(conn, prev_cursor, logs, next_cursor)
     end
   end
 
@@ -47,7 +47,7 @@ defmodule AeMdwWeb.ContractController do
     %{state: state, pagination: pagination, cursor: cursor, scope: scope, query: query} = assigns
 
     with {:ok, calls} <- Contracts.fetch_calls(state, pagination, scope, query, cursor) do
-      Util.paginate(conn, calls)
+      Util.render(conn, calls)
     end
   end
 

--- a/lib/ae_mdw_web/controllers/name_controller.ex
+++ b/lib/ae_mdw_web/controllers/name_controller.ex
@@ -67,7 +67,7 @@ defmodule AeMdwWeb.NameController do
     paginated_auctions =
       AuctionBids.fetch_auctions(state, pagination, order_by, cursor, [{:render_v3?, true} | opts])
 
-    Util.paginate(conn, paginated_auctions)
+    Util.render(conn, paginated_auctions)
   end
 
   @spec auctions_v2(Conn.t(), map()) :: Conn.t()
@@ -76,7 +76,7 @@ defmodule AeMdwWeb.NameController do
       assigns
 
     paginated_auctions = AuctionBids.fetch_auctions(state, pagination, order_by, cursor, opts)
-    Util.paginate(conn, paginated_auctions)
+    Util.render(conn, paginated_auctions)
   end
 
   @spec auction_claims(Conn.t(), map()) :: Conn.t()
@@ -85,7 +85,7 @@ defmodule AeMdwWeb.NameController do
 
     with {:ok, paginated_bids} <-
            Names.fetch_auction_claims(state, name_id, pagination, scope, cursor) do
-      Util.paginate(conn, paginated_bids)
+      Util.render(conn, paginated_bids)
     end
   end
 
@@ -102,7 +102,7 @@ defmodule AeMdwWeb.NameController do
 
     with {:ok, names} <-
            Names.fetch_inactive_names(state, pagination, scope, order_by, cursor, opts) do
-      Util.paginate(conn, names)
+      Util.render(conn, names)
     end
   end
 
@@ -119,7 +119,7 @@ defmodule AeMdwWeb.NameController do
 
     with {:ok, names} <-
            Names.fetch_active_names(state, pagination, scope, order_by, cursor, opts) do
-      Util.paginate(conn, names)
+      Util.render(conn, names)
     end
   end
 
@@ -139,7 +139,7 @@ defmodule AeMdwWeb.NameController do
 
     with {:ok, names} <-
            Names.fetch_names(state, pagination, scope, order_by, query, cursor, opts) do
-      Util.paginate(conn, names)
+      Util.render(conn, names)
     end
   end
 
@@ -157,7 +157,7 @@ defmodule AeMdwWeb.NameController do
 
     with {:ok, names} <-
            Names.fetch_names(state, pagination, scope, order_by, query, cursor, opts) do
-      Util.paginate(conn, names)
+      Util.render(conn, names)
     end
   end
 
@@ -173,7 +173,7 @@ defmodule AeMdwWeb.NameController do
 
     with {:ok, paginated_history} <-
            Names.fetch_name_history(state, pagination, name_or_hash, cursor) do
-      Util.paginate(conn, paginated_history)
+      Util.render(conn, paginated_history)
     end
   end
 
@@ -207,7 +207,7 @@ defmodule AeMdwWeb.NameController do
 
     names = Names.search_names(state, lifecycles, prefix, pagination, cursor, opts)
 
-    Util.paginate(conn, names)
+    Util.render(conn, names)
   end
 
   @spec name_claims(Conn.t(), map()) :: Conn.t()
@@ -220,7 +220,7 @@ defmodule AeMdwWeb.NameController do
     } = assigns
 
     with {:ok, claims} <- Names.fetch_name_claims(state, name_id, pagination, scope, cursor) do
-      Util.paginate(conn, claims)
+      Util.render(conn, claims)
     end
   end
 
@@ -234,7 +234,7 @@ defmodule AeMdwWeb.NameController do
     } = assigns
 
     with {:ok, transfers} <- Names.fetch_name_transfers(state, name_id, pagination, scope, cursor) do
-      Util.paginate(conn, transfers)
+      Util.render(conn, transfers)
     end
   end
 
@@ -248,7 +248,7 @@ defmodule AeMdwWeb.NameController do
     } = assigns
 
     with {:ok, updates} <- Names.fetch_name_updates(state, name_id, pagination, scope, cursor) do
-      Util.paginate(conn, updates)
+      Util.render(conn, updates)
     end
   end
 

--- a/lib/ae_mdw_web/controllers/oracle_controller.ex
+++ b/lib/ae_mdw_web/controllers/oracle_controller.ex
@@ -27,7 +27,7 @@ defmodule AeMdwWeb.OracleController do
 
     paginated_oracles = Oracles.fetch_inactive_oracles(state, pagination, cursor, opts)
 
-    Util.paginate(conn, paginated_oracles)
+    Util.render(conn, paginated_oracles)
   end
 
   @spec active_oracles(Conn.t(), map()) :: Conn.t()
@@ -36,7 +36,7 @@ defmodule AeMdwWeb.OracleController do
 
     paginated_oracles = Oracles.fetch_active_oracles(state, pagination, cursor, opts)
 
-    Util.paginate(conn, paginated_oracles)
+    Util.render(conn, paginated_oracles)
   end
 
   @spec oracles(Conn.t(), map()) :: Conn.t()
@@ -52,7 +52,7 @@ defmodule AeMdwWeb.OracleController do
 
     with {:ok, paginated_oracles} <-
            Oracles.fetch_oracles(state, pagination, scope, query, cursor, opts) do
-      Util.paginate(conn, paginated_oracles)
+      Util.render(conn, paginated_oracles)
     end
   end
 
@@ -62,7 +62,7 @@ defmodule AeMdwWeb.OracleController do
 
     with {:ok, paginated_queries} <-
            Oracles.fetch_oracle_queries(state, oracle_id, pagination, scope, cursor) do
-      Util.paginate(conn, paginated_queries)
+      Util.render(conn, paginated_queries)
     end
   end
 
@@ -72,7 +72,7 @@ defmodule AeMdwWeb.OracleController do
 
     with {:ok, paginated_responses} <-
            Oracles.fetch_oracle_responses(state, oracle_id, pagination, scope, cursor) do
-      Util.paginate(conn, paginated_responses)
+      Util.render(conn, paginated_responses)
     end
   end
 end

--- a/lib/ae_mdw_web/controllers/stats_controller.ex
+++ b/lib/ae_mdw_web/controllers/stats_controller.ex
@@ -30,7 +30,7 @@ defmodule AeMdwWeb.StatsController do
     {prev_cursor, stats, next_cursor} =
       Stats.fetch_stats_v1(state, direction, scope, cursor, limit)
 
-    Util.paginate(conn, prev_cursor, stats, next_cursor)
+    Util.render(conn, prev_cursor, stats, next_cursor)
   end
 
   @spec delta_stats(Conn.t(), map()) :: Conn.t()
@@ -45,7 +45,7 @@ defmodule AeMdwWeb.StatsController do
     {prev_cursor, stats, next_cursor} =
       Stats.fetch_delta_stats(state, direction, scope, cursor, limit)
 
-    Util.paginate(conn, prev_cursor, stats, next_cursor)
+    Util.render(conn, prev_cursor, stats, next_cursor)
   end
 
   @spec total_stats(Conn.t(), map()) :: Conn.t()
@@ -60,7 +60,7 @@ defmodule AeMdwWeb.StatsController do
     {prev_cursor, stats, next_cursor} =
       Stats.fetch_total_stats(state, direction, scope, cursor, limit)
 
-    Util.paginate(conn, prev_cursor, stats, next_cursor)
+    Util.render(conn, prev_cursor, stats, next_cursor)
   end
 
   @spec stats(Conn.t(), map()) :: Conn.t()
@@ -77,7 +77,7 @@ defmodule AeMdwWeb.StatsController do
 
     {prev_cursor, miners, next_cursor} = Miners.fetch_miners(state, pagination, cursor)
 
-    Util.paginate(conn, prev_cursor, miners, next_cursor)
+    Util.render(conn, prev_cursor, miners, next_cursor)
   end
 
   @spec transactions_statistics(Conn.t(), map()) :: Conn.t()
@@ -86,7 +86,7 @@ defmodule AeMdwWeb.StatsController do
 
     with {:ok, paginated_statistics} <-
            Stats.fetch_transactions_statistics(state, pagination, query, scope, cursor) do
-      Util.paginate(conn, paginated_statistics)
+      Util.render(conn, paginated_statistics)
     end
   end
 
@@ -96,7 +96,7 @@ defmodule AeMdwWeb.StatsController do
 
     with {:ok, paginated_statistics} <-
            Stats.fetch_blocks_statistics(state, pagination, query, scope, cursor) do
-      Util.paginate(conn, paginated_statistics)
+      Util.render(conn, paginated_statistics)
     end
   end
 
@@ -106,7 +106,7 @@ defmodule AeMdwWeb.StatsController do
 
     with {:ok, paginated_statistics} <-
            Stats.fetch_names_statistics(state, pagination, query, scope, cursor) do
-      Util.paginate(conn, paginated_statistics)
+      Util.render(conn, paginated_statistics)
     end
   end
 end

--- a/lib/ae_mdw_web/controllers/transfer_controller.ex
+++ b/lib/ae_mdw_web/controllers/transfer_controller.ex
@@ -16,7 +16,7 @@ defmodule AeMdwWeb.TransferController do
 
     with {:ok, paginated_transfers} <-
            Transfers.fetch_transfers(state, pagination, scope, query, cursor) do
-      Util.paginate(conn, paginated_transfers)
+      Util.render(conn, paginated_transfers)
     end
   end
 end

--- a/lib/ae_mdw_web/controllers/tx_controller.ex
+++ b/lib/ae_mdw_web/controllers/tx_controller.ex
@@ -53,7 +53,7 @@ defmodule AeMdwWeb.TxController do
     with {:ok, query} <- extract_query(query_params),
          {:ok, paginated_txs} <-
            Txs.fetch_txs(state, pagination, scope, query, cursor, add_spendtx_details?) do
-      WebUtil.paginate(conn, paginated_txs)
+      WebUtil.render(conn, paginated_txs)
     else
       {:error, reason} when is_binary(reason) -> {:error, ErrInput.Query.exception(value: reason)}
       {:error, reason} -> {:error, reason}
@@ -113,7 +113,7 @@ defmodule AeMdwWeb.TxController do
     with :ok <- validate_without_scope(scope),
          {:ok, query} <- extract_query(query_params),
          {:ok, paginated_txs} <- Txs.fetch_micro_block_txs(state, hash, query, pagination, cursor) do
-      WebUtil.paginate(conn, paginated_txs)
+      WebUtil.render(conn, paginated_txs)
     end
   end
 


### PR DESCRIPTION
Customize json rendering passing a View render function for the specific database key or record.
Same concept adopted for the `Collection.paginate` but applied on the View utils which decouples data fetching from rendering.
Plus renames `Util.paginate` to `Util.render` since the actual pagination is already done by `Collection.paginate` (it only renders).