### PR TITLE
docs: add tx types to transactions_spec.yaml

### DIFF
--- a/docs/swagger_v3/channels.spec.yaml
+++ b/docs/swagger_v3/channels.spec.yaml
@@ -1,4 +1,30 @@
 schemas:
+  ChannelId:
+    type: string
+    example: ch_2VfzXmCRZepB3ichPf3WTt2uf8zMqsyY3cZWg8k1vt3xcu8L8V
+  ChannelResponderInitiator:
+    type: object
+    required:
+      - responder_id
+      - initiator_id
+    properties:
+      initiator_id:
+        $ref: '#/components/schemas/AccountAddress'
+      responder_id:
+        $ref: '#/components/schemas/AccountAddress'
+  ChannelResponderInitiatorRound:
+    type: object
+    required:
+      - responder_id
+      - initiator_id
+      - round
+    properties:
+      initiator_id:
+        $ref: '#/components/schemas/AccountAddress'
+      responder_id:
+        $ref: '#/components/schemas/AccountAddress'
+      round:
+        type: integer
   Channel:
     type: object
     required:

--- a/docs/swagger_v3/channels.spec.yaml
+++ b/docs/swagger_v3/channels.spec.yaml
@@ -16,7 +16,7 @@ schemas:
   ChannelResponderInitiatorRound:
     type: object
     allOf:
-      - '#/components/schemas/ChannelResponderInitiator'
+      - $ref: '#/components/schemas/ChannelResponderInitiator'
       - type: object
         required:
           - round

--- a/docs/swagger_v3/channels.spec.yaml
+++ b/docs/swagger_v3/channels.spec.yaml
@@ -1,6 +1,7 @@
 schemas:
   ChannelId:
     type: string
+    pattern: ^ch_\w{38,50}$
     example: ch_2VfzXmCRZepB3ichPf3WTt2uf8zMqsyY3cZWg8k1vt3xcu8L8V
   ChannelResponderInitiator:
     type: object
@@ -14,17 +15,14 @@ schemas:
         $ref: '#/components/schemas/AccountAddress'
   ChannelResponderInitiatorRound:
     type: object
-    required:
-      - responder_id
-      - initiator_id
-      - round
-    properties:
-      initiator_id:
-        $ref: '#/components/schemas/AccountAddress'
-      responder_id:
-        $ref: '#/components/schemas/AccountAddress'
-      round:
-        type: integer
+    allOf:
+      - '#/components/schemas/ChannelResponderInitiator'
+      - type: object
+        required:
+          - round
+        properties:
+          round:
+            type: integer
   Channel:
     type: object
     required:

--- a/docs/swagger_v3/contracts.spec.yaml
+++ b/docs/swagger_v3/contracts.spec.yaml
@@ -1,4 +1,132 @@
 schemas:
+  MdwContractCallExtras:
+    type: object
+    required:
+      - aexn_type
+      - arguments
+      - function
+      - gas_used
+      - log
+      - result
+      - return
+      - return_type
+      - ttl
+    properties:
+      aexn_type:
+        type: string
+        example: aex9
+      arguments:
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              type: string
+            value:
+              type: string
+        example:
+          - type: int
+            value: 1
+          - type: string
+            value: "hello"
+      function:
+        type: string
+        example: "main"
+      gas_used:
+        type: integer
+        example: 1000
+      log:
+        type: array
+        items:
+          type: object
+          properties:
+            address:
+              type: string
+            data:
+              type: string
+            topics:
+              type: array
+              items:
+                type: string
+        example:
+          - address: "ct_2U1usf3A8ZNUcZLkZe5rEoBTxk7eJvk9fcbRDNqmRiwXCHAYN"
+            data: cb_+Jg==
+            topics:
+              - "topic1"
+              - "topic2"
+      result:
+        type: string
+        example: "ok"
+      return:
+        type: object
+        properties:
+          type:
+            type: string
+          value:
+            type: string
+        example:
+          type: int
+          value: 1
+      return_type:
+        type: string
+        example: "int"
+      ttl:
+        type: integer
+        example: 1000
+  MdwContractCreateExtras:
+    type: object
+    required:
+      - aexn_type
+      - args
+      - caller_id
+      - compiler_version
+      - contract_id
+      - gas_used
+      - return_type
+      - return_value
+      - source_hash
+      - ttl
+    properties:
+      aexn_type:
+        type: string
+        example: aex9
+      args:
+        type: array
+        items:
+          type: object
+          properties:
+            type:
+              type: string
+            value:
+              type: string
+        example:
+          - type: int
+            value: 1
+          - type: string
+            value: "hello"
+      caller_id:
+        $ref: '#/components/schemas/AccountAddress'
+      compiler_version:
+        type: string
+        example: "8.0.0"
+      contract_id:
+        $ref: '#/components/schemas/ContractAddress'
+      gas_used:
+        type: integer
+        example: 1000
+      return_type:
+        type: string
+        example: "int"
+      return_value:
+        type: string
+        example: "cb_Xfbg4g=="
+      source_hash:
+        type: string
+        example: "cb_Xfbg4gasdasdasdasdadasdasd=="
+      ttl:
+        type: integer
+        example: 1000
+
   ContractInternalTx:
     description: Contract internal transaction
     type: object
