### PR TITLE
Change the name of the first hardfork to roma

### DIFF
--- a/lib/ae_mdw/db/hardfork_presets.ex
+++ b/lib/ae_mdw/db/hardfork_presets.ex
@@ -8,7 +8,7 @@ defmodule AeMdw.Db.HardforkPresets do
   alias AeMdw.Db.State
   alias AeMdw.Node
 
-  @type hardfork :: :genesis | :minerva | :fortuna | :lima
+  @type hardfork :: :roma | :minerva | :fortuna | :lima | :iris | :ceres
 
   @doc """
   Imports hardfork migrated accounts.
@@ -27,7 +27,7 @@ defmodule AeMdw.Db.HardforkPresets do
   end
 
   @spec hardfork_height(hardfork()) :: AeMdw.Blocks.height()
-  def hardfork_height(:genesis), do: 0
+  def hardfork_height(:roma), do: 0
 
   def hardfork_height(hardfork) do
     hf_vsn = :aec_hard_forks.protocol_vsn(hardfork)
@@ -45,10 +45,9 @@ defmodule AeMdw.Db.HardforkPresets do
     |> Enum.sum()
   end
 
-  defp accounts(:genesis), do: :aec_fork_block_settings.genesis_accounts()
+  defp accounts(:roma), do: :aec_fork_block_settings.genesis_accounts()
   defp accounts(:minerva), do: :aec_fork_block_settings.minerva_accounts()
   defp accounts(:fortuna), do: :aec_fork_block_settings.fortuna_accounts()
-
   defp accounts(:lima) do
     contract_account =
       Node.lima_contracts()
@@ -60,15 +59,15 @@ defmodule AeMdw.Db.HardforkPresets do
       Node.lima_accounts() ++
       Node.lima_extra_accounts()
   end
-
-  defp accounts(_hf), do: %{}
+  defp accounts(:iris), do: %{}
+  defp accounts(:ceres), do: %{}
 
   defp do_import_account_presets() do
     if :aec_governance.get_network_id() in ["ae_uat", "ae_mainnet"] do
       State.commit(
         State.new(),
         [
-          hardfork_mutation(:genesis, &:aec_fork_block_settings.genesis_accounts/0),
+          hardfork_mutation(:roma, &:aec_fork_block_settings.genesis_accounts/0),
           hardfork_mutation(:minerva, &:aec_fork_block_settings.minerva_accounts/0),
           hardfork_mutation(:fortuna, &:aec_fork_block_settings.fortuna_accounts/0),
           hardfork_mutation(:lima, &Node.lima_accounts/0),

--- a/lib/ae_mdw/node.ex
+++ b/lib/ae_mdw/node.ex
@@ -442,17 +442,14 @@ defmodule AeMdw.Node do
   end
 
   defmemop token_supply_delta() do
-    [
-      {HardforkPresets.hardfork_height(:genesis), HardforkPresets.mint_sum(:genesis)}
-      | :aec_hard_forks.protocols()
-        |> Map.keys()
-        |> Enum.sort()
-        |> Enum.map(fn proto ->
-          proto_vsn = :aec_hard_forks.protocol_vsn_name(proto)
-          {HardforkPresets.hardfork_height(proto_vsn), HardforkPresets.mint_sum(proto_vsn)}
-        end)
-    ]
-    |> Map.new()
+    :aec_hard_forks.protocols()
+      |> Map.keys()
+      |> Enum.sort()
+      |> Enum.map(fn proto ->
+        proto_vsn = :aec_hard_forks.protocol_vsn_name(proto)
+        {HardforkPresets.hardfork_height(proto_vsn), HardforkPresets.mint_sum(proto_vsn)}
+      end)
+      |> Map.new()
   end
 
   defmemop tx_ids_positions() do

--- a/priv/migrations/20251024092223_add_roma_account_balances_to_total_supply.ex
+++ b/priv/migrations/20251024092223_add_roma_account_balances_to_total_supply.ex
@@ -1,0 +1,26 @@
+defmodule AeMdw.Migrations.AddRomaAccountBalancesToTotalSupply do
+  alias AeMdw.Db.HardforkPresets
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.RocksDbCF
+  alias AeMdw.Db.State
+  alias AeMdw.Db.WriteMutation
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    mutations =
+      Model.TotalStat
+      |> RocksDbCF.stream()
+      |> Enum.map(fn Model.total_stat(index: height, total_supply: old_total_supply) ->
+          new_total_supply = old_total_supply + HardforkPresets.mint_sum(:roma)
+          WriteMutation.new(
+            Model.TotalStat,
+            Model.total_stat(index: height, total_supply: new_total_supply)
+          )
+      end)
+
+    _state = State.commit_db(state, mutations)
+    {:ok, length(mutations)}
+  end
+end

--- a/test/ae_mdw/db/hardfork_presets_test.exs
+++ b/test/ae_mdw/db/hardfork_presets_test.exs
@@ -109,7 +109,7 @@ defmodule AeMdw.Db.HardforkPresetsTest do
 
   describe "mint_sum" do
     test "returns the sum of mintings of a hardfork" do
-      assert HardforkPresets.mint_sum(:genesis) == 89_451_376_822_397_976_634_367_408
+      assert HardforkPresets.mint_sum(:roma) == 89_451_376_822_397_976_634_367_408
       assert HardforkPresets.mint_sum(:minerva) == 27_051_422_546_127_651_538_826_703
       assert HardforkPresets.mint_sum(:fortuna) == 72_681_157_406_723_951_132_840_970
       assert HardforkPresets.mint_sum(:lima) == 86_948_638_040_240_004_719_633_952


### PR DESCRIPTION
The first hardfork is called roma in the node, and genesis in the mdw. This is causing the mdw to return 0 for the total balances of the roma accounts, since it only knows about genesis accounts, which are the same as genesis accounts.