### PR TITLE
chore: add contract call index to origin

### DIFF
--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -38,7 +38,6 @@ defmodule AeMdw.Db.Model do
   @typep txi() :: Txs.txi()
   @typep txi_idx() :: Txs.txi_idx()
   @typep log_idx() :: Contracts.log_idx()
-  @typep tx_hash() :: Txs.tx_hash()
   @typep bi_txi() :: Blocks.bi_txi()
   @typep bi_txi_idx() :: Blocks.bi_txi_idx()
   @typep query_id() :: Oracles.query_id()
@@ -180,22 +179,20 @@ defmodule AeMdw.Db.Model do
   @type id_count() :: record(:id_count, index: id_count_index(), count: non_neg_integer())
 
   # object origin :
-  #     index = {tx_type, pubkey, txi_idx}, tx_id = tx_hash
-  @origin_defaults [index: {nil, nil, nil}, tx_id: nil]
+  #     index = {tx_type, pubkey}, txi_idx
+  @origin_defaults [index: {nil, nil}, txi_idx: nil]
   defrecord :origin, @origin_defaults
 
-  @type origin_index() :: {tx_type(), pubkey(), txi_idx()}
-  @type origin() :: record(:origin, index: origin_index(), tx_id: tx_hash())
+  @type origin_index() :: {tx_type(), pubkey()}
+  @type origin() :: record(:origin, index: origin_index(), txi_idx: txi_idx())
 
-  # we need this one to quickly locate origin keys to delete for invalidating a fork
-  #
   # rev object origin :
-  #     index = {txi_idx, tx_type, pubkey}
-  @rev_origin_defaults [index: {nil, nil, nil}, unused: nil]
+  #     index = {txi_idx, tx_type}, pubkey
+  @rev_origin_defaults [index: {nil, nil}, pubkey: nil]
   defrecord :rev_origin, @rev_origin_defaults
 
-  @type rev_origin_index() :: {txi_idx(), tx_type(), pubkey()}
-  @type rev_origin() :: record(:rev_origin, index: rev_origin_index())
+  @type rev_origin_index() :: {txi_idx(), tx_type()}
+  @type rev_origin() :: record(:rev_origin, index: rev_origin_index(), pubkey: pubkey())
 
   # plain name:
   #     index = name_hash, plain = plain name

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -180,21 +180,21 @@ defmodule AeMdw.Db.Model do
   @type id_count() :: record(:id_count, index: id_count_index(), count: non_neg_integer())
 
   # object origin :
-  #     index = {tx_type, pubkey, tx_index}, tx_id = tx_hash
+  #     index = {tx_type, pubkey, txi_idx}, tx_id = tx_hash
   @origin_defaults [index: {nil, nil, nil}, tx_id: nil]
   defrecord :origin, @origin_defaults
 
-  @type origin_index() :: {tx_type(), pubkey(), txi()}
+  @type origin_index() :: {tx_type(), pubkey(), txi_idx()}
   @type origin() :: record(:origin, index: origin_index(), tx_id: tx_hash())
 
   # we need this one to quickly locate origin keys to delete for invalidating a fork
   #
   # rev object origin :
-  #     index = {tx_index, tx_type, pubkey}
+  #     index = {txi_idx, tx_type, pubkey}
   @rev_origin_defaults [index: {nil, nil, nil}, unused: nil]
   defrecord :rev_origin, @rev_origin_defaults
 
-  @type rev_origin_index() :: {txi(), tx_type(), pubkey()}
+  @type rev_origin_index() :: {txi_idx(), tx_type(), pubkey()}
   @type rev_origin() :: record(:rev_origin, index: rev_origin_index())
 
   # plain name:

--- a/lib/ae_mdw/db/origin.ex
+++ b/lib/ae_mdw/db/origin.ex
@@ -78,9 +78,13 @@ defmodule AeMdw.Db.Origin do
   end
 
   def pubkey(state, {:contract, txi}) do
-    case State.next(state, Model.RevOrigin, {{txi, -1}, -1, <<>>}) do
-      {:ok, {{^txi, _idx}, type, pubkey}} when type in @contract_creation_types -> pubkey
-      _key_mismatch -> nil
+    case State.next(state, Model.RevOrigin, {{txi, -1}, -1}) do
+      {:ok, {{^txi, _idx}, type} = index} when type in @contract_creation_types ->
+        Model.rev_origin(pubkey: pubkey) = State.fetch!(state, Model.RevOrigin, index)
+        pubkey
+
+      _key_mismatch ->
+        nil
     end
   end
 

--- a/lib/ae_mdw/db/origin.ex
+++ b/lib/ae_mdw/db/origin.ex
@@ -1,7 +1,6 @@
 defmodule AeMdw.Db.Origin do
   @moduledoc false
 
-  alias AeMdw.Collection
   alias AeMdw.Contract
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
@@ -9,10 +8,7 @@ defmodule AeMdw.Db.Origin do
   alias AeMdw.Node
   alias AeMdw.Node.Db
   alias AeMdw.Txs
-  alias AeMdw.Util
   alias AeMdw.Validate
-
-  import AeMdw.Util
 
   require Model
   require Logger
@@ -23,16 +19,7 @@ defmodule AeMdw.Db.Origin do
 
   @typep contract_locator() :: {:contract, Txs.txi()} | {:contract_call, Txs.txi()}
   @typep creation_txi_locator() :: {:contract, Db.pubkey()}
-
-  ##########
-
-  @spec block_index(State.t(), {:contract, binary()}) :: map()
-  def block_index(state, {:contract, id}),
-    do:
-      map_some(
-        tx_index(state, {:contract, id}),
-        &Model.tx(DbUtil.read_tx!(state, &1), :block_index)
-      )
+  @typep txi() :: Txs.txi()
 
   @doc """
   Tries to find the transaction that created a contract by finding it from 3
@@ -50,7 +37,7 @@ defmodule AeMdw.Db.Origin do
     and created through core hard-forks. These contracts will have a negative
     txi where the number is the index of the preloaded contracts.
   """
-  @spec tx_index(State.t(), creation_txi_locator()) :: {:ok, integer()} | :not_found
+  @spec tx_index(State.t(), creation_txi_locator()) :: {:ok, txi()} | :not_found
   def tx_index(state, {:contract, pk}) do
     with :error <- field_txi(state, :contract_create_tx, nil, pk),
          :error <- field_txi(state, :contract_call_tx, nil, pk),
@@ -91,8 +78,8 @@ defmodule AeMdw.Db.Origin do
   end
 
   def pubkey(state, {:contract, txi}) do
