### PR TITLE
fix: docker logs mount bad permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,4 +148,8 @@ RUN useradd --uid 1000 --shell /bin/bash aeternity \
 ARG USER=aeternity
 USER ${USER}
 
+# Clear old logs
+RUN rm -rf /home/aeternity/node/ae_mdw/log
+RUN mkdir -p /home/aeternity/node/ae_mdw/log
+
 CMD ["/home/aeternity/node/bin/server"]


### PR DESCRIPTION
The problem is that the logs directory is mounted with the wrong permissions. The solution is to delete the old logs and recreate the directory with the correct permissions. This fixes #1634 