### PR TITLE
fix: account active name counter

### DIFF
--- a/lib/ae_mdw/db/mutations/name_claim_mutation.ex
+++ b/lib/ae_mdw/db/mutations/name_claim_mutation.ex
@@ -117,7 +117,6 @@ defmodule AeMdw.Db.NameClaimMutation do
       |> Name.delete_inactive(plain_name)
       |> IntTransfer.fee({height, txi_idx}, :lock_name, owner_pk, txi_idx, lock_amount)
       |> State.inc_stat(:burned_in_auctions, lock_amount)
-      |> Names.increment_names_count(owner_pk)
     else
       state3 =
         IntTransfer.fee(state2, {height, txi_idx}, :spend_name, owner_pk, txi_idx, name_fee)

--- a/lib/ae_mdw/db/sync/name.ex
+++ b/lib/ae_mdw/db/sync/name.ex
@@ -245,6 +245,7 @@ defmodule AeMdw.Db.Sync.Name do
     |> State.put(Model.ActiveNameOwnerDeactivation, m_owner_deactivation)
     |> State.inc_stat(:names_activated)
     |> State.inc_stat(:micro_block_names_activated)
+    |> Names.increment_names_count(owner_pk)
   end
 
   @spec deactivate_name(

--- a/priv/migrations/20241128134337_update_active_account_names.ex
+++ b/priv/migrations/20241128134337_update_active_account_names.ex
@@ -1,0 +1,33 @@
+defmodule AeMdw.Migrations.UpdateActiveAccountNames do
+  @moduledoc """
+    Updates the account names count table.
+  """
+  alias AeMdw.Db.RocksDbCF
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.State
+  alias AeMdw.Db.WriteMutation
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    mutations =
+      Model.ActiveNameOwner
+      |> RocksDbCF.stream()
+      |> Enum.reduce(%{}, fn
+        Model.owner(index: {owner, _}), acc -> Map.update(acc, owner, 1, &(&1 + 1))
+      end)
+      |> Enum.map(fn {owner, count} ->
+        WriteMutation.new(
+          Model.AccountNamesCount,
+          Model.account_names_count(index: owner, count: count)
+        )
+      end)
+
+    _state = State.commit(state, mutations)
+
+    updated_count = Enum.count(mutations)
+
+    {:ok, updated_count}
+  end
+end

--- a/test/support/integration_util.ex
+++ b/test/support/integration_util.ex
@@ -1,0 +1,25 @@
+defmodule AeMdw.IntegrationUtil do
+  @moduledoc """
+  Integration tests helper functions.
+  """
+
+  import Phoenix.ConnTest
+
+  @endpoint AeMdwWeb.Endpoint
+
+  @spec scan(any(), Conn.t(), any(), (any(), any() -> any())) :: any()
+  def scan(%{"next" => nil, "data" => data}, _conn, accumulator, f) do
+    f.(data, accumulator)
+  end
+
+  def scan(%{"next" => next, "data" => data}, conn, accumulator, f) do
+    new_acc = f.(data, accumulator)
+
+    %URI{path: path, query: query} = URI.parse(next)
+
+    conn
+    |> get(path <> "?" <> query)
+    |> json_response(200)
+    |> scan(conn, new_acc, f)
+  end
+end


### PR DESCRIPTION
resolves: https://github.com/aeternity/ae_mdw/issues/1629

Currently the number of active names in the `/names?owned_by=<x>` and `/names/count?owned_by=<x>` are different, for example here: https://mainnet.aeternity.io/mdw/v3/names?owned_by=ak_ynYCVP5HXxEHmptuapK51d7wTRPFnrAnQSewqef5urYcMSJ6s and here https://mainnet.aeternity.io/mdw/v3/names/count?owned_by=ak_ynYCVP5HXxEHmptuapK51d7wTRPFnrAnQSewqef5urYcMSJ6s. My suspicion is that is is due to the counter not increased when a name is put to an auction and the auction ends. This will happen after this PR, as the `Name.put_active` function is called at that event.