### PR TITLE
fix: inconsistent account id naming in openapi

### DIFF
--- a/docs/swagger_v3/activities.spec.yaml
+++ b/docs/swagger_v3/activities.spec.yaml
@@ -211,13 +211,13 @@ schemas:
       - type
       - payload
 paths:
-  /accounts/{id}/activities:
+  /accounts/{accountId}/activities:
     get:
       deprecated: false
       description: Get an account activities.
       operationId: GetAccountActivities
       parameters:
-        - name: id
+        - name: accountId
           in: path
           description: The account address
           required: true

--- a/docs/swagger_v3/dex.spec.yaml
+++ b/docs/swagger_v3/dex.spec.yaml
@@ -149,7 +149,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-  /accounts/{account_id}/dex/swaps:
+  /accounts/{accountId}/dex/swaps:
     get:
       deprecated: false
       description: Get DEX swap tokens
@@ -157,7 +157,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/DirectionParam'
         - in: path
-          name: account_id
+          name: accountId
           required: true
           description: The account id
           schema:

--- a/docs/swagger_v3/names.spec.yaml
+++ b/docs/swagger_v3/names.spec.yaml
@@ -575,13 +575,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotFoundResponse'
-  /accounts/{id}/names/pointees:
+  /accounts/{accountId}/names/pointees:
     get:
       deprecated: false
       description: Get account pointees
       operationId: GetAccountPointees
       parameters:
-        - name: id
+        - name: accountId
           in: path
           description: The account that names point to
           required: true

--- a/docs/swagger_v3/transactions.spec.yaml
+++ b/docs/swagger_v3/transactions.spec.yaml
@@ -246,7 +246,7 @@ paths:
                 description: The transactions count
                 example: 15479090
                 type: integer
-  /accounts/{id}/transactions/count:
+  /accounts/{accountId}/transactions/count:
     get:
       deprecated: false
       description: Get transactions count and its type for given aeternity ID.
@@ -254,7 +254,7 @@ paths:
       parameters:
         - description: The ID of the address/name/oracle/etc
           in: path
-          name: id
+          name: accountId
           required: true
           schema:
             $ref: '#/components/schemas/AccountAddress'


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/40289f1e-c597-491a-ba56-24cc9baadc5d)
Now:
![image](https://github.com/user-attachments/assets/c3d70fc7-c407-4cbd-83a6-1271660bddec)
