### PR TITLE
feat!: make docker paths the same as in the node images

### DIFF
--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -8,4 +8,4 @@ runs:
       shell: bash
       run: |
         curl -L https://github.com/aeternity/aeternity/releases/download/v7.3.0-rc3/aeternity-v7.3.0-rc3-ubuntu-x86_64.tar.gz -o aeternity.tgz\
-        && mkdir -p ${NODEROOT} && tar xf aeternity.tgz -C ${NODEROOT} && cp -rf ${NODEROOT}/lib/ ${NODEROOT}
+        && mkdir -p ${NODEROOT} && tar xf aeternity.tgz -C ${NODEROOT} 

--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -8,4 +8,4 @@ runs:
       shell: bash
       run: |
         curl -L https://github.com/aeternity/aeternity/releases/download/v7.3.0-rc3/aeternity-v7.3.0-rc3-ubuntu-x86_64.tar.gz -o aeternity.tgz\
-        && mkdir -p ${NODEROOT}/rel/aeternity && tar xf aeternity.tgz -C ${NODEROOT}/rel/aeternity && cp -rf ${NODEROOT}/rel/aeternity/lib/ ${NODEROOT}
+        && mkdir -p ${NODEROOT} && tar xf aeternity.tgz -C ${NODEROOT} && cp -rf ${NODEROOT}/lib/ ${NODEROOT}

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ chown -R 1000 data
 
 In case you want to setup different accounts on testnet with initial balance you can add this volume to `docker-compose-dev.yml`:
 
-`- ${PWD}/accounts_test.json:/home/aeternity/node/local/rel/aeternity/data/aecore/.genesis/accounts_test.json`
+`- ${PWD}/accounts_test.json:/home/aeternity/node/data/aecore/.genesis/accounts_test.json`
 
 An example of `accounts_test.json` is:
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,7 +9,7 @@ config :esbuild,
   version: "0.8.2"
 
 config :ae_mdw, AeMdw.Db.RocksDb,
