### PR TITLE
fix: remove overwrite of network_id and use values from aeternity.yaml

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,8 +1,5 @@
 import Config
 
-# Chain
-config :aecore, network_id: System.get_env("NETWORK_ID", "ae_mainnet")
-
 # Telemetry
 config :ae_mdw, :enable_livedashboard, true
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -2,9 +2,6 @@ import Config
 
 env = config_env()
 
-# Chain
-config :aecore, network_id: System.get_env("NETWORK_ID", "ae_mainnet")
-
 config :ae_mdw, :wealth_rank_size, String.to_integer(System.get_env("WEALTH_RANK_SIZE", "200"))
 
 #

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,8 +15,6 @@ if System.get_env("INTEGRATION_TEST") != "1" do
   config :ae_mdw, AeMdw.Db.RocksDb, data_dir: "test_data.db"
 end
 
-config :aecore, network_id: System.get_env("NETWORK_ID", "ae_mainnet")
-
 # HTTP
 config :ae_mdw, AeMdwWeb.Endpoint,
   http: [port: 4002],


### PR DESCRIPTION
The config wasn't being used in the project and was overwriting the nodes config. Now the mdw will use the network that the node it's connected to is using.

ref: #1760 