-    case State.next(state, Model.RevOrigin, {txi, -1, <<>>}) do
-      {:ok, {^txi, type, pubkey}} when type in @contract_creation_types -> pubkey
+    case State.next(state, Model.RevOrigin, {{txi, -1}, -1, <<>>}) do
+      {:ok, {{^txi, _idx}, type, pubkey}} when type in @contract_creation_types -> pubkey
       _key_mismatch -> nil
     end
   end
@@ -110,12 +97,6 @@ defmodule AeMdw.Db.Origin do
     contract_id
   end
 
-  @spec count_contracts(State.t()) :: non_neg_integer()
-  def count_contracts(state) do
-    count_by_tx_type(state, :contract_create_tx) + count_by_tx_type(state, :contract_call_tx) +
-      count_by_tx_type(state, :ga_attach_tx)
-  end
-
   #
   # Private functions
   #
@@ -124,13 +105,6 @@ defmodule AeMdw.Db.Origin do
       {:ok, {^tx_type, ^pos, ^pk, txi}} -> {:ok, txi}
       _key_mismatch -> :error
     end
-  end
-
-  defp count_by_tx_type(state, tx_type) do
-    state
-    |> Collection.stream(Model.Origin, {tx_type, Util.min_bin(), nil})
-    |> Stream.take_while(&match?({^tx_type, _pubkey, _txi}, &1))
-    |> Enum.count()
   end
 
   defp hardforks_contracts do

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -31,12 +31,11 @@ defmodule AeMdw.Db.Sync.Contract do
           Blocks.block_hash(),
           Blocks.block_index(),
           Txs.txi(),
-          Txs.tx_hash(),
           Db.pubkey()
         ) :: [
           Mutation.t()
         ]
-  def events_mutations(events, block_hash, block_index, call_txi, call_tx_hash, contract_pk) do
+  def events_mutations(events, block_hash, block_index, call_txi, contract_pk) do
     events =
       Enum.filter(
         events,
@@ -76,7 +75,7 @@ defmodule AeMdw.Db.Sync.Contract do
 
     [
       IntCallsMutation.new(contract_pk, call_txi, int_calls)
-      | events_tx_mutations(int_calls, block_index, block_hash, call_txi, call_tx_hash)
+      | events_tx_mutations(int_calls, block_index, block_hash, call_txi)
     ]
   end
 
@@ -127,13 +126,13 @@ defmodule AeMdw.Db.Sync.Contract do
     end
   end
 
-  defp events_tx_mutations(int_calls, {height, _mbi} = block_index, block_hash, call_txi, tx_hash) do
+  defp events_tx_mutations(int_calls, {height, _mbi} = block_index, block_hash, call_txi) do
     Enum.map(int_calls, fn
       {local_idx, "Oracle.extend", :oracle_extend_tx, _aetx, tx} ->
         Oracle.extend_mutation(tx, block_index, {call_txi, local_idx})
 
       {local_idx, "Oracle.register", :oracle_register_tx, _aetx, tx} ->
-        Oracle.register_mutations(tx, tx_hash, block_index, {call_txi, local_idx})
+        Oracle.register_mutations(tx, block_index, {call_txi, local_idx})
 
       {local_idx, "Oracle.respond", :oracle_response_tx, _aetx, tx} ->
         Oracle.response_mutation(tx, block_index, {call_txi, local_idx})
@@ -142,7 +141,7 @@ defmodule AeMdw.Db.Sync.Contract do
         Oracle.query_mutation(tx, height, {call_txi, local_idx})
 
       {local_idx, "AENS.claim", :name_claim_tx, _aetx, tx} ->
-        Name.name_claim_mutations(tx, tx_hash, block_index, {call_txi, local_idx})
+        Name.name_claim_mutations(tx, block_index, {call_txi, local_idx})
 
       {local_idx, "AENS.update", :name_update_tx, _aetx, tx} ->
         Name.update_mutations(tx, {call_txi, local_idx}, block_index, true)
@@ -177,8 +176,7 @@ defmodule AeMdw.Db.Sync.Contract do
               :contract_call_tx,
               nil,
               contract_pk,
-              {call_txi, local_idx},
-              tx_hash
+              {call_txi, local_idx}
             )
         ]
 

--- a/lib/ae_mdw/db/sync/contract.ex
+++ b/lib/ae_mdw/db/sync/contract.ex
@@ -177,7 +177,7 @@ defmodule AeMdw.Db.Sync.Contract do
               :contract_call_tx,
               nil,
               contract_pk,
-              call_txi,
+              {call_txi, local_idx},
               tx_hash
             )
         ]

--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -29,7 +29,7 @@ defmodule AeMdw.Db.Sync.Name do
   @spec name_claim_mutations(Node.tx(), Txs.tx_hash(), Blocks.block_index(), Txs.txi_idx()) :: [
           Mutation.t()
         ]
-  def name_claim_mutations(tx, tx_hash, {height, _mbi} = block_index, {txi, _idx} = txi_idx) do
+  def name_claim_mutations(tx, tx_hash, {height, _mbi} = block_index, txi_idx) do
     plain_name = String.downcase(:aens_claim_tx.name(tx))
     {:ok, name_hash} = :aens.get_name_hash(plain_name)
     owner_pk = Validate.id!(:aens_claim_tx.account_id(tx))
@@ -48,7 +48,7 @@ defmodule AeMdw.Db.Sync.Name do
         block_index,
         proto_vsn
       )
-      | Origin.origin_mutations(:name_claim_tx, nil, name_hash, txi, tx_hash)
+      | Origin.origin_mutations(:name_claim_tx, nil, name_hash, txi_idx, tx_hash)
     ]
   end
 

--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -26,10 +26,10 @@ defmodule AeMdw.Db.Sync.Name do
   @typep state :: State.t()
   @typep deactivate_stat :: :names_expired | :names_revoked
 
-  @spec name_claim_mutations(Node.tx(), Txs.tx_hash(), Blocks.block_index(), Txs.txi_idx()) :: [
+  @spec name_claim_mutations(Node.tx(), Blocks.block_index(), Txs.txi_idx()) :: [
           Mutation.t()
         ]
-  def name_claim_mutations(tx, tx_hash, {height, _mbi} = block_index, txi_idx) do
+  def name_claim_mutations(tx, {height, _mbi} = block_index, txi_idx) do
     plain_name = String.downcase(:aens_claim_tx.name(tx))
     {:ok, name_hash} = :aens.get_name_hash(plain_name)
     owner_pk = Validate.id!(:aens_claim_tx.account_id(tx))
@@ -48,7 +48,7 @@ defmodule AeMdw.Db.Sync.Name do
         block_index,
         proto_vsn
       )