@@ -56,7 +184,7 @@ schemas:
           gas: 200000
           gas_price: 1000000000
           nonce: 66
-          owner_id: ak_7wqP18AHzyoqymwGaqQp8G2UpzBCggYiq7CZdJiB71VUsLpR4 
+          owner_id: ak_7wqP18AHzyoqymwGaqQp8G2UpzBCggYiq7CZdJiB71VUsLpR4
           ttl: 0
           vm_version: 5
   ContractCall:

--- a/docs/swagger_v3/contracts.spec.yaml
+++ b/docs/swagger_v3/contracts.spec.yaml
@@ -1,95 +1,112 @@
 schemas:
-  MdwContractCallExtras:
+  MdwContractCommonExtras:
     type: object
     required:
       - aexn_type
-      - arguments
-      - function
       - gas_used
-      - log
-      - result
-      - return
       - return_type
       - ttl
     properties:
       aexn_type:
+        nullable: true
         type: string
         example: aex9
-      arguments:
-        type: array
-        items:
+        enum:
+          - aex9
+          - aex141
+      gas_used:
+        type: integer
+        example: 1000
+      return_type:
+        type: string
+        example: ok
+        enum:
+          - ok
+          - error
+          - revert
+      ttl:
+        type: integer
+        example: 1000
+
+  MdwContractCallExtras:
+      type: object
+      required:
+        - arguments
+        - function
+        - log
+        - result
+        - return
+      properties:
+        arguments:
+          type: array
+          items:
+            type: object
+            required:
+              - type
+              - value
+            properties:
+              type:
+                type: string
+              value:
+                type: string
+          example:
+            - type: int
+              value: 1
+            - type: string
+              value: "hello"
+        function:
+          type: string
+          example: "main"
+        log:
+          type: array
+          items:
+            type: object
+            required:
+              - address
+              - data
+              - topics
+            properties:
+              address:
+                type: string
+              data:
+                type: string
+              topics:
+                type: array
+                items:
+                  type: string
+          example:
+            - address: "ct_2U1usf3A8ZNUcZLkZe5rEoBTxk7eJvk9fcbRDNqmRiwXCHAYN"
+              data: cb_+Jg==
+              topics:
+                - "topic1"
+                - "topic2"
+        result:
+          type: string
+          example: ok
+        return:
           type: object
+          required:
+            - type
+            - value
           properties:
             type:
               type: string
             value:
               type: string
-        example:
-          - type: int
+          example:
+            type: int
             value: 1
-          - type: string
-            value: "hello"
-      function:
-        type: string
-        example: "main"
-      gas_used:
-        type: integer
-        example: 1000
-      log:
-        type: array
-        items:
-          type: object
-          properties:
-            address:
-              type: string
-            data:
-              type: string
-            topics:
-              type: array
-              items:
-                type: string
-        example:
-          - address: "ct_2U1usf3A8ZNUcZLkZe5rEoBTxk7eJvk9fcbRDNqmRiwXCHAYN"
-            data: cb_+Jg==
-            topics:
-              - "topic1"
-              - "topic2"
-      result:
-        type: string
-        example: "ok"
-      return:
-        type: object
-        properties:
-          type:
-            type: string
-          value:
-            type: string
-        example:
-          type: int
-          value: 1
-      return_type:
-        type: string
-        example: "int"
-      ttl:
-        type: integer
-        example: 1000
+
   MdwContractCreateExtras:
     type: object
     required:
-      - aexn_type
       - args
       - caller_id
       - compiler_version
       - contract_id
