### PR TITLE
fix: remove hardcoded node log level in favor of aeternity.yaml config

### DIFF
--- a/docker/aeternity.yaml
+++ b/docker/aeternity.yaml
@@ -29,3 +29,7 @@ chain:
 
 fork_management:
     network_id: ae_mainnet
+
+logging:
+  level: warning
+

--- a/lib/ae_mdw/application.ex
+++ b/lib/ae_mdw/application.ex
@@ -34,7 +34,6 @@ defmodule AeMdw.Application do
     :persistent_term.put({:ae_mdw, :build_revision}, build_rev)
 
     :lager.set_loglevel(:epoch_sync_lager_event, :lager_console_backend, :undefined, :error)
-    :lager.set_loglevel(:lager_console_backend, :error)
 
     init(:meta)
     init_public(:contract_cache)


### PR DESCRIPTION
Removed the hardcoded log level for the node. The config from aeternity.yaml is used now
ref: #1649