### PR TITLE
chore: downgrade release-please version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,8 +7,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v3
         with:
           token: ${{secrets.BOT_GITHUB_TOKEN}}
           release-type: elixir
+          pull-request-title-pattern: "chore: release${component} ${version}"
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"ci","section":"CI / CD","hidden":false},{"type":"test","section":"Testing","hidden":false},{"type":"refactor","section":"Refactorings","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'


### PR DESCRIPTION
The relese-please action has had a breaking change from v3 to v4 where it no longer accepts most of it's arguments as inputs to it and has moved them to separate config files. I've had issues seting that up and migrating the configs, so in the interest of being able to create a hc release I've downgraded to v3 since it has the needed update (where we can fix misslabled commits without rewriting the git tree), but still respects the github action inputs. After we have a HC release for the mdw I'm planning to come back and take a look at implementing that if there is nothing more pressing