### PR TITLE
fix: define required fields in Open Api

### DIFF
--- a/docs/swagger_v3/activities.spec.yaml
+++ b/docs/swagger_v3/activities.spec.yaml
@@ -247,6 +247,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/activities.spec.yaml
+++ b/docs/swagger_v3/activities.spec.yaml
@@ -2,6 +2,16 @@ schemas:
   Aex9TransferEvent:
     description: AEx9 Transfer
     type: object
+    required:
+      - amount
+      - block_height
+      - contract_id
+      - log_idx
+      - micro_index
+      - micro_time
+      - recipient_id
+      - sender_id
+      - tx_hash
     properties:
       amount:
         type: integer
@@ -33,6 +43,16 @@ schemas:
   Aex141TransferEvent:
     description: AEx141 Transfer
     type: object
+    required:
+      - block_height
+      - contract_id
+      - log_idx
+      - micro_index
+      - micro_time
+      - recipient
+      - sender
+      - token_id
+      - tx_hash
     properties:
       block_height:
         type: integer
@@ -197,6 +217,7 @@ schemas:
           - $ref: '#/components/schemas/InternalTransferEvent'
     required:
       - block_hash
+      - block_time
       - height
       - type
       - payload

--- a/docs/swagger_v3/aexn.spec.yaml
+++ b/docs/swagger_v3/aexn.spec.yaml
@@ -427,6 +427,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -499,6 +501,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -534,6 +538,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -576,6 +582,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -625,6 +633,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -667,6 +677,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -742,6 +754,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -806,6 +820,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -893,6 +909,8 @@ paths:
                 allOf:
                   - $ref: '#/components/schemas/PaginatedResponse'
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -936,6 +954,8 @@ paths:
                 allOf:
                   - $ref: '#/components/schemas/PaginatedResponse'
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/aexn.spec.yaml
+++ b/docs/swagger_v3/aexn.spec.yaml
@@ -468,6 +468,8 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - data
                 properties:
                   data:
                     type: string
@@ -780,6 +782,8 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - data
                 properties:
                   data:
                     type: integer
@@ -868,6 +872,10 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - account
+                  - amount
+                  - contract
                 properties:
                   account:
                     description: The account present on a AEX9
@@ -961,6 +969,11 @@ paths:
                         type: array
                         items:
                           type: object
+                          required:
+                            - account
+                            - amount
+                            - contract
+                            - height
                           properties:
                             account:
                               description: The account present on a AEX9

--- a/docs/swagger_v3/blocks.spec.yaml
+++ b/docs/swagger_v3/blocks.spec.yaml
@@ -192,6 +192,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -266,6 +268,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -331,6 +335,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/blocks.spec.yaml
+++ b/docs/swagger_v3/blocks.spec.yaml
@@ -16,6 +16,22 @@ schemas:
       time: 1565548832164
       transactions_count: 2
       version: 3
+    required:
+      - beneficiary
+      - hash
+      - height
+      - info
+      - miner
+      - nonce
+      - pow
+      - prev_hash
+      - prev_key_hash
+      - state_hash
+      - target
+      - time
+      - version
+      - micro_blocks_count
+      - transactions_count
     properties:
       beneficiary:
         description: The beneficiary
@@ -36,7 +52,7 @@ schemas:
         description: The nonce
         type: string
       pow:
-        description: The pow
+        description: The proof of work
         type: array
         items:
           type: integer
@@ -80,6 +96,17 @@ schemas:
       time: 1668435898477
       txs_hash: "bx_2TAosDwRW2CwxbNiucN8hRfUHQcnJn2u3quDLPE9jAmgX26Qya"
       version: 5
+    required:
+      - micro_block_index
+      - transactions_count
+      - hash
+      - height
+      - pof_hash
+      - prev_hash
+      - prev_key_hash
+      - state_hash
+      - time
+      - version
     properties:
       micro_block_index:
         description: The index of the micro-block on the micro-block height, starting from 0

