### PR TITLE
fix: telemetry error when application starts

### DIFF
--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -48,10 +48,10 @@ defmodule AeMdw.Application do
     :ok = RocksDb.open(!persist)
 
     children = [
-      AeMdw.APM.Telemetry,
       AeMdwWeb.Supervisor,
       AeMdwWeb.Websocket.Supervisor,
-      AeMdw.Sync.Supervisor
+      AeMdw.Sync.Supervisor,
+      AeMdw.APM.Telemetry
     ]
 
     children =


### PR DESCRIPTION
refs: #1635.

`AeMdw.APM.Telemetry` was issuing calls to `AeMdw.Sync.MemStoreCreator`, that is started at a later point (by `AeMdw.Sync.Supervisor`), so I switched the starting order, to prevent the error.