### PR TITLE
feat: increase the limit of the stats endpoints to 1000

### DIFF
--- a/docs/swagger_v3/base.yaml
+++ b/docs/swagger_v3/base.yaml
@@ -19,6 +19,15 @@ components:
         minimum: 1
         maximum: 100
         default: 10
+    StatsLimitParam:
+      in: query
+      name: limit
+      description: 'Limit paginated resources (max 1000)'
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 10
     ScopeParam:
       in: query
       name: scope

--- a/docs/swagger_v3/stats.spec.yaml
+++ b/docs/swagger_v3/stats.spec.yaml
@@ -269,7 +269,7 @@ paths:
       description: Get delta stats.
       operationId: GetDeltaStats
       parameters:
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/ScopeParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
@@ -300,7 +300,7 @@ paths:
       description: Get total accumulated stats.
       operationId: GetTotalStats
       parameters:
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/ScopeParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
@@ -331,7 +331,7 @@ paths:
       description: Get miners list with total rewards obtained through mining.
       operationId: GetMinerStats
       parameters:
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -396,7 +396,7 @@ paths:
               - key
               - micro
             example: micro
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -461,7 +461,7 @@ paths:
               - key
               - micro
             example: micro
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -516,7 +516,7 @@ paths:
           schema:
             type: string
             example: "2024-01-01"
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -571,7 +571,7 @@ paths:
           schema:
             type: string
             example: "2024-01-01"
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -627,7 +627,7 @@ paths:
           schema:
             type: string
             example: "2024-01-01"
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -689,7 +689,7 @@ paths:
           schema:
             type: string
             example: contract_call
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -771,7 +771,7 @@ paths:
               - week
               - month
             example: week
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -812,7 +812,7 @@ paths:
               - week
               - month
             example: week
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -867,7 +867,7 @@ paths:
           schema:
             type: string
             example: "2024-01-01"
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':
@@ -940,7 +940,7 @@ paths:
           schema:
             type: string
             example: "2024-01-01"
-        - $ref: '#/components/parameters/LimitParam'
+        - $ref: '#/components/parameters/StatsLimitParam'
         - $ref: '#/components/parameters/DirectionParam'
       responses:
         '200':

--- a/lib/ae_mdw_web/controllers/stats_controller.ex
+++ b/lib/ae_mdw_web/controllers/stats_controller.ex
@@ -10,12 +10,9 @@ defmodule AeMdwWeb.StatsController do
 
   @stats_limit 1_000
 
-  plug(PaginatedPlug when action not in ~w(transactions_stats blocks_stats names_stats)a)
-
   plug(
     PaginatedPlug,
-    [max_limit: @stats_limit]
-    when action in ~w(transactions_stats blocks_stats names_stats)a
+    max_limit: @stats_limit
   )
 
   action_fallback(FallbackController)

--- a/test/ae_mdw_web/plugs/paginated_plug_test.exs
+++ b/test/ae_mdw_web/plugs/paginated_plug_test.exs
@@ -177,6 +177,24 @@ defmodule AeMdwWeb.Plugs.PaginatedPlugTest do
     end
   end
 
+  test "it recognises max_limit option", %{conn: conn} do
+    store = empty_store()
+
+    assert %{"error" => "limit too large: 1000"} =
+             conn
+             |> with_store(store)
+             |> put_query(%{"limit" => "1000"})
+             |> PaginatedPlug.call([])
+             |> json_response(400)
+
+    assert %{pagination: {:backward, false, 1000, false}} =
+             conn
+             |> with_store(store)
+             |> put_query(%{"limit" => "1000"})
+             |> PaginatedPlug.call(max_limit: 1000)
+             |> get_assigns()
+  end
+
   defp put_query(conn, query), do: %Conn{conn | params: query, query_params: query}
 
   defp get_assigns(%Conn{assigns: assigns}), do: assigns


### PR DESCRIPTION
This PR increases the max_limit of the stats endpoints to 1000. 

resovles: #2041