### PR TITLE
fix: use endpoint-specific ordering validation

### DIFF
--- a/lib/ae_mdw/aexn_tokens.ex
+++ b/lib/ae_mdw/aexn_tokens.ex
@@ -55,7 +55,7 @@ defmodule AeMdw.AexnTokens do
     with {:ok, cursor} <- deserialize_aexn_cursor(cursor),
          {:ok, params} <- validate_params(query),
          {:ok, filters} <- Util.convert_params(params, &convert_param/1) do
-      sorting_table = Map.get(@sorting_table, order_by)
+      sorting_table = Map.fetch!(@sorting_table, order_by)
 
       paginated_aexn_contracts =
         filters

--- a/test/ae_mdw_web/controllers/aexn_token_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aexn_token_controller_test.exs
@@ -420,6 +420,13 @@ defmodule AeMdwWeb.AexnTokenControllerTest do
       assert %{"error" => ^error_msg} =
                conn |> get("/v2/aex9", cursor: cursor) |> json_response(400)
     end
+
+    test "when invalid order by", %{conn: conn} do
+      assert %{"error" => "invalid query: by=pubkey"} =
+               conn
+               |> get("/v2/aex9", by: "pubkey")
+               |> json_response(400)
+    end
   end
 
   describe "aex141_count" do
@@ -864,6 +871,15 @@ defmodule AeMdwWeb.AexnTokenControllerTest do
       assert List.last(balances)["account_id"] > List.first(next_balances)["account_id"]
 
       assert %{"data" => ^balances} = conn |> get(prev_balances) |> json_response(200)
+    end
+
+    test "when invalid order by", %{conn: conn, contract_pk: contract_pk} do
+      contract_id = encode_contract(contract_pk)
+
+      assert %{"error" => "invalid query: by=foo"} =
+               conn
+               |> get("/v2/aex9/#{contract_id}/balances", by: "foo")
+               |> json_response(400)
     end
   end
 


### PR DESCRIPTION
This was causing 500 errors in a few endpoints when sorting by invalid fields: 

https://mainnet.aeternity.io/mdw/v2/aex9?by=pubkey
https://mainnet.aeternity.io/mdw/v2/aex141?by=amount