### PR TITLE
feat: add support for handling WAE contracts as special AEx9 ones

### DIFF
--- a/lib/ae_mdw/contracts.ex
+++ b/lib/ae_mdw/contracts.ex
@@ -313,11 +313,7 @@ defmodule AeMdw.Contracts do
     }
 
     fn direction ->
-      state
-      |> Collection.stream(@contract_log_table, direction, key_boundary, cursor)
-      |> Stream.map(fn {create_txi, call_txi, log_idx} ->
-        {create_txi, call_txi, log_idx}
-      end)
+      Collection.stream(state, @contract_log_table, direction, key_boundary, cursor)
     end
   end
 

--- a/lib/ae_mdw/db/mutations/contract_call_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_call_mutation.ex
@@ -56,7 +56,7 @@ defmodule AeMdw.Db.ContractCallMutation do
     state = DBContract.call_write(state, create_txi, txi, fun_arg_res)
 
     if call_rec != nil do
-      DBContract.logs_write(state, create_txi, txi, call_rec)
+      DBContract.logs_write(state, create_txi, txi, call_rec, false)
     else
       state
     end

--- a/lib/ae_mdw/db/mutations/contract_create_mutation.ex
+++ b/lib/ae_mdw/db/mutations/contract_create_mutation.ex
@@ -43,7 +43,7 @@ defmodule AeMdw.Db.ContractCreateMutation do
       |> State.cache_put(:ct_create_sync_cache, contract_pk, txi)
 
     if call_rec != nil do
-      DBContract.logs_write(state, txi, txi, call_rec)
+      DBContract.logs_write(state, txi, txi, call_rec, true)
     else
       state
     end

--- a/lib/ae_mdw/node.ex
+++ b/lib/ae_mdw/node.ex
@@ -102,6 +102,7 @@ defmodule AeMdw.Node do
       approval
       approval_for_all
       burn
+      deposit
       mint
       swap
       edition_limit
@@ -114,6 +115,7 @@ defmodule AeMdw.Node do
       token_limit
       token_limit_decrease
       transfer
+      withdrawal
     )a)
   end
 

--- a/priv/migrations/20240820120000_aex9_tokens_contract_mint_events_fix.ex
+++ b/priv/migrations/20240820120000_aex9_tokens_contract_mint_events_fix.ex
@@ -1,0 +1,158 @@
+defmodule AeMdw.Migrations.Aex9TokensContractMintEventsFix do
+  @moduledoc """
+  Fixes the Deposit(address, value) that should have been names Mint(address, value)
+  for one of the AE tokens contract (WAE DEX contract).
+  """
+
+  alias AeMdw.AexnContracts
+  alias AeMdw.Collection
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Origin
+  alias AeMdw.Db.WriteMutation
+  alias AeMdw.Db.DeleteKeysMutation
+  alias AeMdw.Stats
+  alias AeMdw.Util
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    contract_pk =
+      :ae_mdw
+      |> Application.fetch_env!(:ae_token)
+      |> Map.get(:aec_governance.get_network_id())
+
+    case Origin.tx_index(state, {:contract, contract_pk}) do
+      {:ok, create_txi} ->
+        run_with_contract(state, contract_pk, create_txi)
+
+      :not_found ->
+        {:ok, 0}
+    end
+  end
+
+  defp run_with_contract(state, contract_pk, create_txi) do
+    key_boundary = {
+      {create_txi, 0, nil},
+      {create_txi, nil, nil}
+    }
+
+    balances =
+      state
+      |> Collection.stream(Model.ContractLog, :forward, key_boundary, nil)
+      |> Stream.map(&State.fetch!(state, Model.ContractLog, &1))
+      |> Enum.reduce(%{}, fn Model.contract_log(
+                               index: {^create_txi, txi, idx} = index,
+                               args: args,
+                               hash: event_hash
+                             ),
+                             balances ->
+        event_name = AexnContracts.event_name(event_hash) || event_hash
+
+        case {event_name, args} do
+          {"Transfer", [from_pk, to_pk, <<transfered_value::256>>]} ->
+            balances
+            |> update_balance(from_pk, txi, idx, -transfered_value)
+            |> update_balance(to_pk, txi, idx, transfered_value)
+
+          # Mint
+          {"Deposit", [to_pk, <<mint_value::256>>]} ->
+            balances
+            |> update_balance(to_pk, txi, idx, mint_value)
+
+          # Burn
+          {"Withdrawal", [from_pk, <<burn_value::256>>]} ->
+            balances
+            |> update_balance(from_pk, txi, idx, -burn_value)
+
+          {"Allowance", [_from_pk, _to_pk, <<_allowance_value::256>>]} ->
+            balances
+
+          {event, args} ->
+            IO.puts("UNKNOWN EVENT: #{inspect(event)}, args: #{inspect(args)}, #{inspect(index)}")
+            balances
+        end
+      end)
+
+    balances_mutations =
+      Stream.flat_map(balances, fn {account_pk, {balance, txi, idx}} ->
+        [
+          WriteMutation.new(
+            Model.Aex9BalanceAccount,
+            Model.aex9_balance_account(
+              index: {contract_pk, balance, account_pk},
+              txi: txi,
+              log_idx: idx
+            )
+          ),
+          WriteMutation.new(
+            Model.Aex9EventBalance,
+            Model.aex9_event_balance(
+              index: {contract_pk, account_pk},
+              txi: txi,
+              log_idx: idx,
+              amount: balance
+            )
+          )
+        ]
+      end)
+
+    total_holders =
+      Enum.count(balances, fn {_account_pk, {balance, _txi, _idx}} -> balance > 0 end)
+
+    total_balances_amount =
+      balances
+      |> Stream.map(fn {_account_pk, {balance, _txi, _idx}} ->
+        balance
+      end)
+      |> Enum.sum()
+
+    key_boundary = {
+      {contract_pk, Util.min_int(), nil},
+      {contract_pk, Util.max_int(), nil}
+    }
+
+    deletion_keys =
+      state
+      |> Collection.stream(Model.Aex9BalanceAccount, :forward, key_boundary, nil)
+      |> Enum.to_list()
+
+    mutations = [
+      DeleteKeysMutation.new(%{
+        Model.AexnInvalidContract => [{:aex9, contract_pk}],
+        Model.Aex9BalanceAccount => deletion_keys
+      }),
+      WriteMutation.new(
+        Model.Stat,
+        Model.stat(index: Stats.aex9_holder_count_key(contract_pk), payload: total_holders)
+      ),
+      WriteMutation.new(
+        Model.Aex9ContractBalance,
+        Model.aex9_contract_balance(index: contract_pk, amount: total_balances_amount)
+      )
+    ]
+
+    total_mutations =
+      mutations
+      |> Stream.concat(balances_mutations)
+      |> Stream.chunk_every(1000)
+      |> Stream.map(fn mutations ->
+        _state = State.commit_db(state, mutations)
+        length(mutations)
+      end)
+      |> Enum.sum()
+
+    {:ok, total_mutations}
+  end
+
+  defp update_balance(balances, account_pk, txi, idx, amount) do
+    old_balance =
+      case Map.get(balances, account_pk) do
+        nil -> 0
+        {balance, _txi, _idx} -> balance
+      end
+
+    Map.put(balances, account_pk, {old_balance + amount, txi, idx})
+  end
+end

