### PR TITLE
fix: skip node call on empty db

### DIFF
--- a/priv/migrations/20240203120003_dex_events.ex
+++ b/priv/migrations/20240203120003_dex_events.ex
@@ -17,7 +17,13 @@ defmodule AeMdw.Migrations.DexEvents do
 
   @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
   def run(state, _from_start?) do
-    pair_pubkeys_set = load_pairs() |> MapSet.new()
+    pair_pubkeys_set =
+      if State.next(state, Model.Field, nil) == :none do
+        MapSet.new()
+      else
+        load_pairs()
+        |> MapSet.new()
+      end
 
     mutations =
       state


### PR DESCRIPTION
Fix for calling `aec_fork_block_settings:hc_seed_contracts` on an empty db with CI aeternity.yaml:
```
** (Mix) Could not start application ae_mdw: bad return value: {{AeMdw.Application, :start_phase, [:migrate_db, :normal, []]}, {:EXIT, {{:case_clause, 5}, [{:aec_fork_block_settings, :dir, 1, [file: '/home/builder/aeternity/apps/aecore/src/aec_fork_block_settings.erl', line: 32]}, {:aec_fork_block_settings, :seed_contracts_file_name, 2, [file: '/home/builder/aeternity/apps/aecore/src/aec_fork_block_settings.erl', line: 275]}, {:aec_fork_block_settings, :hc_seed_contracts, 2, [file: '/home/builder/aeternity/apps/aecore/src/aec_fork_block_settings.erl', line: 347]}, {AeMdw.Db.Origin, :hc_contracts, 0, [file: 'lib/ae_mdw/db/origin.ex', line: 154]}, {AeMdw.Db.Origin, :hardforks_contracts, 0, [file: 'lib/ae_mdw/db/origin.ex', line: 139]}, {AeMdw.Db.Origin, :tx_index, 2, [file: 'lib/ae_mdw/db/origin.ex', line: 55]}, {AeMdw.Migrations.DexEvents, :load_pairs, 0, [file: '_build/test/lib/ae_mdw/priv/migrations/20240203120003_dex_events.ex', line: 65]}, {AeMdw.Migrations.DexEvents, :run, 2, [file: '_build/test/lib/ae_mdw/priv/migrations/20240203120003_dex_events.ex', line: 20]}]}}}
```