### PR TITLE
fix: randomly failing tests

### DIFF
--- a/lib/ae_mdw/aexn_transfers.ex
+++ b/lib/ae_mdw/aexn_transfers.ex
@@ -235,9 +235,10 @@ defmodule AeMdw.AexnTransfers do
     with {:ok, cursor} <- deserialize_cursor(cursor_bin) do
       {create_txi, call_txi, pk1, pk2, token_id, log_idx} = cursor
 
-      cursor = case account_pk do
-        ^pk1 -> {create_txi, pk1, call_txi, pk2, token_id, log_idx}
-        ^pk2 -> {create_txi, pk2, call_txi, pk1, token_id, log_idx}
+      cursor =
+        case account_pk do
+          ^pk1 -> {create_txi, pk1, call_txi, pk2, token_id, log_idx}
+          ^pk2 -> {create_txi, pk2, call_txi, pk1, token_id, log_idx}
         end
 
       {:ok, {cursor, cursor}}


### PR DESCRIPTION
This seems to fix the two randomly failing tests in `aexn_transfer_controller_test.exs` - `gets transfers sorted by desc txi` and `gets transfers sorted by asc txi`.

The reason the tests were failing seems to be the fact that in `AeMdw.AexnTransfers.build_streamer/3` the `AexnContractToTransfer` stream is switching the receiver and sender (for unification with the other stream), which leads to nondeterministic position of the `account_pk` in the cursor when deserializing.

The tests managed to pass randomly because the data for the setup consists of 20 consecutive `AexnContractFromTransfer`, followed by 20 consecutive `AexnContractToTransfer`, so basically the first 2 pages (as required by the tests) were consisting of the same type, and unless the other PK is smaller (or larger, based on the failing test) than the key_boundary, they will not be intervene. When the setup data is changed to alternate, instead of groups of 20, the tests were failing constantly.

In some cases all tests were passing because the setup has:
```
{@from_pk1, @account_pk, @aex9_pk3}
{@account_pk, @to_pk1, @aex9_pk3}
```
, so basically if the `@from_pk1` and `@to_pk1` (the other PK that was misplaced in deserializing) were randomly assigned "good" values (one smaller, one larger than the `account_pk`) - both tests will pass, and if they were both "bad" values, both tests will fail, so technically in half the cases one of the tests was failing.

In any case, this is what we found during our investigation, and the fix seems to work :).