### PR TITLE
feat: add debug endpoint temporarily to list swaps by txi_idx

### DIFF
--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -467,8 +467,14 @@ defmodule AeMdw.Db.Contract do
     case String.printable?(amounts) do
       true ->
         amounts = amounts |> String.split("|") |> Enum.map(&String.to_integer/1)
-
         create_txi = Dex.get_create_txi(state, create_txi, txi, idx)
+        pair_pk = Dex.get_pair_pk(state, create_txi, txi, idx)
+
+        Model.dex_pair(token1_pk: token1_pk, token2_pk: token2_pk) =
+          State.fetch!(state, Model.DexPair, pair_pk)
+
+        {:ok, token1_create_txi_idx} = Origin.creation_txi_idx(state, token1_pk)
+        {:ok, token2_create_txi_idx} = Origin.creation_txi_idx(state, token2_pk)
 
         state
         |> State.put(
@@ -486,6 +492,14 @@ defmodule AeMdw.Db.Contract do
         |> State.put(
           Model.DexSwapTokens,
           Model.dex_swap_tokens(index: {txi, idx, create_txi})
+        )
+        |> State.put(
+          Model.DexContractTokenSwap,
+          Model.dex_contract_token_swap(index: {token1_create_txi_idx, txi, idx})
+        )
+        |> State.put(
+          Model.DexContractTokenSwap,
+          Model.dex_contract_token_swap(index: {token2_create_txi_idx, txi, idx})
         )
 
       false ->

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -499,7 +499,21 @@ defmodule AeMdw.Db.Model do
   ]
   defrecord :dex_contract_swap_tokens, @dex_contract_swap_tokens_defaults
 
-  # DEX swap tokens indexed by contract:
+  # DEX token swaps indexed by txi_idx:
+  #     index: {token_create_txi_idx, txi, log_idx}
+  @type dex_contract_token_swap_index() :: {txi_idx(), txi(), local_idx()}
+  @type dex_contract_token_swap() ::
+          record(:dex_contract_token_swap,
+            index: dex_contract_token_swap_index(),
+            contract_call_create_txi: txi()
+          )
+  @dex_contract_token_swap_defaults [
+    index: nil,
+    contract_call_create_txi: nil
+  ]
+  defrecord :dex_contract_token_swap, @dex_contract_token_swap_defaults
+
+  # DEX swap tokens indexed by txi_idx:
   #     index: {txi, log_idx, create_txi}
   @type dex_swap_tokens_index() :: {txi(), log_idx(), txi()}
   @type dex_swap_tokens ::
@@ -1374,6 +1388,7 @@ defmodule AeMdw.Db.Model do
       AeMdw.Db.Model.CtEvtContractLog,
       AeMdw.Db.Model.DexPair,
       AeMdw.Db.Model.DexTokenSymbol,
+      AeMdw.Db.Model.DexContractTokenSwap,
       AeMdw.Db.Model.IdxContractLog,
       AeMdw.Db.Model.IntContractCall,
       AeMdw.Db.Model.GrpIntContractCall,
@@ -1471,6 +1486,7 @@ defmodule AeMdw.Db.Model do
   def record(AeMdw.Db.Model.RevOrigin), do: :rev_origin
   def record(AeMdw.Db.Model.DexAccountSwapTokens), do: :dex_account_swap_tokens
   def record(AeMdw.Db.Model.DexContractSwapTokens), do: :dex_contract_swap_tokens
+  def record(AeMdw.Db.Model.DexContractTokenSwap), do: :dex_contract_token_swap
   def record(AeMdw.Db.Model.DexSwapTokens), do: :dex_swap_tokens
   def record(AeMdw.Db.Model.Aex9BalanceAccount), do: :aex9_balance_account
   def record(AeMdw.Db.Model.Aex9EventBalance), do: :aex9_event_balance

--- a/lib/ae_mdw/dex.ex
+++ b/lib/ae_mdw/dex.ex
@@ -118,6 +118,9 @@ defmodule AeMdw.Dex do
             contract_pk
         end
 
+      nil ->
+        Origin.pubkey!(state, {:contract, create_txi})
+
       contract_pk ->
         contract_pk
     end

