### PR TITLE
fix: return the correct number of transactions

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Node Setup
         uses: ./.github/actions/node-setup
 
+        run: rm -rf test_data.db/
+
       - name: Execute coverage
         run: elixir --sname aeternity@localhost -S mix coveralls
 

--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -119,7 +119,7 @@ defmodule AeMdw.Txs do
 
   def count(state, nil, params) when map_size(params) == 0 do
     case DbUtil.last_txi(state) do
-      {:ok, count} -> {:ok, count}
+      {:ok, count} -> {:ok, count + 1}
       :none -> {:ok, 0}
     end
   end

--- a/test/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/ae_mdw_web/controllers/tx_controller_test.exs
@@ -1871,8 +1871,9 @@ defmodule AeMdwWeb.TxControllerTest do
     test "it returns all tx count by default", %{conn: conn, empty_store: store} do
       tx = Model.tx(index: tx_index) = TS.tx(0)
       store = Store.put(store, Model.Tx, tx)
+      actual_count = tx_index + 1
 
-      assert ^tx_index =
+      assert ^actual_count =
                conn
                |> with_store(store)
                |> get("/v3/transactions/count")

--- a/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/aex9_controller_test.exs
@@ -71,7 +71,7 @@ defmodule Integration.AeMdwWeb.Aex9ControllerTest do
           "contract_id" => ^contract_id,
           "contract_tx_hash" => "th_2w36BEYthD48fmveWrHLvzYpyKeTHtWLXCSqLEQjiSFARGfdaM",
           "decimals" => 18,
-          "event_supply" => 32_067_122_530_333_274_155_599,
+          "event_supply" => 31_701_626_408_971_753_079_388,
           "extensions" => ["allowances"],
           "holders" => _holders,
           "initial_supply" => 0,

--- a/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
+++ b/test/integration/ae_mdw_web/controllers/tx_controller_test.exs
@@ -176,9 +176,9 @@ defmodule Integration.AeMdwWeb.TxControllerTest do
 
   describe "count" do
     test "get count of transactions at the current height", %{conn: conn} do
-      %Conn{assigns: %{state: state}} = conn = get(conn, "/v2/txs/count")
+      %Conn{assigns: %{state: state}} = conn = get(conn, "/v3/transactions/count")
 
-      assert json_response(conn, 200) == Util.last_txi!(state)
+      assert json_response(conn, 200) == Util.last_txi!(state) + 1
     end
   end
 


### PR DESCRIPTION
The issue was that the transactions count was derived from the last txi, but the txis are indexed from 0, so the count should be the last txi + 1.