### PR TITLE
fix: get the last key from a binary keys table

### DIFF
--- a/lib/ae_mdw/util/sorted_table.ex
+++ b/lib/ae_mdw/util/sorted_table.ex
@@ -54,8 +54,15 @@ defmodule AeMdw.Util.SortedTable do
   end
 
   @spec prev(t(), key() | nil) :: {:ok, key(), value()} | :none
+  def prev(t, nil) do
+    case :ets.last(t) do
+      @eot -> :none
+      key -> {:ok, key, :ets.lookup_element(t, key, 2)}
+    end
+  end
+
   def prev(t, key) do
-    case :ets.prev(t, key || []) do
+    case :ets.prev(t, key) do
       @eot -> :none
       key -> {:ok, key, :ets.lookup_element(t, key, 2)}
     end

--- a/test/ae_mdw/util/sorted_table_test.exs
+++ b/test/ae_mdw/util/sorted_table_test.exs
@@ -60,4 +60,19 @@ defmodule AeMdw.Util.SortedTableTest do
     assert :not_found = SortedTable.lookup(t, :h)
     assert :not_found = SortedTable.lookup(SortedTable.delete(t, :b), :b)
   end
+
+  test "it returns the first/last value when keys are binaries" do
+    pk1 = <<0::256>>
+    pk2 = <<1::256>>
+    pk3 = <<2::256>>
+
+    t =
+      SortedTable.new()
+      |> SortedTable.insert(pk1, :a)
+      |> SortedTable.insert(pk2, :b)
+      |> SortedTable.insert(pk3, :c)
+
+    assert {:ok, ^pk3, :c} = SortedTable.prev(t, nil)
+    assert {:ok, ^pk1, :a} = SortedTable.next(t, nil)
+  end
 end


### PR DESCRIPTION
Makes first miner to be the wrong one at https://mainnet.aeternity.io/mdw/v3/stats/miners