-      | Origin.origin_mutations(:name_claim_tx, nil, name_hash, txi_idx, tx_hash)
+      | Origin.origin_mutations(:name_claim_tx, nil, name_hash, txi_idx)
     ]
   end
 

--- a/lib/ae_mdw/db/sync/oracle.ex
+++ b/lib/ae_mdw/db/sync/oracle.ex
@@ -26,13 +26,13 @@ defmodule AeMdw.Db.Sync.Oracle do
   @spec register_mutations(Node.tx(), Txs.tx_hash(), Blocks.block_index(), Txs.txi_idx()) :: [
           Mutation.t()
         ]
-  def register_mutations(tx, tx_hash, {height, _mbi} = block_index, {txi, _idx} = txi_idx) do
+  def register_mutations(tx, tx_hash, {height, _mbi} = block_index, txi_idx) do
     oracle_pk = :aeo_register_tx.account_pubkey(tx)
     delta_ttl = :aeo_utils.ttl_delta(height, :aeo_register_tx.oracle_ttl(tx))
     expire = height + delta_ttl
 
     [
-      Origin.origin_mutations(:oracle_register_tx, nil, oracle_pk, txi, tx_hash),
+      Origin.origin_mutations(:oracle_register_tx, nil, oracle_pk, txi_idx, tx_hash),
       OracleRegisterMutation.new(oracle_pk, block_index, expire, txi_idx)
     ]
   end

--- a/lib/ae_mdw/db/sync/oracle.ex
+++ b/lib/ae_mdw/db/sync/oracle.ex
@@ -23,16 +23,16 @@ defmodule AeMdw.Db.Sync.Oracle do
   @typep txi_idx() :: Txs.txi_idx()
   @typep state :: State.t()
 
-  @spec register_mutations(Node.tx(), Txs.tx_hash(), Blocks.block_index(), Txs.txi_idx()) :: [
+  @spec register_mutations(Node.tx(), Blocks.block_index(), Txs.txi_idx()) :: [
           Mutation.t()
         ]
-  def register_mutations(tx, tx_hash, {height, _mbi} = block_index, txi_idx) do
+  def register_mutations(tx, {height, _mbi} = block_index, txi_idx) do
     oracle_pk = :aeo_register_tx.account_pubkey(tx)
     delta_ttl = :aeo_utils.ttl_delta(height, :aeo_register_tx.oracle_ttl(tx))
     expire = height + delta_ttl
 
     [
-      Origin.origin_mutations(:oracle_register_tx, nil, oracle_pk, txi_idx, tx_hash),
+      Origin.origin_mutations(:oracle_register_tx, nil, oracle_pk, txi_idx),
       OracleRegisterMutation.new(oracle_pk, block_index, expire, txi_idx)
     ]
   end

--- a/lib/ae_mdw/db/sync/origin.ex
+++ b/lib/ae_mdw/db/sync/origin.ex
@@ -17,12 +17,12 @@ defmodule AeMdw.Db.Sync.Origin do
           Node.tx_type(),
           WriteFieldMutation.pos(),
           NodeDb.pubkey(),
-          Txs.txi(),
+          Txs.txi_idx(),
           Txs.tx_hash()
         ) :: [Mutation.t()]
-  def origin_mutations(tx_type, pos, pubkey, txi, tx_hash) do
-    m_origin = Model.origin(index: {tx_type, pubkey, txi}, tx_id: tx_hash)
-    m_rev_origin = Model.rev_origin(index: {txi, tx_type, pubkey})
+  def origin_mutations(tx_type, pos, pubkey, {txi, _idx} = txi_idx, tx_hash) do
+    m_origin = Model.origin(index: {tx_type, pubkey, txi_idx}, tx_id: tx_hash)
+    m_rev_origin = Model.rev_origin(index: {txi_idx, tx_type, pubkey})
 
     [
       WriteMutation.new(Model.Origin, m_origin),

--- a/lib/ae_mdw/db/sync/origin.ex
+++ b/lib/ae_mdw/db/sync/origin.ex
@@ -17,12 +17,11 @@ defmodule AeMdw.Db.Sync.Origin do
           Node.tx_type(),
           WriteFieldMutation.pos(),
           NodeDb.pubkey(),
-          Txs.txi_idx(),
-          Txs.tx_hash()
+          Txs.txi_idx()
         ) :: [Mutation.t()]
-  def origin_mutations(tx_type, pos, pubkey, {txi, _idx} = txi_idx, tx_hash) do
-    m_origin = Model.origin(index: {tx_type, pubkey, txi_idx}, tx_id: tx_hash)
-    m_rev_origin = Model.rev_origin(index: {txi_idx, tx_type, pubkey})
+  def origin_mutations(tx_type, pos, pubkey, {txi, _idx} = txi_idx) do
+    m_origin = Model.origin(index: {tx_type, pubkey}, txi_idx: txi_idx)
+    m_rev_origin = Model.rev_origin(index: {txi_idx, tx_type}, pubkey: pubkey)
 
     [
       WriteMutation.new(Model.Origin, m_origin),

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -119,7 +119,7 @@ defmodule AeMdw.Db.Sync.Transaction do
        }) do
     contract_pk = :aect_create_tx.contract_pubkey(tx)
 
-    mutations = Origin.origin_mutations(:contract_create_tx, nil, contract_pk, txi, tx_hash)
+    mutations = Origin.origin_mutations(:contract_create_tx, nil, contract_pk, {txi, -1}, tx_hash)
 
     if Contract.exists?(contract_pk) do
       call_rec = Contract.get_init_call_rec(tx, block_hash)
@@ -216,7 +216,7 @@ defmodule AeMdw.Db.Sync.Transaction do
 
     [
       Channels.open_mutations({block_index, {txi, -1}}, tx),
-      Origin.origin_mutations(:channel_create_tx, nil, channel_pk, txi, tx_hash)
+      Origin.origin_mutations(:channel_create_tx, nil, channel_pk, {txi, -1}, tx_hash)
     ]
   end
 
@@ -300,7 +300,7 @@ defmodule AeMdw.Db.Sync.Transaction do
         do: ContractCreateCacheMutation.new(contract_pk, txi)
 
     [
-      Origin.origin_mutations(:ga_attach_tx, nil, contract_pk, txi, tx_hash),
+      Origin.origin_mutations(:ga_attach_tx, nil, contract_pk, {txi, -1}, tx_hash),
       stat_mutation
     ]
   end

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -112,14 +112,13 @@ defmodule AeMdw.Db.Sync.Transaction do
          type: :contract_create_tx,
          tx: tx,
          txi: txi,
-         tx_hash: tx_hash,
          block_index: block_index,
          block_hash: block_hash,
          tx_events: tx_events
        }) do
     contract_pk = :aect_create_tx.contract_pubkey(tx)
 