--- a/lib/ae_mdw/dex.ex
+++ b/lib/ae_mdw/dex.ex
@@ -304,11 +304,11 @@ defmodule AeMdw.Dex do
 
   defp deserialize_debug_contract_swaps_cursor(cursor_bin) do
     with {:ok, cursor_bin} <- Base.hex_decode32(cursor_bin, padding: false),
-         {{create_txi, create_idx}, txi, log_idx}
+         {{create_txi, create_idx}, txi, log_idx} = cursor
          when is_integer(create_txi) and is_integer(create_idx) and is_integer(txi) and
                 is_integer(log_idx) <-
            :erlang.binary_to_term(cursor_bin) do
-      {:ok, {{create_txi, create_idx}, txi, log_idx}}
+      {:ok, cursor}
     else
       _invalid_cursor ->
         {:error, ErrInput.Cursor.exception(value: cursor_bin)}

--- a/lib/ae_mdw_web/controllers/dex_controller.ex
+++ b/lib/ae_mdw_web/controllers/dex_controller.ex
@@ -44,4 +44,14 @@ defmodule AeMdwWeb.DexController do
       Util.render(conn, paginated_swaps)
     end
   end
+
+  @spec debug_contract_swaps(Conn.t(), map()) :: Conn.t()
+  def debug_contract_swaps(%Conn{assigns: assigns} = conn, %{"contract_id" => contract_id}) do
+    %{state: state, pagination: pagination, cursor: cursor, scope: scope} = assigns
+
+    with {:ok, paginated_swaps} <-
+           Dex.fetch_debug_contract_swaps(state, contract_id, pagination, scope, cursor) do
+      Util.render(conn, paginated_swaps)
+    end
+  end
 end

--- a/lib/ae_mdw_web/router.ex
+++ b/lib/ae_mdw_web/router.ex
@@ -123,6 +123,7 @@ defmodule AeMdwWeb.Router do
 
       get "/dex/swaps", DexController, :swaps
       get "/dex/:contract_id/swaps", DexController, :contract_swaps
+      get "/debug/dex/:contract_id/swaps", DexController, :debug_contract_swaps
       get "/wealth", WealthController, :wealth
 
       get "/api", UtilController, :static_file,

--- a/priv/migrations/20241119120001_index_dex_swaps_by_token.ex
+++ b/priv/migrations/20241119120001_index_dex_swaps_by_token.ex
@@ -1,0 +1,57 @@
+defmodule AeMdw.Migrations.IndexDexSwapsByToken do
+  @moduledoc """
+  Indexes DEX swaps by token.
+  """
+
+  alias AeMdw.Collection
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.Origin
+  alias AeMdw.Db.State
+  alias AeMdw.Db.WriteMutation
+  alias AeMdw.Dex
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    evt_hash = :aec_hash.blake2b_256_hash("SwapTokens")
+    key_boundary = {{evt_hash, 0, 0, 0}, {evt_hash, nil, nil, nil}}
+
+    state
+    |> Collection.stream(Model.EvtContractLog, :forward, key_boundary, nil)
+    |> Stream.flat_map(fn {_evt_hash, txi, contract_txi, log_idx} ->
+      pair_pk = Dex.get_pair_pk(state, contract_txi, txi, log_idx)
+
+      Model.dex_pair(token1_pk: token1_pk, token2_pk: token2_pk) =
+        State.fetch!(state, Model.DexPair, pair_pk)
+
+      {:ok, token1_create_txi_idx} = Origin.creation_txi_idx(state, token1_pk)
+      {:ok, token2_create_txi_idx} = Origin.creation_txi_idx(state, token2_pk)
+
+      [
+        WriteMutation.new(
+          Model.DexContractTokenSwap,
+          Model.dex_contract_token_swap(
+            index: {token1_create_txi_idx, txi, log_idx},
+            contract_call_create_txi: contract_txi
+          )
+        ),
+        WriteMutation.new(
+          Model.DexContractTokenSwap,
+          Model.dex_contract_token_swap(
+            index: {token2_create_txi_idx, txi, log_idx},
+            contract_call_create_txi: contract_txi
+          )
+        )
+      ]
+    end)
+    |> Stream.chunk_every(1_000)
+    |> Stream.map(fn mutations ->
+      _state = State.commit_db(state, mutations)
+
+      length(mutations)
+    end)
+    |> Enum.sum()
+    |> then(&{:ok, &1})
+  end
+end

