### PR TITLE
fix: dex contract swaps

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -13,6 +13,7 @@ defmodule AeMdw.Db.Contract do
   alias AeMdw.Db.State
   alias AeMdw.Db.Sync.ActiveEntities
   alias AeMdw.Db.Sync.Stats, as: SyncStats
+  alias AeMdw.Dex
   alias AeMdw.Log
   alias AeMdw.Node
   alias AeMdw.Node.Db
@@ -80,8 +81,7 @@ defmodule AeMdw.Db.Contract do
 
       truncated_name = sort_field_truncate(name)
 
-      m_contract_name =
-        Model.aexn_contract_name(index: {aexn_type, truncated_name, contract_pk})
+      m_contract_name = Model.aexn_contract_name(index: {aexn_type, truncated_name, contract_pk})
 
       m_downcased_contract_name =
         Model.aexn_contract_downcased_name(
@@ -446,6 +446,8 @@ defmodule AeMdw.Db.Contract do
     case String.printable?(amounts) do
       true ->
         amounts = amounts |> String.split("|") |> Enum.map(&String.to_integer/1)
+
+        create_txi = Dex.get_create_txi(state, create_txi, txi, idx)
 
         state
         |> State.put(

--- a/priv/migrations/20240823130804_update_createtxi_in_dex_swaps.ex
+++ b/priv/migrations/20240823130804_update_createtxi_in_dex_swaps.ex
@@ -1,0 +1,42 @@
+defmodule AeMdw.Migrations.UpdateCreatetxiInDexSwaps do
+  alias AeMdw.Collection
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Db.DeleteKeysMutation
+  alias AeMdw.Db.WriteMutation
+  alias AeMdw.Dex
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    mutations_length =
+      state
+      |> Collection.stream(Model.DexContractSwapTokens, nil)
+      |> Enum.map(fn {create_txi, pk, txi, idx} = key ->
+        actual_create_txi = Dex.get_create_txi(state, create_txi, txi, idx)
+
+        {
+          WriteMutation.new(
+            Model.DexContractSwapTokens,
+            Model.dex_contract_swap_tokens(index: {actual_create_txi, pk, txi, idx})
+          ),
+          key
+        }
+      end)
+      |> Stream.chunk_every(1000)
+      |> Stream.map(fn chunk ->
+        {mutations, deletion_keys} = Enum.unzip(chunk)
+
+        mutations = [
+          DeleteKeysMutation.new(%{Model.DexContractSwapTokens => deletion_keys}) | mutations
+        ]
+
+        _state = State.commit_db(state, mutations)
+        length(mutations)
+      end)
+      |> Enum.sum()
+
+    {:ok, mutations_length}
+  end
+end

--- a/priv/migrations/20240823130804_update_createtxi_in_dex_swaps.ex
+++ b/priv/migrations/20240823130804_update_createtxi_in_dex_swaps.ex
@@ -1,4 +1,7 @@
 defmodule AeMdw.Migrations.UpdateCreatetxiInDexSwaps do
+  @moduledoc """
+  Reindex dex contract swaps with correct create_txi
+  """
   alias AeMdw.Collection
   alias AeMdw.Db.Model
   alias AeMdw.Db.State


### PR DESCRIPTION
This fix should make the dex swaps findable by contract_id