### PR TITLE
OpenApi v3 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,7 +945,7 @@ $ curl -s "https://mainnet.aeternity.io/mdw/v3/transactions/count?tx_type=oracle
 
 ## Blocks
 
-### `/v3//key-blocks`
+### `/v3/key-blocks`
 
 There are several endpoints for querying block(s) or generation(s). A generation can be understood as key block and micro blocks containing transactions.
 

--- a/docs/swagger_v3/aexn.spec.yaml
+++ b/docs/swagger_v3/aexn.spec.yaml
@@ -597,14 +597,14 @@ paths:
             type: string
             example: ct_2uiqD8jf1zkKzYwbjRVH5VSSth9KsV6hfC6dYf9o8kcdiRVLRk
         - description: From account
-          in: path
+          in: query
           name: from
           required: false
           schema:
             type: string
             example: ak_2KAcA2Pp1nrR8Wkt3FtCkReGzAi8vJ9Snxa4PcmrthVx8AhPe8
         - description: To account
-          in: path
+          in: query
           name: to
           required: false
           schema:

--- a/docs/swagger_v3/dex.spec.yaml
+++ b/docs/swagger_v3/dex.spec.yaml
@@ -114,9 +114,10 @@ paths:
         - in: path
           name: contract_id
           required: true
-          type: string
           description: The contract id
-          example: "ct_22NTeTHfqVXLChCMCy3eAAj3hGW2nuNUwHhQ1zRX3k4iZKq8Ru"
+          schema:
+            type: string
+            example: "ct_22NTeTHfqVXLChCMCy3eAAj3hGW2nuNUwHhQ1zRX3k4iZKq8Ru"
       responses:
         '200':
           description: Returns paginatinated list of DEX swaps
@@ -147,9 +148,10 @@ paths:
         - in: path
           name: account_id
           required: true
-          type: string
           description: The account id
-          example: "ak_2t7TnocFw7oCYSS7g2yGutZMpGEJta6dq2DTX38SmuqmwtN6Ch"
+          schema:
+            type: string
+            example: "ak_2t7TnocFw7oCYSS7g2yGutZMpGEJta6dq2DTX38SmuqmwtN6Ch"
       responses:
         '200':
           description: Returns paginatinated list of DEX swaps


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

Otherwise autorest fails with
```
error   | schema_violation | Schema violation: must be equal to one of the allowed values (paths > /v3/aex141/{contractId}/transfers > get > parameters > 3 > required)
  allowedValues: true
    - file:///.../middleware-openapi.yaml:2802:3
error   | schema_violation | Schema violation: must be equal to one of the allowed values (paths > /v3/aex141/{contractId}/transfers > get > parameters > 4 > required)
  allowedValues: true
    - file:///.../middleware-openapi.yaml:2802:3
error   | schema_violation | Schema violation: must NOT have additional properties (paths > /v3/dex/{contract_id}/swaps > get > parameters > 1)
  additionalProperty: type
    - file:///.../middleware-openapi.yaml:2802:3
error   | schema_violation | Schema violation: must NOT have additional properties (paths > /v3/accounts/{account_id}/dex/swaps > get > parameters > 1)
  additionalProperty: type
    - file:///.../middleware-openapi.yaml:2802:3
```