### PR TITLE
fix: take max expiration between extension and prev expiration

### DIFF
--- a/lib/ae_mdw/db/mutations/name_claim_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_claim_mutation.ex
@@ -152,8 +152,10 @@ defmodule AeMdw.Db.NameClaimMutation do
              owner: prev_owner
            ) = auction_bid} ->
             auction_end =
-              prev_auction_end +
-                :aec_governance.name_claim_bid_extension(plain_name, protocol_version)
+              max(
+                prev_auction_end,
+                height + :aec_governance.name_claim_bid_extension(plain_name, protocol_version)
+              )
 
             prev_name_claim_tx = DbUtil.read_node_tx(state, prev_txi_idx)
             prev_name_fee = :aens_claim_tx.name_fee(prev_name_claim_tx)

--- a/test/ae_mdw/db/name_claim_mutation_test.exs
+++ b/test/ae_mdw/db/name_claim_mutation_test.exs
@@ -202,7 +202,6 @@ defmodule AeMdw.Db.NameClaimMutationTest do
       })
 
     {:name_claim_tx, claim_tx} = :aetx.specialize_type(claim_aetx)
-    expire_height = expire_height + extension
 
     with_mocks [
       {AeMdw.Node.Db, [:passthrough],
@@ -250,8 +249,6 @@ defmodule AeMdw.Db.NameClaimMutationTest do
 
       state = Mutation.execute(bid_mutation_2, state)
 
-      expire_height = expire_height + extension
-
       assert {:ok,
               Model.auction_bid(
                 index: ^plain_name,
@@ -268,13 +265,13 @@ defmodule AeMdw.Db.NameClaimMutationTest do
           name_fee,
           false,
           {almost_expired_txi + 1, -1},
-          {claim_height + 200, 0},
+          {claim_height + timeout - 10, 0},
           protocol_version
         )
 
       state = Mutation.execute(bid_mutation_3, state)
 
-      expire_height = expire_height + extension
+      expire_height = claim_height + timeout - 10 + extension
 
       assert {:ok,
               Model.auction_bid(


### PR DESCRIPTION
The expiration when timeout != 0 was incorrect, it should instead use the max value of these two:
https://github.com/aeternity/aeternity/blob/master/apps/aens/src/aens_auctions.erl#L84-L86