--- a/test/ae_mdw/db/contract_test.exs
+++ b/test/ae_mdw/db/contract_test.exs
@@ -190,11 +190,11 @@ defmodule AeMdw.Db.ContractTest do
     end
 
     test "tracks dex pair creations and dex swaps" do
-      dex_pair_pk = :crypto.strong_rand_bytes(32)
-      dex_token1_pk = :crypto.strong_rand_bytes(32)
-      dex_token2_pk = :crypto.strong_rand_bytes(32)
-      height = Enum.random(100_000..999_999)
-      call_txi = Enum.random(100_000_000..999_999_999)
+      dex_pair_pk = <<100::256>>
+      dex_token1_pk = <<101::256>>
+      dex_token2_pk = <<102::256>>
+      height = 123
+      call_txi = 456
       create_token_txi = call_txi - 2
       create_pair_txi = call_txi - 1
 
@@ -209,6 +209,35 @@ defmodule AeMdw.Db.ContractTest do
 
       state =
         empty_state()
+        |> State.put(
+          Model.RevOrigin,
+          Model.rev_origin(
+            index: {{create_token_txi, -1}, :contract_create_tx},
+            pubkey: dex_pair_pk
+          )
+        )
+        |> State.put(
+          Model.Field,
+          Model.field(index: {:contract_create_tx, nil, dex_token1_pk, create_token_txi})
+        )
+        |> State.put(
+          Model.Origin,
+          Model.origin(
+            index: {:contract_create_tx, dex_token1_pk},
+            txi_idx: {create_token_txi, -1}
+          )
+        )
+        |> State.put(
+          Model.Field,
+          Model.field(index: {:contract_create_tx, nil, dex_token2_pk, create_token_txi})
+        )
+        |> State.put(
+          Model.Origin,
+          Model.origin(
+            index: {:contract_create_tx, dex_token2_pk},
+            txi_idx: {create_token_txi, -1}
+          )
+        )
         |> State.put(
           Model.AexnContract,
           Model.aexn_contract(index: {:aex9, dex_token1_pk}, meta_info: {"name1", "S1", 18})

--- a/test/integration/ae_mdw_web/controllers/dex_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/dex_controller_test.exs
@@ -1,0 +1,51 @@
+defmodule Integration.AeMdwWeb.DexControllerTest do
+  use AeMdwWeb.ConnCase, async: false
+
+  alias AeMdw.Db.Model
+
+  require Model
+
+  @moduletag :integration
+
+  @default_limit 10
+  @ae_token_id "ct_J3zBY8xxjsRr3QojETNw48Eb38fjvEuJKkQ6KzECvubvEcvCa"
+
+  describe "debug_contract_swaps" do
+    test "it lists all dex swaps ordered by txi", %{conn: conn} do
+      assert %{"data" => dex_swaps, "next" => next} =
+               conn |> get("/v3/debug/dex/#{@ae_token_id}/swaps") |> json_response(200)
+
+      dex_txis =
+        dex_swaps
+        |> Enum.map(fn %{"tx_hash" => tx_hash} ->
+          conn
+          |> get("/v2/txs/#{tx_hash}")
+          |> json_response(200)
+          |> Map.fetch!("tx_index")
+        end)
+        |> Enum.reverse()
+
+      assert @default_limit = length(dex_swaps)
+      assert ^dex_txis = Enum.sort(dex_txis)
+
+      assert %{"data" => next_dex_swaps, "prev" => prev_dex_swaps} =
+               conn |> get(next) |> json_response(200)
+
+      next_dex_txis =
+        dex_swaps
+        |> Enum.map(fn %{"tx_hash" => tx_hash} ->
+          conn
+          |> get("/v2/txs/#{tx_hash}")
+          |> json_response(200)
+          |> Map.fetch!("tx_index")
+        end)
+        |> Enum.reverse()
+
+      assert @default_limit = length(next_dex_swaps)
+      assert ^next_dex_txis = Enum.sort(next_dex_txis)
+      assert Enum.at(dex_txis, @default_limit - 1) >= Enum.at(next_dex_txis, 0)
+
+      assert %{"data" => ^dex_swaps} = conn |> get(prev_dex_swaps) |> json_response(200)
+    end
+  end
+end


### PR DESCRIPTION
Temporarily adding a debug endpoint to allow us to test. Will move it to `/dex/:contract_id/swaps` once we feel confident about it.