--- a/docs/swagger_v3/blocks.spec.yaml
+++ b/docs/swagger_v3/blocks.spec.yaml
@@ -1,69 +1,4 @@
 schemas:
-  Block:
-    example:
-      beneficiary: ak_2MR38Zf355m6JtP13T3WEcUcSLVLCxjGvjk6zG95S2mfKohcSS
-      hash: kh_uoTGwc4HPzEW9qmiQR1zmVVdHmzU6YmnVvdFe6HvybJJRj7V6
-      height: 123008
-      info: cb_AAAAAfy4hFE=
-      miner: ak_Fqnmm5hRAMaVPWk8wzpodMopZgWghMns4mM7kSV1jgT89p9AV
-      nonce: 9223756548132686000
-      pow: [12359907, 21243613,  31370838, 34911479, 39070315, 39375528, 45751339, 49864206, 56785423, 70282271, 89781776, 136985196, 140580763, 142415353, 145306210, 148449813, 156037609, 161568067, 170308922, 185345129, 192805579, 214115188, 220339679, 243288723, 258891016, 283001743, 284306909, 286457285, 326405486, 352963232, 377904500, 378120539, 380987399, 388675008, 447958786, 457602498, 465751225, 466823982, 475416389, 491255227, 530197445, 533633643]
-      ev_hash: kh_hwin2p8u87mqiK836FixGa1pL9eBkL1Ju37Yi6EUebCgAf8rm
-      prev_key_hash: kh_hwin2p8u87mqiK836FixGa1pL9eBkL1Ju37Yi6EUebCgAf8rm
-      state_hash: bs_9Dg6mTmiJLpbg9dzgjnNFVidQesvZYZG3dEviUCd4oE1hUcna
-      target: 504082055
-      time: 1565548832164
-      version: 3
-    properties:
-      beneficiary:
-        description: The beneficiary
-        type: string
-      hash:
-        description: The block hash
-        type: string
-      height:
-        description: The block height
-        type: integer
-      info:
-        description: The info
-        type: string
-      micro_blocks_count:
-        description: The number of micro blocks
-        type: integer
-      miner:
-        description: The miner public key
-        type: string
-      nonce:
-        description: The nonce
-        type: string
-      pow:
-        description: The pow
-        type: array
-        items:
-          type: integer
-      prev_hash:
-        description: The previous block hash
-        type: string
-      prev_key_hash:
-        description: The previous key block hash
-        type: string
-      state_hash:
-        description: The state hash
-        type: string
-      target:
-        description: The target
-        type: integer
-      time:
-        description: The time
-        type: integer
-      transactions_count:
-        description: The number of transactions
-        type: integer
-      version:
-        description: The version
-        type: integer
-    title: Key Block
-    type: object
   KeyBlock:
     example:
       beneficiary: ak_2MR38Zf355m6JtP13T3WEcUcSLVLCxjGvjk6zG95S2mfKohcSS
@@ -119,6 +54,12 @@ schemas:
         type: integer
       time:
         description: The time
+        type: integer
+      micro_blocks_count:
+        description: The number of micro blocks
+        type: integer
+      transactions_count:
+        description: The number of transactions
         type: integer
       version:
         description: The version

--- a/docs/swagger_v3/channels.spec.yaml
+++ b/docs/swagger_v3/channels.spec.yaml
@@ -110,6 +110,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/channels.spec.yaml
+++ b/docs/swagger_v3/channels.spec.yaml
@@ -1,6 +1,26 @@
 schemas:
   Channel:
     type: object
+    required:
+      - active
+      - amount
+      - channel
+      - channel_reserve
+      - delegate_ids
+      - initiator
+      - initiator_amount
+      - last_updated_height
+      - last_updated_tx_type
+      - last_updated_time
+      - last_updated_tx_hash
+      - lock_period
+      - locked_until
+      - responder
+      - responder_amount
+      - round
+      - solo_round
+      - state_hash
+      - updates_count
     properties:
       active:
         type: boolean