-      - gas_used
-      - return_type
       - return_value
       - source_hash
-      - ttl
     properties:
-      aexn_type:
-        type: string
-        example: aex9
       args:
         type: array
         items:
@@ -111,21 +128,12 @@ schemas:
         example: "8.0.0"
       contract_id:
         $ref: '#/components/schemas/ContractAddress'
-      gas_used:
-        type: integer
-        example: 1000
-      return_type:
-        type: string
-        example: "int"
       return_value:
         type: string
         example: "cb_Xfbg4g=="
       source_hash:
         type: string
         example: "cb_Xfbg4gasdasdasdasdadasdasd=="
-      ttl:
-        type: integer
-        example: 1000
 
   ContractInternalTx:
     description: Contract internal transaction

--- a/docs/swagger_v3/contracts.spec.yaml
+++ b/docs/swagger_v3/contracts.spec.yaml
@@ -5,7 +5,6 @@ schemas:
       - aexn_type
       - gas_used
       - return_type
-      - ttl
     properties:
       aexn_type:
         nullable: true
@@ -23,7 +22,6 @@ schemas:
         enum:
           - ok
           - error
-          - revert
       ttl:
         type: integer
         example: 1000
@@ -83,6 +81,10 @@ schemas:
         result:
           type: string
           example: ok
+          enum:
+            - ok
+            - error
+            - revert
         return:
           type: object
           required:

--- a/docs/swagger_v3/names.spec.yaml
+++ b/docs/swagger_v3/names.spec.yaml
@@ -1,4 +1,12 @@
 schemas:
+  MdwName:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        example: "test.chain"
   NameTx:
     nullable: true
     type: object

--- a/docs/swagger_v3/transactions.spec.yaml
+++ b/docs/swagger_v3/transactions.spec.yaml
@@ -1,4 +1,10 @@
 schemas:
+  GAReturnType:
+    type: string
+    example: ok
+    enum:
+      - ok
+      - error
   MdwTx:
     description: The node transaction with the fields added by the mdw
     allOf:
@@ -50,10 +56,12 @@ schemas:
         - title: ContractCallTx
           allOf:
           - $ref: '#/components/schemas/ContractCallTx'
+          - $ref: '#/components/schemas/MdwContractCommonExtras'
           - $ref: '#/components/schemas/MdwContractCallExtras'
         - title: ContractCreateTx
           allOf:
           - $ref: '#/components/schemas/ContractCreateTx'
+          - $ref: '#/components/schemas/MdwContractCommonExtras'
           - $ref: '#/components/schemas/MdwContractCreateExtras'
         - title: GAAttachTx
           allOf:
@@ -77,7 +85,7 @@ schemas:
               gas_used:
                 type: integer
               return_type:
-                type: string
+                $ref: '#/components/schemas/GAReturnType'
         - title: GAMetaTx
           allOf:
           - $ref: '#/components/schemas/GAMetaTx'
@@ -89,7 +97,7 @@ schemas:
               gas_used:
                 type: integer
               return_type:
-                type: string
+                $ref: '#/components/schemas/GAReturnType'
         - title: NameClaimTx
           allOf:
           - $ref: '#/components/schemas/NameClaimTx'
@@ -137,32 +145,30 @@ schemas:
     discriminator:
       propertyName: type
       mapping:
-        channel_close_mutual: '#/components/schemas/ChannelCloseMutualTx'
-        channel_close_solo: '#/components/schemas/ChannelCloseSoloTx'
-        channel_create: '#/components/schemas/ChannelCreateTx'
-        channel_deposit: '#/components/schemas/ChannelDepositTx'
-        channel_force_progress: '#/components/schemas/ChannelForceProgressTx'
-        channel_settle: '#/components/schemas/ChannelSettleTx'
-        channel_slash: '#/components/schemas/ChannelSlashTx'
-        channel_snapshot_solo: '#/components/schemas/ChannelSnapshotSoloTx'
-        channel_withdraw: '#/components/schemas/ChannelWithdrawTx'
-        contract_call: '#/components/schemas/ContractCallTx'
-        contract_create: '#/components/schemas/ContractCreateTx'
-        ga_attach: '#/components/schemas/GAAttachTx'
-        ga_meta: '#/components/schemas/GAMetaTx'
-        name_claim: '#/components/schemas/NameClaimTx'
-        name_preclaim: '#/components/schemas/NamePreclaimTx'
-        name_revoke: '#/components/schemas/NameRevokeTx'
-        name_transfer: '#/components/schemas/NameTransferTx'
-        name_update: '#/components/schemas/NameUpdateTx'
-        oracle_extend: '#/components/schemas/OracleExtendTx'
-        oracle_query: '#/components/schemas/OracleQueryTx'
-        oracle_register: '#/components/schemas/OracleRegisterTx'
-        oracle_response: '#/components/schemas/OracleRespondTx'
-        paying_for: '#/components/schemas/PayingForTx'
-        spend: '#/components/schemas/SpendTx'
-    required:
-      - type
+        ChannelCloseMutualTx: '#/components/schemas/ChannelCloseMutualTx'
+        ChannelCloseSoloTx: '#/components/schemas/ChannelCloseSoloTx'
+        ChannelCreateTx: '#/components/schemas/ChannelCreateTx'
+        ChannelDepositTx: '#/components/schemas/ChannelDepositTx'
+        ChannelForceProgressTx: '#/components/schemas/ChannelForceProgressTx'
+        ChannelSettleTx: '#/components/schemas/ChannelSettleTx'
+        ChannelSlashTx: '#/components/schemas/ChannelSlashTx'
+        ChannelSnapshotSoloTx: '#/components/schemas/ChannelSnapshotSoloTx'
+        ChannelWithdrawTx: '#/components/schemas/ChannelWithdrawTx'
+        ContractCallTx: '#/components/schemas/ContractCallTx'
+        ContractCreateTx: '#/components/schemas/ContractCreateTx'
+        GAAttachTx: '#/components/schemas/GAAttachTx'
+        GAMetaTx: '#/components/schemas/GAMetaTx'
+        NameClaimTx: '#/components/schemas/NameClaimTx'
+        NamePreclaimTx: '#/components/schemas/NamePreclaimTx'
+        NameRevokeTx: '#/components/schemas/NameRevokeTx'
+        NameTransferTx: '#/components/schemas/NameTransferTx'
+        NameUpdateTx: '#/components/schemas/NameUpdateTx'
+        OracleExtendTx: '#/components/schemas/OracleExtendTx'
+        OracleQueryTx: '#/components/schemas/OracleQueryTx'
+        OracleRegisterTx: '#/components/schemas/OracleRegisterTx'
+        OracleRespondTx: '#/components/schemas/OracleRespondTx'
+        PayingForTx: '#/components/schemas/PayingForTx'
+        SpendTx: '#/components/schemas/SpendTx'
     type: object
 
   Transaction:
@@ -252,7 +258,7 @@ schemas:
           $ref: '#/components/schemas/Signature'
       tx:
         description: The transaction
-        $ref: '#/components/schemas/MdwTx'
+        $ref: '#/components/schemas/Tx'
     example:
       block_hash: "none"
       block_height: -1

--- a/docs/swagger_v3/transactions.spec.yaml
+++ b/docs/swagger_v3/transactions.spec.yaml
@@ -1,4 +1,170 @@
 schemas:
+  MdwTx:
+    description: The node transaction with the fields added by the mdw
+    allOf:
+      - type: object
+        required:
+          - type
+          - version
+        properties:
+          type:
+            type: string
+          version:
+            type: integer
+      - oneOf:
+        - title: ChannelCloseMutualTx
+          allOf:
+          - $ref: '#/components/schemas/ChannelResponderInitiator'
+          - $ref: '#/components/schemas/ChannelCloseMutualTx'
+        - title: ChannelCloseSoloTx
+          allOf:
+          - $ref: '#/components/schemas/ChannelCloseSoloTx'
+          - $ref: '#/components/schemas/ChannelResponderInitiatorRound'
+        - title: ChannelCreateTx
+          allOf:
+          - $ref: '#/components/schemas/ChannelCreateTx'
+          - type: object
+            required:
+              - channel_id
+            properties:
+              channel_id:
+                $ref: '#/components/schemas/ChannelId'
+        - $ref: '#/components/schemas/ChannelDepositTx'
+        - title: ChannelForceProgressTx
+          allOf:
+          - $ref: '#/components/schemas/ChannelForceProgressTx'
+          - $ref: '#/components/schemas/ChannelResponderInitiator'
+        - title: ChannelSettleTx
+          allOf:
+          - $ref: '#/components/schemas/ChannelSettleTx'
+          - $ref: '#/components/schemas/ChannelResponderInitiator'
+        - title: ChannelSlashTx
+          allOf:
+          - $ref: '#/components/schemas/ChannelSlashTx'
+          - $ref: '#/components/schemas/ChannelResponderInitiatorRound'
+        - title: ChannelSnapshotSoloTx
+          allOf:
+          - $ref: '#/components/schemas/ChannelSnapshotSoloTx'
+          - $ref: '#/components/schemas/ChannelResponderInitiatorRound'
+        - $ref: '#/components/schemas/ChannelWithdrawTx'
+        - title: ContractCallTx
+          allOf:
+          - $ref: '#/components/schemas/ContractCallTx'
+          - $ref: '#/components/schemas/MdwContractCallExtras'
+        - title: ContractCreateTx
+          allOf:
+          - $ref: '#/components/schemas/ContractCreateTx'
+          - $ref: '#/components/schemas/MdwContractCreateExtras'
+        - title: GAAttachTx
+          allOf:
+          - $ref: '#/components/schemas/GAAttachTx'
+          - type: object
+            required:
+              - args
+              - auth_fun_name
+              - contract_id
+              - gas_used
+              - return_type
+            properties:
+              args:
+                type: array
+                items:
+                  type: string
+              auth_fun_name:
+                type: string
+              contract_id:
+                $ref: '#/components/schemas/ContractAddress'
+              gas_used:
+                type: integer
+              return_type:
+                type: string
+        - title: GAMetaTx
+          allOf:
+          - $ref: '#/components/schemas/GAMetaTx'
+          - type: object
+            required:
+              - gas_used
+              - return_type
+            properties:
+              gas_used:
+                type: integer
+              return_type:
+                type: string
+        - title: NameClaimTx
+          allOf:
+          - $ref: '#/components/schemas/NameClaimTx'
+          - type: object
+            required:
+              - name_id
+            properties:
+              name_id:
+                $ref: '#/components/schemas/NameHash'
+        - $ref: '#/components/schemas/NamePreclaimTx'
+        - title: NameRevokeTx
+          allOf:
+          - $ref: '#/components/schemas/NameRevokeTx'
+          - $ref: '#/components/schemas/MdwName'
+        - title: NameTransferTx
+          allOf:
+          - $ref: '#/components/schemas/NameTransferTx'
+          - $ref: '#/components/schemas/MdwName'
+        - title: NameUpdateTx
+          allOf:
+          - $ref: '#/components/schemas/NameUpdateTx'
+          - $ref: '#/components/schemas/MdwName'
+        - $ref: '#/components/schemas/OracleExtendTx'
+        - title: OracleQueryTx
+          allOf:
+          - $ref: '#/components/schemas/OracleQueryTx'
+          - type: object
+            required:
+              - query_id
+            properties:
+              query_id:
+                $ref: '#/components/schemas/OracleQueryId'
+        - title: OracleRegisterTx
+          allOf:
+          - $ref: '#/components/schemas/OracleRegisterTx'
+          - type: object
+            required:
+              - oracle_id
+            properties:
+              oracle_id:
+                $ref: '#/components/schemas/OracleAddress'
+        - $ref: '#/components/schemas/OracleRespondTx'
+        - $ref: '#/components/schemas/PayingForTx'
+        - $ref: '#/components/schemas/SpendTx'
+    discriminator:
+      propertyName: type
+      mapping:
+        channel_close_mutual: '#/components/schemas/ChannelCloseMutualTx'
+        channel_close_solo: '#/components/schemas/ChannelCloseSoloTx'
+        channel_create: '#/components/schemas/ChannelCreateTx'
+        channel_deposit: '#/components/schemas/ChannelDepositTx'
+        channel_force_progress: '#/components/schemas/ChannelForceProgressTx'
+        channel_settle: '#/components/schemas/ChannelSettleTx'
+        channel_slash: '#/components/schemas/ChannelSlashTx'
+        channel_snapshot_solo: '#/components/schemas/ChannelSnapshotSoloTx'
+        channel_withdraw: '#/components/schemas/ChannelWithdrawTx'
+        contract_call: '#/components/schemas/ContractCallTx'
+        contract_create: '#/components/schemas/ContractCreateTx'
+        ga_attach: '#/components/schemas/GAAttachTx'
+        ga_meta: '#/components/schemas/GAMetaTx'
+        name_claim: '#/components/schemas/NameClaimTx'
+        name_preclaim: '#/components/schemas/NamePreclaimTx'
+        name_revoke: '#/components/schemas/NameRevokeTx'
+        name_transfer: '#/components/schemas/NameTransferTx'
+        name_update: '#/components/schemas/NameUpdateTx'
+        oracle_extend: '#/components/schemas/OracleExtendTx'
+        oracle_query: '#/components/schemas/OracleQueryTx'
+        oracle_register: '#/components/schemas/OracleRegisterTx'
+        oracle_response: '#/components/schemas/OracleRespondTx'
+        paying_for: '#/components/schemas/PayingForTx'
+        spend: '#/components/schemas/SpendTx'
+    required:
+      - type
+    type: object
+
   Transaction:
     description: Transaction
     type: object
