### PR TITLE
chore: add generation of key boundaries

### DIFF
--- a/lib/ae_mdw/collection.ex
+++ b/lib/ae_mdw/collection.ex
@@ -121,12 +121,10 @@ defmodule AeMdw.Collection do
 
   @spec generate_key_boundary(tuple()) :: key_boundary()
   def generate_key_boundary(key) do
-    size = tuple_size(key)
-
-    (size - 1)..0
-    |> Enum.reduce({[], []}, fn i, {first, last} ->
-      {[get_min_key(elem(key, i)) | first], [get_max_key(elem(key, i)) | last]}
-    end)
+    key
+    |> Tuple.to_list()
+    |> Enum.map(&{get_min_key(&1), get_max_key(&1)})
+    |> Enum.unzip()
     |> then(fn {first, last} -> {List.to_tuple(first), List.to_tuple(last)} end)
   end
 

--- a/test/ae_mdw/collection_test.exs
+++ b/test/ae_mdw/collection_test.exs
@@ -1,0 +1,24 @@
+defmodule AeMdw.CollectionTest do
+  use ExUnit.Case
+
+  alias AeMdw.Collection
+  alias AeMdw.Util
+
+  test "generate key boundaries" do
+    assert {{:test}, {:test}} == Collection.generate_key_boundary({:test})
+
+    assert {{:test, Util.min_int()}, {:test, Util.max_int()}} ==
+             Collection.generate_key_boundary({:test, Collection.integer()})
+
+    assert {{:test, Util.min_int(), 0}, {:test, Util.max_int(), Util.max_int()}} ==
+             Collection.generate_key_boundary(
+               {:test, Collection.integer(), Collection.pos_integer()}
+             )
+
+    assert {{Util.min_256bit_int(), Util.min_bin()}, {Util.max_int(), Util.max_256bit_bin()}} ==
+             Collection.generate_key_boundary({Collection.integer_256bit(), Collection.binary()})
+
+    assert {{:test1, :test2, Util.min_int()}, {:test1, :test2, Util.max_int()}} ==
+             Collection.generate_key_boundary({:test1, :test2, Collection.integer()})
+  end
+end


### PR DESCRIPTION
This change is going to simplify and unify generation of key boundaries for streaming of collections (and prevent small mistakes like using the same value for beginning and end of range while typing out key boundaries).