### PR TITLE
fix: contemplate case sensitivity when looking for names

### DIFF
--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -959,7 +959,7 @@ defmodule AeMdw.Names do
 
   defp locate_name_or_auction_source(state, plain_name_or_hash) do
     plain_name =
-      with {:ok, hash_bin} <- Validate.id(plain_name_or_hash),
+      with {:ok, hash_bin} <- Validate.name_id(plain_name_or_hash),
            {:ok, Model.plain_name(value: plain_name)} <-
              State.get(state, Model.PlainName, hash_bin) do
         plain_name


### PR DESCRIPTION
Currently, accessing a name in a case any other than lowercase doesn't work, e.g.:  https://mainnet.aeternity.io/mdw/v3/names/test.chain works, but https://mainnet.aeternity.io/mdw/v3/names/tEst.chain doesn't. This PR fixes that.