-    mutations = Origin.origin_mutations(:contract_create_tx, nil, contract_pk, {txi, -1}, tx_hash)
+    mutations = Origin.origin_mutations(:contract_create_tx, nil, contract_pk, {txi, -1})
 
     if Contract.exists?(contract_pk) do
       call_rec = Contract.get_init_call_rec(tx, block_hash)
@@ -130,7 +129,6 @@ defmodule AeMdw.Db.Sync.Transaction do
           block_hash,
           block_index,
           txi,
-          tx_hash,
           contract_pk
         )
 
@@ -164,8 +162,7 @@ defmodule AeMdw.Db.Sync.Transaction do
          txi: txi,
          block_index: block_index,
          block_hash: block_hash,
-         tx_events: tx_events,
-         tx_hash: tx_hash
+         tx_events: tx_events
        }) do
     contract_or_name_pk =
       tx
@@ -187,7 +184,6 @@ defmodule AeMdw.Db.Sync.Transaction do
         block_hash,
         block_index,
         txi,
-        tx_hash,
         contract_pk
       )
 
@@ -209,14 +205,13 @@ defmodule AeMdw.Db.Sync.Transaction do
          signed_tx: signed_tx,
          block_index: block_index,
          txi: txi,
-         tx: tx,
-         tx_hash: tx_hash
+         tx: tx
        }) do
     {:ok, channel_pk} = :aesc_utils.channel_pubkey(signed_tx)
 
     [
       Channels.open_mutations({block_index, {txi, -1}}, tx),
-      Origin.origin_mutations(:channel_create_tx, nil, channel_pk, {txi, -1}, tx_hash)
+      Origin.origin_mutations(:channel_create_tx, nil, channel_pk, {txi, -1})
     ]
   end
 
@@ -289,8 +284,7 @@ defmodule AeMdw.Db.Sync.Transaction do
          block_hash: block_hash,
          signed_tx: signed_tx,
          tx: tx,
-         txi: txi,
-         tx_hash: tx_hash
+         txi: txi
        }) do
     contract_pk = :aega_attach_tx.contract_pubkey(tx)
     {:ok, call_rec} = Contract.call_rec(signed_tx, contract_pk, block_hash)
@@ -300,7 +294,7 @@ defmodule AeMdw.Db.Sync.Transaction do
         do: ContractCreateCacheMutation.new(contract_pk, txi)
 
     [
-      Origin.origin_mutations(:ga_attach_tx, nil, contract_pk, {txi, -1}, tx_hash),
+      Origin.origin_mutations(:ga_attach_tx, nil, contract_pk, {txi, -1}),
       stat_mutation
     ]
   end
@@ -309,20 +303,18 @@ defmodule AeMdw.Db.Sync.Transaction do
          type: :oracle_register_tx,
          tx: tx,
          txi: txi,
-         tx_hash: tx_hash,
          block_index: block_index
        }) do
-    Oracle.register_mutations(tx, tx_hash, block_index, {txi, -1})
+    Oracle.register_mutations(tx, block_index, {txi, -1})
   end
 
   defp tx_mutations(%TxContext{
          type: :name_claim_tx,
          tx: tx,
          txi: txi,
-         tx_hash: tx_hash,
          block_index: block_index
        }) do
-    SyncName.name_claim_mutations(tx, tx_hash, block_index, {txi, -1})
+    SyncName.name_claim_mutations(tx, block_index, {txi, -1})
   end
 
   defp tx_mutations(%TxContext{

--- a/priv/migrations/20240930120001_restructure_origins.ex
+++ b/priv/migrations/20240930120001_restructure_origins.ex
@@ -1,0 +1,120 @@
+defmodule AeMdw.Migrations.RestructureOrigins do
+  @moduledoc """
+  Reindex Origin and RevOrigin records, now including transaction index.
+  """
+  alias AeMdw.Collection
+  alias AeMdw.Contract
+  alias AeMdw.Db.DeleteKeysMutation
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Sync.Transaction
+  alias AeMdw.Db.WriteMutation
+  alias AeMdw.Node.Db
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    state
+    |> Collection.stream(Model.Origin, nil)
+    |> Stream.filter(fn {_tx_type, _pubkey, txi} -> is_integer(txi) end)
+    |> Stream.map(fn {tx_type, pubkey, txi} = index ->
+      origin = State.fetch!(state, Model.Origin, index)
+      rev_origin_index = {txi, tx_type, pubkey}
+      idx = search_pubkey_idx(state, txi, pubkey)
+
+      {
+        [
+          WriteMutation.new(
+            Model.Origin,
+            Model.origin(origin,
+              index: {tx_type, pubkey, {txi, idx}}
+            )
+          ),
+          WriteMutation.new(
+            Model.RevOrigin,
+            Model.rev_origin(index: {{txi, idx}, tx_type, pubkey})
+          )
+        ],
+        {index, rev_origin_index}
+      }
+    end)
+    |> Stream.chunk_every(1_000)
+    |> Stream.map(fn chunk ->
+      {mutations, deletion_keys} = Enum.unzip(chunk)
+      {origin_deletion_keys, rev_deletion_keys} = Enum.unzip(deletion_keys)
+
+      mutations = [
+        DeleteKeysMutation.new(%{
+          Model.Origin => origin_deletion_keys,
+          Model.RevOrigin => rev_deletion_keys
+        })
+        | mutations
+      ]
+
+      _state = State.commit_db(state, mutations)
+      length(mutations)
+    end)
+    |> Enum.sum()
+    |> then(&{:ok, &1})
+  end
+
+  defp search_pubkey_idx(state, txi, pubkey) do
+    Model.tx(id: tx_hash, block_index: block_index) = State.fetch!(state, Model.Tx, txi)
+
+    case Db.get_tx_data(tx_hash) do
+      {block_hash, :contract_create_tx, signed_tx, tx} ->
+        contract_pubkey = :aect_create_tx.contract_pubkey(tx)
+
+        if contract_pubkey == pubkey do
+          -1
+        else
+          mb_events =
+            block_hash
+            |> :aec_db.get_block()
+            |> Contract.get_grouped_events()
+
+          %WriteMutation{record: Model.origin(index: {_tx_type, ^pubkey, {^txi, idx}})} =
+            signed_tx
+            |> Transaction.transaction_mutations(txi, block_index, block_hash, 0, mb_events)
+            |> List.flatten()
+            |> Enum.find(
+              &match?(
+                %WriteMutation{
+                  table: Model.Origin,
+                  record: Model.origin(index: {_tx_type, ^pubkey, _txi_idx})
+                },
+                &1
+              )
+            )
+
+          idx
+        end
+
+      {block_hash, :contract_call_tx, signed_tx, _tx} ->
+        mb_events =
+          block_hash
+          |> :aec_db.get_block()
+          |> Contract.get_grouped_events()
+
+        %WriteMutation{record: Model.origin(index: {_tx_type, ^pubkey, {^txi, idx}})} =
+          signed_tx
+          |> Transaction.transaction_mutations(txi, block_index, block_hash, 0, mb_events)
+          |> List.flatten()
+          |> Enum.find(
+            &match?(
+              %WriteMutation{
+                table: Model.Origin,
+                record: Model.origin(index: {_tx_type, ^pubkey, _txi_idx})
+              },
+              &1
+            )
+          )
+
+        idx
+
+      {_block_hash, _tx_type, _signed_tx, _tx} ->
+        -1
+    end
+  end
+end

--- a/priv/migrations/20240930120001_restructure_origins.ex
+++ b/priv/migrations/20240930120001_restructure_origins.ex
@@ -19,7 +19,6 @@ defmodule AeMdw.Migrations.RestructureOrigins do
     |> Collection.stream(Model.Origin, nil)
     |> Stream.filter(fn {_tx_type, _pubkey, txi} -> is_integer(txi) end)
     |> Stream.map(fn {tx_type, pubkey, txi} = index ->
-      origin = State.fetch!(state, Model.Origin, index)
       rev_origin_index = {txi, tx_type, pubkey}
       idx = search_pubkey_idx(state, txi, pubkey)
 
@@ -27,13 +26,14 @@ defmodule AeMdw.Migrations.RestructureOrigins do
         [
           WriteMutation.new(
             Model.Origin,
-            Model.origin(origin,
-              index: {tx_type, pubkey, {txi, idx}}
+            Model.origin(
+              index: {tx_type, pubkey},
+              txi_idx: {txi, idx}
             )
           ),
           WriteMutation.new(
             Model.RevOrigin,
-            Model.rev_origin(index: {{txi, idx}, tx_type, pubkey})
+            Model.rev_origin(index: {{txi, idx}, tx_type}, pubkey: pubkey)
           )
         ],
         {index, rev_origin_index}

--- a/test/ae_mdw/db/contract_create_mutation_test.exs
+++ b/test/ae_mdw/db/contract_create_mutation_test.exs
@@ -107,8 +107,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
               :contract_create_tx,
               nil,
               contract_pk,
-              {create_txi, -1},
-              :crypto.strong_rand_bytes(32)
+              {create_txi, -1}
             ),
             aexn_create_mutation,
             ContractCreateMutation.new(create_txi, call_rec)
@@ -198,8 +197,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
               :contract_create_tx,
               nil,
               contract_pk,
-              {create_txi, -1},
-              :crypto.strong_rand_bytes(32)
+              {create_txi, -1}
             ),
             ContractCreateMutation.new(create_txi, call_rec)
           ])