--- a/test/ae_mdw/db/contract_test.exs
+++ b/test/ae_mdw/db/contract_test.exs
@@ -50,7 +50,7 @@ defmodule AeMdw.Db.ContractTest do
       state =
         empty_state()
         |> State.cache_put(:ct_create_sync_cache, contract_pk, create_txi)
-        |> Contract.logs_write(create_txi, call_txi, call_rec)
+        |> Contract.logs_write(create_txi, call_txi, call_rec, false)
 
       m_log0 =
         Model.contract_log(
@@ -131,7 +131,7 @@ defmodule AeMdw.Db.ContractTest do
         empty_state()
         |> State.cache_put(:ct_create_sync_cache, contract_pk, create_txi)
         |> State.cache_put(:ct_create_sync_cache, remote_pk, remote_txi)
-        |> Contract.logs_write(create_txi, call_txi, call_rec)
+        |> Contract.logs_write(create_txi, call_txi, call_rec, false)
 
       m_log0 =
         Model.contract_log(
@@ -221,7 +221,7 @@ defmodule AeMdw.Db.ContractTest do
           Model.Field,
           Model.field(index: {:contract_create_tx, nil, dex_pair_pk, create_pair_txi})
         )
-        |> Contract.logs_write(create_pair_txi, call_txi, call_rec)
+        |> Contract.logs_write(create_pair_txi, call_txi, call_rec, false)
 
       assert %{token1: dex_token1_pk, token2: dex_token2_pk} ==
                DexCache.get_pair(dex_pair_pk)
@@ -241,7 +241,7 @@ defmodule AeMdw.Db.ContractTest do
       call_txi = call_txi + 1
       log_idx = 0
 
-      state = Contract.logs_write(state, create_token_txi, call_txi, call_rec2)
+      state = Contract.logs_write(state, create_token_txi, call_txi, call_rec2, false)
 
       assert {:ok, Model.dex_account_swap_tokens(amounts: [123, 456], to: ^account2_pk)} =
                State.get(
@@ -302,7 +302,7 @@ defmodule AeMdw.Db.ContractTest do
           Model.AexnContract,
           Model.aexn_contract(index: {:aex9, contract_pk}, txi_idx: {txi, -1})
         )
-        |> Contract.logs_write(txi, txi, call_rec)
+        |> Contract.logs_write(txi, txi, call_rec, true)
 
       assert :not_found == State.get(state, Model.Aex9EventBalance, {contract_pk, account_pk1})
       assert :not_found == State.get(state, Model.Aex9EventBalance, {contract_pk, account_pk2})
@@ -354,7 +354,7 @@ defmodule AeMdw.Db.ContractTest do
           Model.AexnContract,
           Model.aexn_contract(index: {:aex9, contract_pk2}, txi_idx: {create_txi2, -1})
         )