-  data_dir: "#{node_root}/rel/aeternity/data/mdw.db",
+  data_dir: "#{node_root}/data/mdw.db",
   drop_tables: [
     Model.AsyncTasks,
     Model.Aex9Balance,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,8 +1,3 @@
 import Config
 
 config :ae_mdw, build_revision: String.trim(File.read!("AEMDW_REVISION"))
-
-# Logging
-config :logger,
-  level: :info,
-  backends: [{LoggerFileBackend, :info}]

--- a/docker-compose-dev-testnet.yml
+++ b/docker-compose-dev-testnet.yml
@@ -16,16 +16,16 @@ services:
       - "3013:3013" #Node's default external API port
       - "3014:3014" #Node's channels default websocket port
     volumes:
-      - ${PWD}/data_testnet/mnesia:/home/aeternity/node/local/rel/aeternity/data/mnesia
-      - ${PWD}/data_testnet/mdw.db:/home/aeternity/node/local/rel/aeternity/data/mdw.db
-      - ${PWD}/docker/aeternity_testnet.yaml:/home/aeternity/aeternity.yaml
-      - ${PWD}/docker/aeternity-dev.yaml:/home/aeternity/aeternity-dev.yaml
-      - ${PWD}/docker/accounts.json:/home/aeternity/node/local/rel/aeternity/data/aecore/.genesis/accounts_test.json
-      - ${PWD}/priv:/home/aeternity/node/ae_mdw/priv
+      - ${PWD}/data_testnet/mnesia:/home/aeternity/node/data/mnesia
+      - ${PWD}/data_testnet/mdw.db:/home/aeternity/node/data/mdw.db
+      - ${PWD}/docker/aeternity_testnet.yaml:/home/aeternity/.aeternity/aeternity/aeternity.yaml
+      - ${PWD}/docker/aeternity-dev.yaml:/home/aeternity/.aeternity/aeternity/aeternity-dev.yaml
+      - ${PWD}/docker/accounts.json:/home/aeternity/node/data/aecore/.genesis/accounts_test.json
+      - ${PWD}/priv:/home/aeternity/ae_mdw/priv
       - ${PWD}:/app
       - ${PWD}/docker/gitconfig:/root/.gitconfig
     environment:
-      - AETERNITY_CONFIG=${AETERNITY_CONFIG:-/home/aeternity/aeternity.yaml}
+      - AETERNITY_CONFIG=${AETERNITY_CONFIG:-/home/aeternity/.aeternity/aeternity/aeternity.yaml}
     networks:
       ae_mdw_net_testnet:
         aliases:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -16,18 +16,18 @@ services:
       - "3013:3013" #Node's default external API port
       - "3014:3014" #Node's channels default websocket port
     volumes:
-      - ${PWD}/data/mnesia:/home/aeternity/node/local/rel/aeternity/data/mnesia
-      - ${PWD}/data/mdw.db:/home/aeternity/node/local/rel/aeternity/data/mdw.db
-      - ${PWD}/docker/aeternity.yaml:/home/aeternity/aeternity.yaml
-      - ${PWD}/docker/aeternity-dev.yaml:/home/aeternity/aeternity-dev.yaml
-      - ${PWD}/docker/accounts.json:/home/aeternity/node/local/rel/aeternity/data/aecore/.genesis/accounts_test.json
-      - ${PWD}/priv:/home/aeternity/node/ae_mdw/priv
+      - ${PWD}/data/mnesia:/home/aeternity/node/data/mnesia
+      - ${PWD}/data/mdw.db:/home/aeternity/node/data/mdw.db
+      - ${PWD}/docker/aeternity.yaml:/home/aeternity/.aeternity/aeternity/aeternity.yaml
+      - ${PWD}/docker/aeternity-dev.yaml:/home/aeternity/.aeternity/aeternity/aeternity-dev.yaml
+      - ${PWD}/docker/accounts.json:/home/aeternity/node/data/aecore/.genesis/accounts_test.json
+      - ${PWD}/priv:/home/aeternity/ae_mdw/priv
       - ${PWD}:/app
       - ${PWD}/docker/gitconfig:/root/.gitconfig
       - ${PWD}/.bash_history:/root/.bash_history
       - ${PWD}/.erlang_history:/root/.erlang_history
     environment:
-      - AETERNITY_CONFIG=${AETERNITY_CONFIG:-/home/aeternity/aeternity.yaml}
+      - AETERNITY_CONFIG=${AETERNITY_CONFIG:-/home/aeternity/.aeternity/aeternity/aeternity.yaml}
       - HIST_FILE=/root/.bash_history
       - ELIXIR_ERL_OPTIONS=-kernel shell_history enabled -kernel shell_history_path '.erlang_history'
       - ENABLE_CONSOLE_LOG=true

--- a/docker-compose-hc.yml
+++ b/docker-compose-hc.yml
@@ -17,18 +17,18 @@ services:
       - "3013:3013" #Node's default external API port
       - "3014:3014" #Node's channels default websocket port
     volumes:
-      - ${PWD}/data_hc/mnesia:/home/aeternity/node/local/rel/aeternity/data/mnesia
-      - ${PWD}/data_hc/mdw.db:/home/aeternity/node/local/rel/aeternity/data/mdw.db
-      - ${PWD}/hyperchain/aeternity.yaml:/home/aeternity/aeternity.yaml
-      - ${PWD}/docker/aeternity-dev.yaml:/home/aeternity/aeternity-dev.yaml
-      - ${PWD}/docker/accounts.json:/home/aeternity/node/local/rel/aeternity/data/aecore/.genesis/accounts_test.json
-      - ${PWD}/hyperchains/accounts.json:/home/aeternity/node/local/rel/aeternity/data/aecore/.ceres/hc_devnet_accounts.json
-      - ${PWD}/hyperchains/contracts.json:/home/aeternity/node/local/rel/aeternity/data/aecore/.ceres/hc_devnet_contracts.json
-      - ${PWD}/priv:/home/aeternity/node/ae_mdw/priv
+      - ${PWD}/data_hc/mnesia:/home/aeternity/node/data/mnesia
+      - ${PWD}/data_hc/mdw.db:/home/aeternity/node/data/mdw.db
+      - ${PWD}/hyperchain/aeternity.yaml:/home/aeternity/.aeternity/aeternity/aeternity.yaml
+      - ${PWD}/docker/aeternity-dev.yaml:/home/aeternity/.aeternity/aeternity/aeternity-dev.yaml
+      - ${PWD}/docker/accounts.json:/home/aeternity/node/data/aecore/.genesis/accounts_test.json
+      - ${PWD}/hyperchains/accounts.json:/home/aeternity/node/dataa/aecore/.ceres/hc_devnet_accounts.json
+      - ${PWD}/hyperchains/contracts.json:/home/aeternity/node/data/aecore/.ceres/hc_devnet_contracts.json
+      - ${PWD}/priv:/home/aeternity/ae_mdw/priv
       - ${PWD}:/app
       - ${PWD}/docker/gitconfig:/root/.gitconfig
     environment:
-      - AETERNITY_CONFIG=${AETERNITY_CONFIG:-/home/aeternity/aeternity.yaml}
+      - AETERNITY_CONFIG=${AETERNITY_CONFIG:-/home/aeternity/.aeternity/aeternity/aeternity.yaml}
     networks:
       ae_mdw_net_hc:
         aliases:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -13,4 +13,4 @@ services:
     volumes:
       - ${PWD}:/app
     environment:
-      AETERNITY_CONFIG: /home/aeternity/aeternity.yaml
+      AETERNITY_CONFIG: /home/aeternity/.aeternity/aeternity/aeternity.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,10 @@ services:
       - "3013:3013" #Node's default external API port
       - "3014:3014" #Node's channels default websocket port
     volumes:
-      - ${PWD}/data/mnesia:/home/aeternity/node/local/rel/aeternity/data/mnesia
-      - ${PWD}/data/mdw.db:/home/aeternity/node/local/rel/aeternity/data/mdw.db
-      - ${PWD}/log:/home/aeternity/node/ae_mdw/log
+      - ${PWD}/data/mnesia:/home/aeternity/node/data/mnesia
+      - ${PWD}/data/mdw.db:/home/aeternity/node/data/mdw.db
+      - ${PWD}/log:/home/aeternity/ae_mdw/log
       # uncomment for custom node setup
-      #- ${HOME}/aeternity.yaml:/home/aeternity/aeternity.yaml
+      #- ${HOME}/aeternity.yaml:/home/aeternity/.aeternity/aeternity/aeternity.yaml
     environment:
-      - AETERNITY_CONFIG=/home/aeternity/aeternity.yaml
+      - AETERNITY_CONFIG=${AETERNITY_CONFIG:-/home/aeternity/.aeternity/aeternity/aeternity.yaml}

--- a/mix.exs
+++ b/mix.exs
@@ -145,7 +145,7 @@ defmodule AeMdw.MixProject do
   # Specifies your project dependencies.
   defp deps() do
     [
-      {:ae_plugin, github: "aeternity/ae_plugin", ref: "cacff2c"},
+      {:ae_plugin, github: "aeternity/ae_plugin", ref: "82c6372"},
       {:stream_split, "~> 0.1.5"},
       {:ex2ms, "~> 1.6.0"},
       {:logger_file_backend, "~> 0.0.11"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "ae_plugin": {:git, "https://github.com/aeternity/ae_plugin.git", "cacff2ca9eb14a1b4cd3be08dc93a10e4194717d", [ref: "cacff2c"]},
+  "ae_plugin": {:git, "https://github.com/aeternity/ae_plugin.git", "82c6372e33f5ab57a56e803d7ab1ab265fc0f128", [ref: "82c6372"]},
   "bandit": {:hex, :bandit, "1.6.7", "42f30e37a1c89a2a12943c5dca76f731a2313e8a2e21c1a95dc8241893e922d1", [:mix], [{:hpax, "~> 1.0", [hex: :hpax, repo: "hexpm", optional: false]}, {:plug, "~> 1.14", [hex: :plug, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}, {:thousand_island, "~> 1.0", [hex: :thousand_island, repo: "hexpm", optional: false]}, {:websock, "~> 0.5", [hex: :websock, repo: "hexpm", optional: false]}], "hexpm", "551ba8ff5e4fc908cbeb8c9f0697775fb6813a96d9de5f7fe02e34e76fd7d184"},
   "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
   "blankable": {:hex, :blankable, "1.0.0", "89ab564a63c55af117e115144e3b3b57eb53ad43ba0f15553357eb283e0ed425", [:mix], [], "hexpm", "7cf11aac0e44f4eedbee0c15c1d37d94c090cb72a8d9fddf9f7aec30f9278899"},


### PR DESCRIPTION
This PR aims to unify the config and data paths between the mdw and node images so that the mdw image is a drop in replacement for the node. 

~~This relies on a change in this PR https://github.com/aeternity/ae_plugin/pull/11 and the mdw in this branch is using a fork that has implemented it. That PR would need to be merged so that this one can be changed back to the correct repo~~