@@ -283,8 +281,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
             :contract_create_tx,
             nil,
             contract_pk,
-            {create_txi, -1},
-            :crypto.strong_rand_bytes(32)
+            {create_txi, -1}
           ),
           ContractCreateMutation.new(create_txi, call_rec)
         ]
@@ -359,8 +356,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
             :contract_create_tx,
             nil,
             contract_pk,
-            {create_txi, -1},
-            :crypto.strong_rand_bytes(32)
+            {create_txi, -1}
           ),
           ContractCreateMutation.new(create_txi, call_rec)
         ]

--- a/test/ae_mdw/db/contract_create_mutation_test.exs
+++ b/test/ae_mdw/db/contract_create_mutation_test.exs
@@ -107,7 +107,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
               :contract_create_tx,
               nil,
               contract_pk,
-              create_txi,
+              {create_txi, -1},
               :crypto.strong_rand_bytes(32)
             ),
             aexn_create_mutation,
@@ -198,7 +198,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
               :contract_create_tx,
               nil,
               contract_pk,
-              create_txi,
+              {create_txi, -1},
               :crypto.strong_rand_bytes(32)
             ),
             ContractCreateMutation.new(create_txi, call_rec)
@@ -283,7 +283,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
             :contract_create_tx,
             nil,
             contract_pk,
-            create_txi,
+            {create_txi, -1},
             :crypto.strong_rand_bytes(32)
           ),
           ContractCreateMutation.new(create_txi, call_rec)
@@ -359,7 +359,7 @@ defmodule AeMdw.Db.ContractCreateMutationTest do
             :contract_create_tx,
             nil,
             contract_pk,
-            create_txi,
+            {create_txi, -1},
             :crypto.strong_rand_bytes(32)
           ),
           ContractCreateMutation.new(create_txi, call_rec)

--- a/test/ae_mdw/db/name_claim_mutation_test.exs
+++ b/test/ae_mdw/db/name_claim_mutation_test.exs
@@ -21,10 +21,6 @@ defmodule AeMdw.Db.NameClaimMutationTest do
       {:ns_claim_tx, {:id, :account, new_owner_pk}, 11_251, plain_name, 7, :prelima,
        1_000_000_000_000_000, 0}
 
-    tx_hash =
-      <<159, 240, 103, 205, 63, 165, 186, 153, 226, 186, 128, 241, 61, 192, 66, 89, 156, 217, 200,
-        247, 31, 137, 16, 129, 250, 190, 199, 100, 137, 179, 112, 165>>
-
     claim_height = 200
     old_claim_height = 100
     owner_pk = <<8435::256>>
@@ -55,7 +51,7 @@ defmodule AeMdw.Db.NameClaimMutationTest do
     with_mocks [
       {AeMdw.Node.Db, [], [proto_vsn: fn _height -> 3 end]}
     ] do
-      mutations = Sync.Name.name_claim_mutations(tx, tx_hash, block_index, txi_idx)
+      mutations = Sync.Name.name_claim_mutations(tx, block_index, txi_idx)
 
       state =
         mutations

--- a/test/ae_mdw/db/origin_test.exs
+++ b/test/ae_mdw/db/origin_test.exs
@@ -6,9 +6,7 @@ defmodule AeMdw.Db.OriginTest do
   alias AeMdw.Db.NullStore
   alias AeMdw.Db.Origin
   alias AeMdw.Db.State
-  alias AeMdw.Db.Store
   alias AeMdw.Validate
-  alias AeMdw.TestSamples, as: TS
 
   import Mock
 
@@ -16,46 +14,6 @@ defmodule AeMdw.Db.OriginTest do
 
   @contract_id1 "ct_eJhrbPPS4V97VLKEVbSCJFpdA4uyXiZujQyLqMFoYV88TzDe6"
   @contract_id2 "ct_KJgjAXMtRF68AbT5A2aC9fTk8PA4WFv26cFSY27fXs6FtYQHK"