@@ -34,7 +200,7 @@ schemas:
           $ref: '#/components/schemas/Signature'
       tx:
         description: The transaction
-        $ref: '#/components/schemas/Tx' 
+        $ref: '#/components/schemas/MdwTx'
     example:
       block_hash: mh_ufiYLdN8am8fBxMnb6xq2K4MQKo4eFSCF5bgixq4EzKMtDUXP
       block_height: 1
@@ -66,10 +232,10 @@ schemas:
       - signatures
       - tx
     properties:
-      block_hash: 
+      block_hash:
         type: string
         description: The block hash, but since it's pending it's always "none"
-      block_height: 
+      block_height:
         type: integer
         description: The block height, but since it's pending it's always -1
       encoded_tx:
@@ -86,7 +252,7 @@ schemas:
           $ref: '#/components/schemas/Signature'
       tx:
         description: The transaction
-        $ref: '#/components/schemas/Tx'
+        $ref: '#/components/schemas/MdwTx'
     example:
       block_hash: "none"
       block_height: -1

--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -206,9 +206,7 @@ defmodule AeMdw.Db.Format do
     |> put_in(["micro_index"], mb_index)
     |> put_in(["micro_time"], mb_time)
     |> update_in(["tx"], fn tx ->
-      state
-      |> custom_encode(type, tx, tx_rec, signed_tx, index, block_hash)
-      |> put_ttl(signed_tx)
+      custom_encode(state, type, tx, tx_rec, signed_tx, index, block_hash)
     end)
   end
 
@@ -669,18 +667,5 @@ defmodule AeMdw.Db.Format do
     |> Collection.stream(Model.PreviousName, :backward, key_boundary, nil)
     |> Stream.map(&State.fetch!(state, Model.PreviousName, &1))
     |> Enum.map(fn Model.previous_name(name: name) -> name_info_to_raw_map(state, name) end)
-  end
-
-  defp put_ttl(tx, tx_rec) do
-    ttl =
-      tx_rec
-      |> :aetx_sign.tx()
-      |> :aetx.ttl()
-      |> case do
-        :max_ttl -> nil
-        ttl -> ttl
-      end
-
-    Map.put(tx, "ttl", ttl)
   end
 end

--- a/lib/ae_mdw/db/format.ex
+++ b/lib/ae_mdw/db/format.ex
@@ -206,7 +206,9 @@ defmodule AeMdw.Db.Format do
     |> put_in(["micro_index"], mb_index)
     |> put_in(["micro_time"], mb_time)
     |> update_in(["tx"], fn tx ->
-      custom_encode(state, type, tx, tx_rec, signed_tx, index, block_hash)
+      state
+      |> custom_encode(type, tx, tx_rec, signed_tx, index, block_hash)
+      |> put_ttl(signed_tx)
     end)
   end
 
@@ -667,5 +669,18 @@ defmodule AeMdw.Db.Format do
     |> Collection.stream(Model.PreviousName, :backward, key_boundary, nil)
     |> Stream.map(&State.fetch!(state, Model.PreviousName, &1))
     |> Enum.map(fn Model.previous_name(name: name) -> name_info_to_raw_map(state, name) end)
+  end
+
+  defp put_ttl(tx, tx_rec) do
+    ttl =
+      tx_rec
+      |> :aetx_sign.tx()
+      |> :aetx.ttl()
+      |> case do
+        :max_ttl -> nil
+        ttl -> ttl
+      end
+
+    Map.put(tx, "ttl", ttl)
   end
 end


### PR DESCRIPTION
Added the missing fields in the swagger for transactions and added the ttl field to the transactions as in the docs

resolves: #2115 