### PR TITLE
chore: pin ae_plugin to the current master by ref

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -145,7 +145,7 @@ defmodule AeMdw.MixProject do
   # Specifies your project dependencies.
   defp deps() do
     [
-      {:ae_plugin, github: "aeternity/ae_plugin"},
+      {:ae_plugin, github: "aeternity/ae_plugin", ref: "cacff2c"},
       {:stream_split, "~> 0.1.5"},
       {:ex2ms, "~> 1.6.0"},
       {:logger_file_backend, "~> 0.0.11"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "ae_plugin": {:git, "https://github.com/aeternity/ae_plugin.git", "cacff2ca9eb14a1b4cd3be08dc93a10e4194717d", []},
+  "ae_plugin": {:git, "https://github.com/aeternity/ae_plugin.git", "cacff2ca9eb14a1b4cd3be08dc93a10e4194717d", [ref: "cacff2c"]},
   "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm", "3ad58ae787e9c7c94dd7ceda3b587ec2c64604563e049b2a0e8baafae832addb"},
   "blankable": {:hex, :blankable, "1.0.0", "89ab564a63c55af117e115144e3b3b57eb53ad43ba0f15553357eb283e0ed425", [:mix], [], "hexpm", "7cf11aac0e44f4eedbee0c15c1d37d94c090cb72a8d9fddf9f7aec30f9278899"},
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},


### PR DESCRIPTION
This must be **merged and released** before https://github.com/aeternity/ae_mdw/pull/2086 since there will be changes on the master of ae_plugin