-
-  describe "count_contracts/1" do
-    test "it counts spend_tx, contract_call_tx and ga_attach_tx contract origins" do
-      state =
-        NullStore.new()
-        |> MemStore.new()
-        |> Store.put(
-          Model.Origin,
-          Model.origin(index: {:contract_create_tx, TS.contract_pk(0), 123})
-        )
-        |> Store.put(
-          Model.Origin,
-          Model.origin(index: {:contract_create_tx, TS.contract_pk(1), 123})
-        )
-        |> Store.put(
-          Model.Origin,
-          Model.origin(index: {:contract_create_tx, TS.contract_pk(2), 123})
-        )
-        |> Store.put(
-          Model.Origin,
-          Model.origin(index: {:contract_call_tx, TS.contract_pk(3), 123})
-        )
-        |> Store.put(Model.Origin, Model.origin(index: {:ga_attach_tx, TS.contract_pk(4), 123}))
-        |> State.new()
-
-      with_mocks [
-        {:aec_fork_block_settings, [],
-         [
-           lima_contracts: fn ->
-             [%{pubkey: Validate.id!(@contract_id1), amount: 2_448_618_414_302_482_322}]
-           end,
-           contracts: fn _protocol ->
-             [{"calls", []}, {"contracts", [%{"pubkey" => @contract_id2}]}]
-           end
-         ]}
-      ] do
-        assert(5 = Origin.count_contracts(state))
-      end
-    end
-  end
 
   describe "tx_index/2" do
     test "returns relative index of hardfork contracts" do

--- a/test/ae_mdw/db/sync/contract_test.exs
+++ b/test/ae_mdw/db/sync/contract_test.exs
@@ -69,14 +69,13 @@ defmodule AeMdw.Db.Sync.ContractTest do
       mutation = IntCallsMutation.new(contract_pk, call_txi, int_calls)
 
       mutations =
-        SyncContract.events_mutations(events, <<0::256>>, {0, 0}, call_txi, <<>>, contract_pk)
+        SyncContract.events_mutations(events, <<0::256>>, {0, 0}, call_txi, contract_pk)
 
       assert mutation in List.flatten(mutations)
     end
 
     test "it creates an Field record for each Chain.create/clone event, using the next Call.amount event" do
       call_txi = Enum.random(100_000..999_999)
-      call_tx_hash = :crypto.strong_rand_bytes(32)
       block_hash = :crypto.strong_rand_bytes(32)
       owner_pk = <<1::256>>
       owner_id = :aeser_id.create(:account, owner_pk)
@@ -167,8 +166,7 @@ defmodule AeMdw.Db.Sync.ContractTest do
           :contract_call_tx,
           nil,
           contract_pk1,
-          {call_txi, 1},
-          call_tx_hash
+          {call_txi, 1}
         )
 
       contract1 = :aect_contracts.new(owner_pk, nonce, %{vm: 7, abi: 3}, "code-2", 222)
@@ -197,7 +195,6 @@ defmodule AeMdw.Db.Sync.ContractTest do
             block_hash,
             {0, 0},
             call_txi,
-            call_tx_hash,
             contract_pk
           )
           |> List.flatten()
@@ -260,7 +257,6 @@ defmodule AeMdw.Db.Sync.ContractTest do
             block_hash,
             {554_178, 13},
             25_866_736,
-            <<2::256>>,
             25_866_736
           )
 
@@ -280,7 +276,7 @@ defmodule AeMdw.Db.Sync.ContractTest do
       event_mutations =
         "AENS.transfer"
         |> contract_events()
-        |> SyncContract.events_mutations(<<0::256>>, block_index, call_txi, <<>>, -1)
+        |> SyncContract.events_mutations(<<0::256>>, block_index, call_txi, -1)
         |> List.flatten()
 
       assert Enum.any?(event_mutations, fn
@@ -301,7 +297,7 @@ defmodule AeMdw.Db.Sync.ContractTest do
       event_mutations =
         "AENS.update"
         |> contract_events()
-        |> SyncContract.events_mutations(<<0::256>>, block_index, call_txi, <<>>, -1)
+        |> SyncContract.events_mutations(<<0::256>>, block_index, call_txi, -1)
         |> List.flatten()
 
       assert Enum.any?(event_mutations, fn
@@ -338,8 +334,6 @@ defmodule AeMdw.Db.Sync.ContractTest do
       sync_height = 50_000
       expire = sync_height + delta_ttl
       call_txi = sync_height * 1_000
-
-      call_tx_hash = <<1::256>>
       contract_pk = <<2::256>>
 
       mutations =
@@ -348,7 +342,6 @@ defmodule AeMdw.Db.Sync.ContractTest do
           <<0::256>>,
           {sync_height, 0},
           call_txi,
-          call_tx_hash,
           contract_pk
         )
         |> List.flatten()
@@ -364,11 +357,11 @@ defmodule AeMdw.Db.Sync.ContractTest do
                },
                %WriteMutation{
                  table: Model.Origin,
-                 record: Model.origin(index: {^tx_type, ^pubkey, {^call_txi, 0}})
+                 record: Model.origin(index: {^tx_type, ^pubkey}, txi_idx: {^call_txi, 0})
                },
                %WriteMutation{
                  table: Model.RevOrigin,
-                 record: Model.rev_origin(index: {{^call_txi, 0}, ^tx_type, ^pubkey})
+                 record: Model.rev_origin(index: {{^call_txi, 0}, ^tx_type}, pubkey: ^pubkey)
                },
                %AeMdw.Db.WriteFieldMutation{
                  pos: nil,
@@ -398,7 +391,6 @@ defmodule AeMdw.Db.Sync.ContractTest do
       sync_height = 50_000
       block_index = {sync_height, 0}
       call_txi = sync_height * 1_000
-      call_tx_hash = <<2::256>>
       contract_pk = <<3::256>>
 
       mutations =
@@ -407,7 +399,6 @@ defmodule AeMdw.Db.Sync.ContractTest do
           <<0::256>>,
           block_index,
           call_txi,
-          call_tx_hash,
           contract_pk
         )
         |> List.flatten()

--- a/test/ae_mdw/db/sync/contract_test.exs
+++ b/test/ae_mdw/db/sync/contract_test.exs
@@ -167,7 +167,7 @@ defmodule AeMdw.Db.Sync.ContractTest do
           :contract_call_tx,
           nil,
           contract_pk1,
-          call_txi,
+          {call_txi, 1},
           call_tx_hash
         )
 
