### PR TITLE
chore: bump release-please version to 4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,7 +7,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{secrets.BOT_GITHUB_TOKEN}}
           release-type: elixir


### PR DESCRIPTION
The action was tested from this branch and it created a release PR as expected -> https://github.com/aeternity/ae_mdw/pull/2063