@@ -19,7 +39,7 @@ schemas:
         description: Minimum amount for sufficient funds
         example: 500000000000000000
       delegate_ids:
-        type: object
+        type: object # TODO: define properties
         description: Pubkeys of delegated accounts
         example: {
           "initiator": [],

--- a/docs/swagger_v3/contracts.spec.yaml
+++ b/docs/swagger_v3/contracts.spec.yaml
@@ -228,6 +228,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -257,6 +259,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/contracts.spec.yaml
+++ b/docs/swagger_v3/contracts.spec.yaml
@@ -2,6 +2,13 @@ schemas:
   Contract:
     description: Contract creation info
     type: object
+    required:
+      - aexn_type
+      - block_hash
+      - contract
+      - source_tx_hash
+      - source_tx_type
+      - create_tx
     properties:
       aexn_type:
         type: string
@@ -36,6 +43,16 @@ schemas:
   ContractCall:
     description: ContractCall
     type: object
+    required:
+      - block_hash
+      - call_tx_hash
+      - contract_id
+      - contract_tx_hash
+      - function
+      - height
+      - internal_tx
+      - local_idx
+      - micro_index
     properties:
       block_hash:
         type: string
@@ -82,6 +99,22 @@ schemas:
   ContractLog:
     description: ContractLog
     type: object
+    required:
+      - args
+      - block_hash
+      - block_time
+      - call_tx_hash
+      - contract_id
+      - contract_tx_hash
+      - data
+      - event_hash
+      - event_name
+      - ext_caller_contract_id
+      - ext_caller_contract_tx_hash
+      - height
+      - log_idx
+      - micro_index
+      - parent_contract_id
     properties:
       args:
         type: array
@@ -119,6 +152,7 @@ schemas:
       ext_caller_contract_id:
         type: string
         example: ct_7UfopTwsRuLGFEcsScbYgQ6YnySXuyMxQWhw6fjycnzS5Nyzq
+        nullable: true
       ext_caller_contract_tx_hash:
         type: string
         example: th_2Twp3pJeVuwQ7cMSdPQRfpAUWwdMiwx6coVMpRaNSuzFRnDZF

--- a/docs/swagger_v3/dex.spec.yaml
+++ b/docs/swagger_v3/dex.spec.yaml
@@ -5,6 +5,11 @@ schemas:
     properties:
       amounts:
         type: object
+        required:
+          - amount0_in
+          - amount1_in
+          - amount0_out
+          - amount1_out
         properties:
           amount0_in:
             type: integer

--- a/docs/swagger_v3/dex.spec.yaml
+++ b/docs/swagger_v3/dex.spec.yaml
@@ -92,6 +92,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -126,6 +128,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -160,6 +164,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/names.spec.yaml
+++ b/docs/swagger_v3/names.spec.yaml
@@ -1,6 +1,14 @@
 schemas:
   NameTx:
     type: object
+    required:
+      - block_hash
+      - block_height
+      - hash
+      - micro_index
+      - micro_time
+      - signatures
+      - tx
     properties:
       block_hash:
         type: string
@@ -18,9 +26,20 @@ schemas:
           type: string
       tx:
         type: object
+        required:
+          - account_id
+          - fee
+          - name_id
+          - nonce
+          - type
+          - version
         properties:
+          account_id:
+            type: string
           fee:
             type: integer
+          name_id:
+            type: string
           nonce:
             type: integer
           ttl:
@@ -49,6 +68,20 @@ schemas:
   Name:
     description: Name
     type: object
+    required:
+      - active
+      - hash
+      - active_from
+      - approximate_activation_time
+      - approximate_expire_time
+      - expire_height
+      - pointers
+      - auction
+      - auction_timeout
+      - ownership
+      - name
+      - name_fee
+      - revoke
     properties:
       active:
         type: boolean
@@ -72,7 +105,7 @@ schemas:
         type: array
         items:
           $ref: '#/components/schemas/Pointer'
-        properties:
+        properties: # TODO: can't be array and object at the same time
           account_pubkey:
             type: string
             example: ak_25BWMx4An9mmQJNPSwJisiENek3bAGadze31Eetj4K4JJC8VQN
@@ -84,7 +117,7 @@ schemas:
         example: 1088448
       ownership:
         type: object
-        properties:
+        properties: # TODO: define required fields
           current:
             type: string
             example: ak_25BWMx4An9mmQJNPSwJisiENek3bAGadze31Eetj4K4JJC8VQN
@@ -102,6 +135,13 @@ schemas:
   Auction:
     description: Auction
     type: object
+    required:
+      - auction_end
+      - activation_time
+      - approximate_expire_time
+      - last_bid
+      - name
+      - name_fee
     properties:
       auction_end:
         type: integer
@@ -114,6 +154,15 @@ schemas:
         example: 1692935617598
       last_bid:
         type: object
+        required:
+          - block_hash
+          - block_height
+          - encoded_tx
+          - hash
+          - micro_index
+          - micro_time
+          - signatures
+          - tx
         properties:
           block_hash:
             type: string
@@ -140,6 +189,7 @@ schemas:
               example: sg_VXb4ipxdLk5PxfoQ6xUv9ma3GGmmMSARsRbXeWdS8cAGZS5SVdkfJgLskSw7rXzZSikGwha23LzsK7LPrDomkohRZTcb8
           tx:
             type: object
+            # TODO: define properties
             example:
               account_id: ak_2JJNMYcnqPaABiSY5omockmv4cCoZefv4XzStAxKe9gM2xYz2r
               fee: 16540000000000
@@ -160,6 +210,13 @@ schemas:
   NameClaim:
     description: Name Claim
     type: object
+    required:
+      - active_from
+      - source_tx_hash
+      - source_tx_type
+      - block_hash
+      - height
+      - tx
     properties:
       active_from:
         type: integer
@@ -178,6 +235,7 @@ schemas:
         example: 45784
       tx:
         type: object
+        # TODO: define properties
         example:
           account_id: "ak_2JJNMYcnqPaABiSY5omockmv4cCoZefv4XzStAxKe9gM2xYz2r"
           fee: 16540000000000
@@ -189,6 +247,13 @@ schemas:
   NameTransfer:
     description: Name Transfer
     type: object
+    required:
+      - active_from
+      - block_hash
+      - height
+      - source_tx_hash
+      - source_tx_type
+      - tx
     properties:
       active_from:
         type: integer
@@ -207,6 +272,7 @@ schemas:
         example: NameTransferTx
       tx:
         type: object
+        # TODO: define properties
         example:
           account_id: "ak_24jcHLTZQfsou7NvomRJ1hKEnjyNqbYSq2Az7DmyrAyUHPq8uR"
           fee: 30000
@@ -217,6 +283,13 @@ schemas:
   NameUpdate:
     description: Name Update
     type: object
+    required:
+      - active_from
+      - block_hash
+      - height
+      - source_tx_hash
+      - source_tx_type
+      - tx
     properties:
       active_from:
         type: integer
@@ -235,6 +308,7 @@ schemas:
         example: NameUpdateTx
       tx:
         type: object
+        # TODO: define properties
         example:
           account_id: "ak_2CXSVZqVaGuZsmcRs3CN6wb2b9GKtf7Arwej7ahbeAQ1S8qkmM"
           client_ttl: 36000
@@ -249,6 +323,16 @@ schemas:
   Pointee:
     description: Pointee
     type: object
+    required:
+      - active
+      - name
+      - key
+      - block_hash
+      - tx
+      - source_tx_type
+      - source_tx_hash
+      - block_height
+      - block_time
     properties:
       active:
         type: boolean
@@ -264,6 +348,7 @@ schemas:
         example: mh_2Nr1oj3Z3D9sYnEDrNk4SXjboT3otCXQafsNukRcRDg25URKrR
       tx:
         type: object
+        # TODO: define properties
         example:
           account_id: "ak_2CXSVZqVaGuZsmcRs3CN6wb2b9GKtf7Arwej7ahbeAQ1S8qkmM"
           client_ttl: 36000
@@ -290,6 +375,10 @@ schemas:
   Pointer:
     description: Pointer
     type: object
+    required:
+      - id
+      - key
+      - encoded_key
     properties:
       id:
         type: string
@@ -509,6 +598,8 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - data
                 properties:
                   data:
                     type: array

--- a/docs/swagger_v3/names.spec.yaml
+++ b/docs/swagger_v3/names.spec.yaml
@@ -357,6 +357,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -414,6 +416,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -548,6 +552,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -584,6 +590,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -620,6 +628,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -656,6 +666,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/names.spec.yaml
+++ b/docs/swagger_v3/names.spec.yaml
@@ -23,23 +23,12 @@ schemas:
             type: integer
           nonce:
             type: integer
-          oracle_id:
-            type: string
-          oracle_ttl:
-            type: object
-            properties:
-              type:
-                type: string
-              value:
-                type: integer
           ttl:
             type: integer
           type:
             type: string
           version:
             type: integer
-          tx_hash:
-            type: string
     example:
       block_hash: mh_2Nr1oj3Z3D9sYnEDrNk4SXjboT3otCXQafsNukRcRDg25URKrR
       block_height: 45784

--- a/docs/swagger_v3/oracles.spec.yaml
+++ b/docs/swagger_v3/oracles.spec.yaml
@@ -1,6 +1,14 @@
 schemas:
   OracleTx:
     type: object
+    required:
+      - block_hash
+      - block_height
+      - hash
+      - micro_index
+      - micro_time
+      - signatures
+      - tx
     properties:
       block_hash:
         type: string
@@ -18,6 +26,14 @@ schemas:
           type: string
       tx:
         type: object
+        required:
+          - fee
+          - nonce
+          - oracle_id
+          - oracle_ttl
+          - type
+          - version
+          - tx_hash
         properties:
           fee:
             type: integer
@@ -26,9 +42,16 @@ schemas:
           oracle_id:
             type: string
           oracle_ttl:
+            description: Expiration of the oracle
             type: object
+            required:
+              - type
+              - value
             properties:
               type:
+                enum:
+                - delta
+                - block
                 type: string
               value:
                 type: integer
@@ -120,11 +143,13 @@ schemas:
         $ref: "#/components/schemas/OracleTx"
     required:
       - register
+      - register_time
       - query_fee
       - oracle
       - format
       - extends
       - expire_height
+      - approximate_expire_time
       - active_from
       - active
     type: object
@@ -309,6 +334,7 @@ schemas:
       - block_time
       - height
       - query_id
+      - query
       - source_tx_hash
       - source_tx_type
       - fee
@@ -347,6 +373,11 @@ schemas:
         type: string
       tx:
         type: object
+        required:
+          - fee
+          - nonce
+          - oracle_id
+          - oracle_ttl
         properties:
           fee:
             description: The transaction fee
@@ -360,6 +391,17 @@ schemas:
           oracle_ttl:
             description: Expiration of the oracle
             type: object
+            required:
+              - type
+              - value
+            properties:
+              type:
+                enum:
+                - delta
+                - block
+                type: string
+              value:
+                type: integer
           ttl:
             description: Transaction TTL
             type: integer

--- a/docs/swagger_v3/oracles.spec.yaml
+++ b/docs/swagger_v3/oracles.spec.yaml
@@ -395,6 +395,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -460,6 +462,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -499,6 +503,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -538,6 +544,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/stats.spec.yaml
+++ b/docs/swagger_v3/stats.spec.yaml
@@ -2,6 +2,23 @@ schemas:
   DeltaStat:
     description: DeltaStat
     type: object
+    required:
+      - height
+      - auctions_started
+      - block_reward
+      - burned_in_auctions
+      - channels_closed
+      - channels_opened
+      - contracts_created
+      - dev_reward
+      - names_activated
+      - names_expired
+      - names_revoked
+      - oracles_expired
+      - oracles_registered
+      - last_tx_hash
+      - locked_in_auctions
+      - locked_in_channels
     properties:
       height:
         description: The generation
@@ -71,6 +88,22 @@ schemas:
   TotalStat:
     type: object
     description: TotalStat
+    required:
+      - height
+      - contracts
+      - locked_in_auctions
+      - burned_in_auctions
+      - locked_in_channels
+      - active_auctions
+      - active_names
+      - inactive_names
+      - active_oracles
+      - inactive_oracles
+      - open_channels
+      - sum_block_reward
+      - sum_dev_reward
+      - total_token_supply
+      - last_tx_hash
     properties:
       height:
         description: The generation
@@ -136,6 +169,10 @@ schemas:
   Statistic:
     type: object
     description: Statistic
+    required:
+      - count
+      - start_date
+      - end_date
     properties:
       count:
         description: The statistic count
@@ -153,6 +190,9 @@ schemas:
   Miner:
     type: object
     description: Miner
+    required:
+      - miner
+      - total_reward
     properties:
       miner:
         description: The miner (beneficiary) address

--- a/docs/swagger_v3/stats.spec.yaml
+++ b/docs/swagger_v3/stats.spec.yaml
@@ -181,6 +181,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -210,6 +212,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -238,6 +242,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -301,6 +307,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -361,6 +369,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array
@@ -414,6 +424,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/transactions.spec.yaml
+++ b/docs/swagger_v3/transactions.spec.yaml
@@ -175,6 +175,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array

--- a/docs/swagger_v3/transactions.spec.yaml
+++ b/docs/swagger_v3/transactions.spec.yaml
@@ -2,6 +2,15 @@ schemas:
   Transaction:
     description: Transaction
     type: object
+    required:
+      - block_hash
+      - block_height
+      - encoded_tx
+      - hash
+      - micro_index
+      - micro_time
+      - signatures
+      - tx
     properties:
       block_hash:
         description: The block hash
@@ -28,6 +37,7 @@ schemas:
           type: string
       tx:
         description: The transaction
+        # TODO: define properties
         type: object
     example:
       block_hash: mh_ufiYLdN8am8fBxMnb6xq2K4MQKo4eFSCF5bgixq4EzKMtDUXP
@@ -281,6 +291,32 @@ paths:
                   sender_id: 2
               schema:
                 type: object
+                required:
+                  - channel_close_mutual_tx
+                  - channel_close_solo_tx
+                  - channel_create_tx
+                  - channel_deposit_tx
+                  - channel_force_progress_tx
+                  - channel_offchain_tx
+                  - channel_settle_tx
+                  - channel_slash_tx
+                  - channel_snapshot_solo_tx
+                  - channel_withdraw_tx
+                  - contract_call_tx
+                  - contract_create_tx
+                  - ga_attach_tx
+                  - ga_meta_tx
+                  - name_claim_tx
+                  - name_preclaim_tx
+                  - name_revoke_tx
+                  - name_transfer_tx
+                  - name_update_tx
+                  - oracle_extend_tx
+                  - oracle_query_tx
+                  - oracle_register_tx
+                  - oracle_response_tx
+                  - paying_for_tx
+                  - spend_tx
                 properties:
                   channel_close_mutual_tx:
                     type: integer

--- a/docs/swagger_v3/transactions.spec.yaml
+++ b/docs/swagger_v3/transactions.spec.yaml
@@ -29,9 +29,6 @@ schemas:
       tx:
         description: The transaction
         type: object
-      ttl:
-        description: The time to live
-        type: integer
     example:
       block_hash: mh_ufiYLdN8am8fBxMnb6xq2K4MQKo4eFSCF5bgixq4EzKMtDUXP
       block_height: 1

--- a/docs/swagger_v3/transactions.spec.yaml
+++ b/docs/swagger_v3/transactions.spec.yaml
@@ -286,79 +286,79 @@ paths:
                 type: object
                 properties:
                   channel_close_mutual_tx:
-                    type: object
+                    type: integer
                     description: The channel close mutual transactions count
                   channel_close_solo_tx:
-                    type: object
+                    type: integer
                     description: The channel close solo transactions count
                   channel_create_tx:
-                    type: object
+                    type: integer
                     description: The channel create transactions count
                   channel_deposit_tx:
-                    type: object
+                    type: integer
                     description: The channel deposit transactions count
                   channel_force_progress_tx:
                     type: integer
                     description: The channel force progress transactions count
                   channel_offchain_tx:
-                    type: object
+                    type: integer
                     description: The channel offchain transactions count
                   channel_settle_tx:
-                    type: object
+                    type: integer
                     description: The channel settle transactions count
                   channel_slash_tx:
-                    type: object
+                    type: integer
                     description: The channel slash transactions count
                   channel_snapshot_solo_tx:
-                    type: object
+                    type: integer
                     description: The channel snapshot solo transactions count
                   channel_withdraw_tx:
-                    type: object
+                    type: integer
                     description: The channel withdraw transactions count
                   contract_call_tx:
-                    type: object
+                    type: integer
                     description: The contract call transactions count
                   contract_create_tx:
-                    type: object
+                    type: integer
                     description: The contract create transactions count
                   ga_attach_tx:
-                    type: object
+                    type: integer
                     description: The ga attach transactions count
                   ga_meta_tx:
-                    type: object
+                    type: integer
                     description: The ga meta transactions count
                   name_claim_tx:
-                    type: object
+                    type: integer
                     description: The name claim transactions count
                   name_preclaim_tx:
-                    type: object
+                    type: integer
                     description: The name preclaim transactions count
                   name_revoke_tx:
-                    type: object
+                    type: integer
                     description: The name revoke transactions count
                   name_transfer_tx:
                     type: integer
                     description: The name transfer transactions count
                   name_update_tx:
-                    type: object
+                    type: integer
                     description: The name update transactions count
                   oracle_extend_tx:
-                    type: object
+                    type: integer
                     description: The oracle extend transactions count
                   oracle_query_tx:
-                    type: object
+                    type: integer
                     description: The oracle query transactions count
                   oracle_register_tx:
-                    type: object
+                    type: integer
                     description: The oracle register transactions count
                   oracle_response_tx:
-                    type: object
+                    type: integer
                     description: The oracle response transactions count
                   paying_for_tx:
-                    type: object
+                    type: integer
                     description: The paying for transactions count
                   spend_tx:
-                    type: object
+                    type: integer
                     description: The spend transactions count
         '400':
           description: Bad request

--- a/docs/swagger_v3/transfers.spec.yaml
+++ b/docs/swagger_v3/transfers.spec.yaml
@@ -1,6 +1,14 @@
 schemas:
   Transfer:
     type: object
+    required:
+      - account_id
+      - amount
+      - height
+      - kind
+      - ref_block_hash
+      - ref_tx_hash
+      - ref_tx_type
     properties:
       account_id:
         type: string

--- a/docs/swagger_v3/transfers.spec.yaml
+++ b/docs/swagger_v3/transfers.spec.yaml
@@ -46,6 +46,8 @@ paths:
               schema:
                 allOf:
                   - type: object
+                    required:
+                      - data
                     properties:
                       data:
                         type: array


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

As I know, only `ttl` field can be missed in tx fields provided by node, like here
https://mainnet.aeternity.io/mdw/v3/transactions/th_TGYTBqCFCrfvdfBXWwQa4KYXhDn8stwRTuJLtuu19ieqKYvjR

Without this change, TS forces me to ensure the property is present before accessing its value.