@@ -364,11 +364,11 @@ defmodule AeMdw.Db.Sync.ContractTest do
                },
                %WriteMutation{
                  table: Model.Origin,
-                 record: Model.origin(index: {^tx_type, ^pubkey, ^call_txi})
+                 record: Model.origin(index: {^tx_type, ^pubkey, {^call_txi, 0}})
                },
                %WriteMutation{
                  table: Model.RevOrigin,
-                 record: Model.rev_origin(index: {^call_txi, ^tx_type, ^pubkey})
+                 record: Model.rev_origin(index: {{^call_txi, 0}, ^tx_type, ^pubkey})
                },
                %AeMdw.Db.WriteFieldMutation{
                  pos: nil,

--- a/test/ae_mdw/db/sync/name_test.exs
+++ b/test/ae_mdw/db/sync/name_test.exs
@@ -70,7 +70,7 @@ defmodule AeMdw.Db.Sync.NameTest do
             block_index,
             protocol_version
           )
-          | Origin.origin_mutations(:name_claim_tx, nil, name_hash, txi, tx_hash)
+          | Origin.origin_mutations(:name_claim_tx, nil, name_hash, {txi, -1}, tx_hash)
         ]
 
         assert ^mutations = Name.name_claim_mutations(tx_rec, tx_hash, block_index, txi_idx)
@@ -115,7 +115,7 @@ defmodule AeMdw.Db.Sync.NameTest do
             block_index,
             4
           )
-          | Origin.origin_mutations(:name_claim_tx, nil, name_hash, txi, tx_hash)
+          | Origin.origin_mutations(:name_claim_tx, nil, name_hash, {txi, -1}, tx_hash)
         ]
 
         assert ^mutations = Name.name_claim_mutations(tx_rec, tx_hash, block_index, {txi, -1})

--- a/test/ae_mdw/db/sync/name_test.exs
+++ b/test/ae_mdw/db/sync/name_test.exs
@@ -40,7 +40,6 @@ defmodule AeMdw.Db.Sync.NameTest do
       block_index = {height, 1}
       txi = height * 1_000
       txi_idx = {txi, -1}
-      tx_hash = <<txi::256>>
 
       {:ok, aetx} =
         :aens_claim_tx.new(%{
@@ -70,10 +69,10 @@ defmodule AeMdw.Db.Sync.NameTest do
             block_index,
             protocol_version
           )
-          | Origin.origin_mutations(:name_claim_tx, nil, name_hash, {txi, -1}, tx_hash)
+          | Origin.origin_mutations(:name_claim_tx, nil, name_hash, {txi, -1})
         ]
 
-        assert ^mutations = Name.name_claim_mutations(tx_rec, tx_hash, block_index, txi_idx)
+        assert ^mutations = Name.name_claim_mutations(tx_rec, block_index, txi_idx)
       end
     end
 
@@ -85,7 +84,6 @@ defmodule AeMdw.Db.Sync.NameTest do
       height = AeMdw.Node.lima_height() + Enum.random(100..999)
       block_index = {height, 1}
       txi = height * 1000
-      tx_hash = <<txi::256>>
 
       {:ok, aetx} =
         :aens_claim_tx.new(%{
@@ -115,10 +113,10 @@ defmodule AeMdw.Db.Sync.NameTest do
             block_index,
             4
           )
-          | Origin.origin_mutations(:name_claim_tx, nil, name_hash, {txi, -1}, tx_hash)
+          | Origin.origin_mutations(:name_claim_tx, nil, name_hash, {txi, -1})
         ]
 
-        assert ^mutations = Name.name_claim_mutations(tx_rec, tx_hash, block_index, {txi, -1})
+        assert ^mutations = Name.name_claim_mutations(tx_rec, block_index, {txi, -1})
       end
     end
   end

--- a/test/ae_mdw/db/sync/oracle_test.exs
+++ b/test/ae_mdw/db/sync/oracle_test.exs
@@ -35,7 +35,7 @@ defmodule AeMdw.Db.Sync.OracleTest do
       {_mod, tx_rec} = :aetx.specialize_callback(aetx)
 
       mutations = [
-        Origin.origin_mutations(:oracle_register_tx, nil, pubkey, txi, tx_hash),
+        Origin.origin_mutations(:oracle_register_tx, nil, pubkey, txi_idx, tx_hash),
         OracleRegisterMutation.new(pubkey, block_index, expire, txi_idx)
       ]
 

--- a/test/ae_mdw/db/sync/oracle_test.exs
+++ b/test/ae_mdw/db/sync/oracle_test.exs
@@ -17,7 +17,6 @@ defmodule AeMdw.Db.Sync.OracleTest do
       ttl = 10_000
       expire = height + ttl
       txi = height * 1000
-      tx_hash = <<123_456::256>>
       txi_idx = {txi, -1}
 
       {:ok, aetx} =
@@ -35,11 +34,11 @@ defmodule AeMdw.Db.Sync.OracleTest do
       {_mod, tx_rec} = :aetx.specialize_callback(aetx)
 
       mutations = [
-        Origin.origin_mutations(:oracle_register_tx, nil, pubkey, txi_idx, tx_hash),
+        Origin.origin_mutations(:oracle_register_tx, nil, pubkey, txi_idx),
         OracleRegisterMutation.new(pubkey, block_index, expire, txi_idx)
       ]
 
-      assert ^mutations = Oracle.register_mutations(tx_rec, tx_hash, block_index, txi_idx)
+      assert ^mutations = Oracle.register_mutations(tx_rec, block_index, txi_idx)
     end
   end
 

