### PR TITLE
fix: move tx fees to txs table to fix stats endpoint

### DIFF
--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -37,12 +37,12 @@ defmodule AeMdw.Db.Format do
   def to_raw_map(_state, {{height, mbi}, txi}),
     do: %{block_height: height, micro_index: mbi, tx_index: txi}
 
-  def to_raw_map(state, {:tx, _index, hash, {_kb_index, _mb_index}, _mb_time} = mdw_tx),
+  def to_raw_map(state, Model.tx(id: hash) = mdw_tx),
     do: to_raw_map(state, mdw_tx, AE.Db.get_tx_data(hash))
 
   def to_raw_map(
         state,
-        {:tx, index, hash, {kb_index, mb_index}, mb_time},
+        Model.tx(index: index, id: hash, block_index: {kb_index, mb_index}, time: mb_time),
         {block_hash, tx_type, signed_tx, tx_rec}
       ) do
     tx_map =

--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -191,12 +191,12 @@ defmodule AeMdw.Db.Format do
 
   ##########
 
-  def to_map(state, {:tx, _index, hash, {_kb_index, _mb_index}, _mb_time} = rec),
+  def to_map(state, Model.tx(id: hash) = rec),
     do: to_map(state, rec, AE.Db.get_tx_data(hash))
 
   def to_map(
         state,
-        {:tx, index, _hash, {_kb_index, mb_index}, mb_time},
+        Model.tx(index: index, block_index: {_kb_index, mb_index}, time: mb_time),
         {block_hash, type, signed_tx, tx_rec}
       ) do
     header = :aec_db.get_header(block_hash)

--- a/lib/ae_mdw/db/model.ex
+++ b/lib/ae_mdw/db/model.ex
@@ -142,8 +142,8 @@ defmodule AeMdw.Db.Model do
           )
 
   # txs table :
-  #     index = tx_index (0..), id = tx_id, block_index = {kbi, mbi}
-  @tx_defaults [index: nil, id: nil, block_index: nil, time: nil]
+  #     index = tx_index (0..), id = tx_id, block_index = {kbi, mbi} time = time, fee = fee
+  @tx_defaults [index: nil, id: nil, block_index: nil, time: nil, fee: nil]
   defrecord :tx, @tx_defaults
 
   @type tx_index() :: txi()
@@ -152,7 +152,8 @@ defmodule AeMdw.Db.Model do
             index: tx_index(),
             id: Txs.tx_hash(),
             block_index: block_index(),
-            time: Blocks.time()
+            time: Blocks.time(),
+            fee: non_neg_integer()
           )
 
   # txs time index :

--- a/lib/ae_mdw/db/sync/transaction.ex
+++ b/lib/ae_mdw/db/sync/transaction.ex
@@ -84,7 +84,8 @@ defmodule AeMdw.Db.Sync.Transaction do
   def transaction_mutations(signed_tx, txi, block_index, block_hash, mb_time, mb_events) do
     {type, tx} = :aetx.specialize_type(:aetx_sign.tx(signed_tx))
     tx_hash = :aetx_sign.hash(signed_tx)
