### PR TITLE
fix: replace hc check to use the node functions

### DIFF
--- a/lib/ae_mdw/sync/hyperchain.ex
+++ b/lib/ae_mdw/sync/hyperchain.ex
@@ -26,7 +26,7 @@ defmodule AeMdw.Sync.Hyperchain do
 
   @spec connected_to_parent?() :: boolean()
   def connected_to_parent?() do
-    :aec_consensus_hc.get_entropy_hash(1) != {:error, :not_in_cache}
+    :check_parent == :aec_parent_connector.request_top()
   end
 
   @spec epoch_info_at_height(Blocks.height()) :: {:ok, epoch_info()} | :error

--- a/mix.exs
+++ b/mix.exs
@@ -106,7 +106,8 @@ defmodule AeMdw.MixProject do
           :sext,
           :rocksdb,
           :telemetry,
-          :aeapi
+          :aeapi,
+          :aec_parent_connector
         ]
       ],
       dialyzer: dialyzer(),

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule AeMdw.MixProject do
           :aec_hard_forks,
           :aec_hash,
           :aec_headers,
+          :aec_parent_connector,
           :aec_paying_for_tx,
           :aec_spend_tx,
           :aec_sync,
@@ -106,8 +107,7 @@ defmodule AeMdw.MixProject do
           :sext,
           :rocksdb,
           :telemetry,
-          :aeapi,
-          :aec_parent_connector
+          :aeapi
         ]
       ],
       dialyzer: dialyzer(),


### PR DESCRIPTION
This PR changes the way the mdw checks for a connection to the parent chain in a way that delegates the error handling to the node. The biggest difference is that now the node process responsible for the connection controlls when the code errors out. Now if the parent is reachable it checks periodically to see if the start_height is reached. Otherwise if it is unreachable the node gives a warning and checks again after a short interval.