### PR TITLE
fix(docker): healthcheck WebSocket probe for Phoenix/Bandit

### DIFF
--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -2,11 +2,18 @@
 HTTP_RES=$(curl -s -o /dev/null -f localhost:4000/status && echo $?)
 SWAGGER_RES=$(curl -s -o /dev/null -f localhost:4000/swagger/swagger_v2.json && echo $?)
 DEPRECATED_SWAGGER_RES=$(curl -s -o /dev/null -f localhost:4000/v2/api && echo $?)
-WS_RES=$(curl -i -H "Connection: close" -H "Upgrade: websocket" -f localhost:4001/websocket --stderr - | grep -q 426 && echo $?)
-WS2_RES=$(curl -i -H "Connection: close" -H "Upgrade: websocket" -f localhost:4001/v2/websocket --stderr - | grep -q 426 && echo $?)
+
+ws_check() {
+  curl -sS -m 0.5 -i \
+    -H "Connection: Upgrade" -H "Upgrade: websocket" \
+    -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" -H "Sec-WebSocket-Version: 13" \
+    "http://localhost:4001$1" 2>&1 | grep -q " 101 " && echo 0 || echo 1
+}
+WS_RES=$(ws_check /websocket)
+WS2_RES=$(ws_check /v2/websocket)
 
 if [ "$HTTP_RES" == "0" ] && [ "$WS_RES" == "0" ] && [ "$WS2_RES" == "0" ] && \
-   [ "$SWAGGER_RES" == "0" ] && [ "$DEPRECATED_SWAGGER_RES" ]; then
+   [ "$SWAGGER_RES" == "0" ] && [ "$DEPRECATED_SWAGGER_RES" == "0" ]; then
     exit 0
 else
     exit 1


### PR DESCRIPTION
## Problem

Docker healthcheck WebSocket probes were failing: the server returns **400 Bad Request** instead of **426 Upgrade Required**.

Phoenix (with Bandit) changed behavior in [phoenixframework/phoenix#5621](https://github.com/phoenixframework/phoenix/pull/5621): invalid or incomplete WebSocket handshakes now get **400** (RFC-compliant) instead of **426** (Cowboy’s previous behavior). The healthcheck was sending an incomplete handshake (no `Sec-WebSocket-Key`, `Connection: close` instead of `Upgrade`), so the server correctly responded with 400 and the check failed.

## Solution

- Send a **valid WebSocket upgrade request** (Connection: Upgrade, Upgrade: websocket, Sec-WebSocket-Key, Sec-WebSocket-Version: 13) and expect **101 Switching Protocols**.
- Extract the common WebSocket check into a `ws_check()` function.
- Fix `DEPRECATED_SWAGGER_RES` condition to require `"0"` explicitly (was truthy check).
- Use `-sS -m 0.5` on curl for quiet output and a 1s timeout.

## Testing

Run the healthcheck against a running MDW container (e.g. started with docker-compose); both `/websocket` and `/v2/websocket` should pass when the WebSocket server is up.