-    m_tx = Model.tx(index: txi, id: tx_hash, block_index: block_index, time: mb_time)
+    fee = Db.get_tx_fee(tx_hash)
+    m_tx = Model.tx(index: txi, id: tx_hash, block_index: block_index, time: mb_time, fee: fee)
 
     tx_context =
       TxContext.new(

--- a/lib/ae_mdw/stats.ex
+++ b/lib/ae_mdw/stats.ex
@@ -16,7 +16,6 @@ defmodule AeMdw.Stats do
   alias AeMdw.Node
   alias AeMdw.Util
   alias AeMdw.Validate
-  alias AeMdw.Node.Db, as: NodeDb
   alias AeMdw.Sync.Hyperchain
 
   require Model
@@ -692,8 +691,7 @@ defmodule AeMdw.Stats do
     if txs_count != 0 do
       start_txi..end_txi
       |> Enum.reduce(0, fn tx_index, acc ->
-        Model.tx(id: tx_hash) = State.fetch!(state, Model.Tx, tx_index)
-        fee = NodeDb.get_tx_fee(tx_hash)
+        Model.tx(fee: fee) = State.fetch!(state, Model.Tx, tx_index)
 
         acc + fee
       end)

--- a/priv/migrations/20250203081538_add_fee_to_txs.ex
+++ b/priv/migrations/20250203081538_add_fee_to_txs.ex
@@ -1,0 +1,41 @@
+defmodule AeMdw.Migrations.AddFeeToTxs do
+  @moduledoc """
+  Add the tx fees to the tx table in order to skip fetching them from the node every time.
+  """
+  alias AeMdw.Db.WriteMutation
+  alias AeMdw.Db.RocksDbCF
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Model
+  alias AeMdw.Node.Db, as: NodeDb
+
+  import Record, only: [defrecord: 2]
+
+  require Model
+
+  defrecord(:tx, index: nil, id: nil, block_index: nil, time: nil)
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    Model.Tx
+    |> RocksDbCF.stream()
+    |> Stream.chunk_every(1000)
+    |> Task.async_stream(
+      fn txs ->
+        Enum.map(txs, fn tx(index: index, id: id, block_index: block_index, time: time) ->
+          fee = NodeDb.get_tx_fee(id)
+          tx = Model.tx(index: index, id: id, block_index: block_index, time: time, fee: fee)
+
+          WriteMutation.new(Model.Tx, tx)
+        end)
+      end,
+      timeout: :infinity
+    )
+    |> Stream.map(fn {:ok, mutations} ->
+      _state = State.commit_db(state, mutations)
+
+      length(mutations)
+    end)
+    |> Enum.sum()
+    |> then(&{:ok, &1})
+  end
+end

--- a/test/ae_mdw_web/controllers/oracle_controller_test.exs
+++ b/test/ae_mdw_web/controllers/oracle_controller_test.exs
@@ -186,7 +186,7 @@ defmodule AeMdwWeb.OracleControllerTest do
         {Oracle, [:passthrough], [oracle_tree!: fn _block_hash -> :aeo_state_tree.empty() end]},
         {Format, [:passthrough],
          [
-           to_map: fn _state, {:tx, _index, hash, {_kb_index, _mb_index}, _mb_time} ->
+           to_map: fn _state, Model.tx(id: hash) ->
              %{
                "hash" => Enc.encode(:tx_hash, hash),
                "tx" => %{

--- a/test/ae_mdw_web/controllers/stats_controller_test.exs
+++ b/test/ae_mdw_web/controllers/stats_controller_test.exs
@@ -1007,7 +1007,6 @@ defmodule AeMdwWeb.StatsControllerTest do
         |> Store.put(Model.Block, Model.block(index: {10, -1}, hash: <<2::256>>))
 
       with_mocks([
-        {AeMdw.Node.Db, [], get_tx_fee: fn <<i::256>> -> i end},
         {:aec_chain, [],
          get_key_block_by_height: fn
            1 -> {:ok, :first_block}
@@ -1048,7 +1047,6 @@ defmodule AeMdwWeb.StatsControllerTest do
         |> Store.put(Model.Block, Model.block(index: {10, -1}, hash: <<2::256>>))
 
       with_mocks([
-        {AeMdw.Node.Db, [], get_tx_fee: fn <<i::256>> -> i end},
         {:aec_chain, [],
          get_key_block_by_height: fn
            1 -> {:ok, :first_block}

--- a/test/ae_mdw_web/controllers/stats_controller_test.exs
+++ b/test/ae_mdw_web/controllers/stats_controller_test.exs
@@ -966,7 +966,6 @@ defmodule AeMdwWeb.StatsControllerTest do
       fee_avg = Enum.sum((last_txi - 3)..last_txi) / Enum.count((last_txi - 3)..last_txi)
 
       with_mocks([
-        {AeMdw.Node.Db, [], get_tx_fee: fn <<i::256>> -> i end},
         {:aec_chain, [],
          get_key_block_by_height: fn
            1 -> {:ok, :first_block}
@@ -1081,7 +1080,7 @@ defmodule AeMdwWeb.StatsControllerTest do
     |> Enum.reduce({store, 1}, fn txi, {store, i} ->
       {
         store
-        |> Store.put(Model.Tx, Model.tx(index: txi, id: <<txi::256>>))
+        |> Store.put(Model.Tx, Model.tx(index: txi, id: <<txi::256>>, fee: txi))
         |> Store.put(
           Model.Time,
           Model.time(index: {now - :timer.hours(i * 5), txi})


### PR DESCRIPTION
This speeds the the function that gets the average tx fees in the stats endpoint. Before it timedout the endpoint