--- a/test/ae_mdw_web/controllers/activities_controller_test.exs
+++ b/test/ae_mdw_web/controllers/activities_controller_test.exs
@@ -587,11 +587,11 @@ defmodule AeMdwWeb.ActivitiesControllerTest do
         )
         |> Store.put(
           Model.RevOrigin,
-          Model.rev_origin(index: {{create_txi1, -1}, :contract_call_tx, contract_pk1})
+          Model.rev_origin(index: {{create_txi1, -1}, :contract_call_tx}, pubkey: contract_pk1)
         )
         |> Store.put(
           Model.RevOrigin,
-          Model.rev_origin(index: {{create_txi2, -1}, :contract_call_tx, contract_pk2})
+          Model.rev_origin(index: {{create_txi2, -1}, :contract_call_tx}, pubkey: contract_pk2)
         )
         |> Store.put(
           Model.AexnContract,

--- a/test/ae_mdw_web/controllers/activities_controller_test.exs
+++ b/test/ae_mdw_web/controllers/activities_controller_test.exs
@@ -587,11 +587,11 @@ defmodule AeMdwWeb.ActivitiesControllerTest do
         )
         |> Store.put(
           Model.RevOrigin,
-          Model.rev_origin(index: {create_txi1, :contract_call_tx, contract_pk1})
+          Model.rev_origin(index: {{create_txi1, -1}, :contract_call_tx, contract_pk1})
         )
         |> Store.put(
           Model.RevOrigin,
-          Model.rev_origin(index: {create_txi2, :contract_call_tx, contract_pk2})
+          Model.rev_origin(index: {{create_txi2, -1}, :contract_call_tx, contract_pk2})
         )
         |> Store.put(
           Model.AexnContract,

--- a/test/ae_mdw_web/controllers/aex9_controller_test.exs
+++ b/test/ae_mdw_web/controllers/aex9_controller_test.exs
@@ -16,8 +16,6 @@ defmodule AeMdwWeb.Aex9ControllerTest do
 
   require Model
 
-  @aex9_token_id encode_contract(<<100::256>>)
-
   setup_all do
     store =
       Enum.reduce(100..125, MemStore.new(NullStore.new()), fn i, store ->

--- a/test/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/ae_mdw_web/controllers/contract_controller_test.exs
@@ -2457,7 +2457,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
         )
         |> Store.put(
           Model.RevOrigin,
-          Model.rev_origin(index: {create_txi, :contract_create_tx, contract_pk})
+          Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, contract_pk})
         )
         |> Store.put(Model.ContractLog, m_log)
         |> Store.put(Model.DataContractLog, m_data_log)
@@ -2511,7 +2511,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
       )
       |> Store.put(
         Model.RevOrigin,
-        Model.rev_origin(index: {create_txi, :contract_create_tx, contract_pk})
+        Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, contract_pk})
       )
 
     first_log_txi = last_log_txi + 1
@@ -2567,7 +2567,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
       )
       |> Store.put(
         Model.RevOrigin,
-        Model.rev_origin(index: {create_txi, :contract_create_tx, aex9_contract_pk})
+        Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, aex9_contract_pk})
       )
 
     first_log_txi = first_log_txi + length(@aex9_events)
@@ -2626,7 +2626,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
     )
     |> Store.put(
       Model.RevOrigin,
-      Model.rev_origin(index: {create_txi, :contract_create_tx, aex141_contract_pk})
+      Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, aex141_contract_pk})
     )
   end
 
@@ -2672,7 +2672,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
           )
           |> Store.put(
             Model.RevOrigin,
-            Model.rev_origin(index: {create_txi, :contract_create_tx, contract_pk})
+            Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, contract_pk})
           )
           |> Store.put(
             Model.Tx,
@@ -2738,7 +2738,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
       )
       |> Store.put(
         Model.RevOrigin,
-        Model.rev_origin(index: {create_txi, :contract_create_tx, extra_ct_pk})
+        Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, extra_ct_pk})
       )
       |> Store.put(
         Model.Tx,

--- a/test/ae_mdw_web/controllers/contract_controller_test.exs
+++ b/test/ae_mdw_web/controllers/contract_controller_test.exs
@@ -2457,7 +2457,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
         )
         |> Store.put(
           Model.RevOrigin,
-          Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, contract_pk})
+          Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx}, pubkey: contract_pk)
         )
         |> Store.put(Model.ContractLog, m_log)
         |> Store.put(Model.DataContractLog, m_data_log)
@@ -2511,7 +2511,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
       )
       |> Store.put(
         Model.RevOrigin,
-        Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, contract_pk})
+        Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx}, pubkey: contract_pk)
       )
 
     first_log_txi = last_log_txi + 1
@@ -2567,7 +2567,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
       )
       |> Store.put(
         Model.RevOrigin,
-        Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, aex9_contract_pk})
+        Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx}, pubkey: aex9_contract_pk)
       )
 
     first_log_txi = first_log_txi + length(@aex9_events)
@@ -2626,7 +2626,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
     )
     |> Store.put(
       Model.RevOrigin,
-      Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, aex141_contract_pk})
+      Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx}, pubkey: aex141_contract_pk)
     )
   end
 
@@ -2672,7 +2672,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
           )
           |> Store.put(
             Model.RevOrigin,
-            Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, contract_pk})
+            Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx}, pubkey: contract_pk)
           )
           |> Store.put(
             Model.Tx,
@@ -2738,7 +2738,7 @@ defmodule AeMdwWeb.Controllers.ContractControllerTest do
       )
       |> Store.put(
         Model.RevOrigin,
-        Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx, extra_ct_pk})
+        Model.rev_origin(index: {{create_txi, -1}, :contract_create_tx}, pubkey: extra_ct_pk)
       )
       |> Store.put(
         Model.Tx,

--- a/test/ae_mdw_web/controllers/dex_controller_test.exs
+++ b/test/ae_mdw_web/controllers/dex_controller_test.exs
@@ -114,8 +114,8 @@ defmodule AeMdwWeb.DexControllerTest do
             |> Store.put(
               Model.RevOrigin,
               Model.rev_origin(
-                index:
-                  {{block_index_number, -1}, :contract_create_tx, <<block_index_number::256>>}
+                index: {{block_index_number, -1}, :contract_create_tx},
+                pubkey: <<block_index_number::256>>
               )
             )
             |> Store.put(
@@ -892,7 +892,10 @@ defmodule AeMdwWeb.DexControllerTest do
       )
       |> Store.put(
         Model.RevOrigin,
-        Model.rev_origin(index: {{txi, -1}, :contract_create_tx, <<block_index_number::256>>})
+        Model.rev_origin(
+          index: {{txi, -1}, :contract_create_tx},
+          pubkey: <<block_index_number::256>>
+        )
       )
       |> Store.put(
         Model.Field,

--- a/test/ae_mdw_web/controllers/dex_controller_test.exs
+++ b/test/ae_mdw_web/controllers/dex_controller_test.exs
@@ -114,7 +114,8 @@ defmodule AeMdwWeb.DexControllerTest do
             |> Store.put(
               Model.RevOrigin,
               Model.rev_origin(
-                index: {block_index_number, :contract_create_tx, <<block_index_number::256>>}
+                index:
+                  {{block_index_number, -1}, :contract_create_tx, <<block_index_number::256>>}
               )
             )
             |> Store.put(
@@ -891,7 +892,7 @@ defmodule AeMdwWeb.DexControllerTest do
       )
       |> Store.put(
         Model.RevOrigin,
-        Model.rev_origin(index: {txi, :contract_create_tx, <<block_index_number::256>>})
+        Model.rev_origin(index: {{txi, -1}, :contract_create_tx, <<block_index_number::256>>})
       )
       |> Store.put(
         Model.Field,


### PR DESCRIPTION
This is going to allow us later on to identify creation txis by {txi, idx} tuple. Just txi is ambiguous. 