### PR TITLE
fix: use last gen status regardless of transaction index

### DIFF
--- a/lib/ae_mdw/db/status.ex
+++ b/lib/ae_mdw/db/status.ex
@@ -81,15 +81,19 @@ defmodule AeMdw.Db.Status do
   end
 
   defp safe_mdw_tx_index_and_height(state) do
-    case Util.last_txi(state) do
-      {:ok, last_txi} ->
-        mdw_height = Util.synced_height(state)
+    mdw_height =
+      case Util.synced_height(state) do
+        -1 -> 0
+        height -> height
+      end
 
-        {last_txi, mdw_height}
+    last_txi =
+      case Util.last_txi(state) do
+        {:ok, last_txi} -> last_txi
+        :none -> 0
+      end
 
-      :none ->
-        {0, 0}
-    end
+    {last_txi, mdw_height}
   end
 
   defp calculate_gens_per_min(0, gens_per_min), do: gens_per_min

--- a/test/ae_mdw_web/controllers/util_controller_test.exs
+++ b/test/ae_mdw_web/controllers/util_controller_test.exs
@@ -1,5 +1,10 @@
 defmodule AeMdwWeb.UtilControllerTest do
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Store
+
   use AeMdwWeb.ConnCase
+
+  require Model
 
   describe "static_file" do
     test "gets v1/v2 swagger files from priv directory", %{conn: conn} do
@@ -12,6 +17,20 @@ defmodule AeMdwWeb.UtilControllerTest do
                conn
                |> get("/v2/api")
                |> response(200)
+    end
+  end
+
+  describe "status" do
+    test "it returns last gen, regardless of transactions", %{conn: conn, store: store} do
+      store =
+        store
+        |> Store.put(Model.DeltaStat, Model.delta_stat(index: 10))
+
+      assert %{"mdw_height" => 10} =
+               conn
+               |> with_store(store)
+               |> get("/status")
+               |> json_response(200)
     end
   end
 end


### PR DESCRIPTION
refs #1632 