-        |> Contract.logs_write(create_txi1, txi, call_rec)
+        |> Contract.logs_write(create_txi1, txi, call_rec, true)
 
       assert :not_found == State.get(state, Model.Aex9EventBalance, {contract_pk2, account_pk1})
       assert :not_found == State.get(state, Model.Aex9EventBalance, {contract_pk2, account_pk2})
@@ -406,7 +406,7 @@ defmodule AeMdw.Db.ContractTest do
           Model.AexnContract,
           Model.aexn_contract(index: {:aex9, contract_pk}, txi_idx: {txi, -1})
         )
-        |> Contract.logs_write(txi, txi + 1, call_rec)
+        |> Contract.logs_write(txi, txi + 1, call_rec, false)
 
       assert Model.aex9_contract_balance(amount: 700) =
                State.fetch!(state, Model.Aex9ContractBalance, contract_pk)
@@ -453,7 +453,7 @@ defmodule AeMdw.Db.ContractTest do
           Model.AexnContract,
           Model.aexn_contract(index: {:aex9, contract_pk}, txi_idx: {txi, -1})
         )
-        |> Contract.logs_write(txi, txi + 1, call_rec)
+        |> Contract.logs_write(txi, txi + 1, call_rec, false)
 
       assert Model.aex9_contract_balance(amount: -1000) =
                State.fetch!(state, Model.Aex9ContractBalance, contract_pk)
@@ -507,7 +507,7 @@ defmodule AeMdw.Db.ContractTest do
           Model.AexnContract,
           Model.aexn_contract(index: {:aex9, remote_pk2}, txi_idx: {txi - 1, -1})
         )
-        |> Contract.logs_write(txi - 1, txi, call_rec)
+        |> Contract.logs_write(txi - 1, txi, call_rec, false)
 
       assert {:ok, Model.aex9_event_balance(amount: ^mint_amount)} =
                State.get(state, Model.Aex9EventBalance, {remote_pk1, account_pk1})
@@ -551,7 +551,7 @@ defmodule AeMdw.Db.ContractTest do
           Model.AexnContract,
           Model.aexn_contract(index: {:aex9, contract_pk}, txi_idx: {txi - 1, -1})
         )
-        |> Contract.logs_write(txi - 1, txi, call_rec)
+        |> Contract.logs_write(txi - 1, txi, call_rec, false)
 
       assert {:ok, Model.aex9_event_balance(amount: -2_000_000)} =
                State.get(state, Model.Aex9EventBalance, {contract_pk, account_pk1})
@@ -611,7 +611,7 @@ defmodule AeMdw.Db.ContractTest do
 
       {state, _txi} =
         Enum.reduce(call_rec_list, {state, txi}, fn call_rec, {state, txi} ->
-          {Contract.logs_write(state, create_txi, txi, call_rec), txi + 1}
+          {Contract.logs_write(state, create_txi, txi, call_rec, false), txi + 1}
         end)
 
       assert {:ok, Model.aex9_event_balance(amount: 1_190_000_000_000_000_000)} =
@@ -663,7 +663,7 @@ defmodule AeMdw.Db.ContractTest do
           Model.aexn_contract(index: {:aex9, contract_pk}, txi_idx: {txi, -1})
         )
         |> State.cache_put(:ct_create_sync_cache, contract_pk, txi)
-        |> Contract.logs_write(txi, txi, call_rec)
+        |> Contract.logs_write(txi, txi, call_rec, true)
 
       assert :not_found == State.get(state, Model.Aex9EventBalance, {contract_pk, account_pk1})
       assert :not_found == State.get(state, Model.Aex9EventBalance, {contract_pk, account_pk2})
@@ -746,7 +746,7 @@ defmodule AeMdw.Db.ContractTest do
         empty_state()
         |> State.cache_put(:ct_create_sync_cache, contract_pk, txi)
         |> State.put(Model.AexnContract, Model.aexn_contract(index: {:aex141, contract_pk}))
-        |> Contract.logs_write(txi, txi, call_rec)
+        |> Contract.logs_write(txi, txi, call_rec, false)
 
       assert :not_found == State.get(state, Model.NftContractLimits, contract_pk)
       assert :none == State.prev(state, Model.NftOwnership, {account_pk1, contract_pk, nil})
@@ -787,7 +787,7 @@ defmodule AeMdw.Db.ContractTest do
           Model.AexnContract,
           Model.aexn_contract(index: {:aex9, contract_pk}, txi_idx: {create_txi, -1})
         )
-        |> Contract.logs_write(create_txi, txi, call_rec)
+        |> Contract.logs_write(create_txi, txi, call_rec, false)
 
       assert {:ok, Model.aex9_event_balance(txi: ^txi, log_idx: 0, amount: 1_000_000)} =
                State.get(state, Model.Aex9EventBalance, {contract_pk, account_pk})


### PR DESCRIPTION
WAE contracts mistakenly emit a `Withdraw` event instead of `Burn` and a `Deposit` instead of `Mint`. We are now interpreting these events as what they should be.