### PR TITLE
fix: handle invalid hashes error

### DIFF
--- a/lib/ae_mdw/error.ex
+++ b/lib/ae_mdw/error.ex
@@ -61,6 +61,7 @@ defmodule AeMdw.Error do
           }
 
     defexception!(Id)
+    defexception!(Hash)
     defexception!(BlockIndex)
     defexception!(NonnegInt)
     defexception!(TxField)

--- a/test/ae_mdw_web/controllers/block_controller_test.exs
+++ b/test/ae_mdw_web/controllers/block_controller_test.exs
@@ -191,6 +191,16 @@ defmodule AeMdwWeb.BlockControllerTest do
                  |> json_response(404)
       end
     end
+
+    test "when key block hash is invalid, it returns 400", %{conn: conn} do
+      encoded_hash = "asdadads"
+      error_msg = "invalid hash: #{encoded_hash}"
+
+      assert %{"error" => ^error_msg} =
+               conn
+               |> get("/v2/key-blocks/#{encoded_hash}/micro-blocks")
+               |> json_response(400)
+    end
   end
 
   describe "key-block" do


### PR DESCRIPTION
Erroring route example: https://mainnet.aeternity.io/mdw/v2/key-blocks/kh_KDMuJpBxDagQ4iV7XFXBH5x3snYMEbRyXyBPpf2MrqRaRxLr