### PR TITLE
fix: cursor parameter sanitization and AEX9 balance lookup errors

### DIFF
--- a/lib/ae_mdw/active_entities.ex
+++ b/lib/ae_mdw/active_entities.ex
@@ -139,12 +139,14 @@ defmodule AeMdw.ActiveEntities do
 
   defp deserialize_cursor(cursor) do
     with {:ok, cursor_bin} <- Base.hex_decode32(cursor, padding: false),
-         {entity, txi, create_txi} <- :erlang.binary_to_term(cursor_bin) do
+         {entity, txi, create_txi} <- :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, {entity, txi, create_txi}}
     else
       _invalid_cursor ->
         {:error, ErrInput.Cursor.exception(value: cursor)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor)}
   end
 
   defp serialize_cursor({entity, txi, create_txi}) do

--- a/lib/ae_mdw/aex141.ex
+++ b/lib/ae_mdw/aex141.ex
@@ -247,32 +247,38 @@ defmodule AeMdw.Aex141 do
   defp deserialize_cursor(Model.NftTemplate, cursor_bin64) do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64),
          {<<_pk::256>>, template_id} = cursor when is_integer(template_id) <-
-           :erlang.binary_to_term(cursor_bin) do
+           :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, cursor}
     else
       _invalid -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
   end
 
   defp deserialize_cursor(Model.NftTemplateToken, cursor_bin64) do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64),
          {<<_pk::256>>, template_id, token_id} = cursor
          when is_integer(template_id) and is_integer(token_id) <-
-           :erlang.binary_to_term(cursor_bin) do
+           :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, cursor}
     else
       _invalid -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
   end
 
   defp deserialize_cursor(Model.NftTokenOwner, cursor_bin64) do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64),
          {<<_pk::256>>, token_id} = cursor when is_integer(token_id) <-
-           :erlang.binary_to_term(cursor_bin) do
+           :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, cursor}
     else
       _invalid -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
   end
 
   defp serialize_ownership_cursor({_account_pk, contract_pk, token_id}),
@@ -283,11 +289,13 @@ defmodule AeMdw.Aex141 do
   defp deserialize_ownership_cursor(account_pk, cursor_bin64) do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64),
          {<<_pk::256>> = contract_pk, token_id} when is_integer(token_id) <-
-           :erlang.binary_to_term(cursor_bin) do
+           :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, {account_pk, contract_pk, token_id}}
     else
       _invalid -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
   end
 
   defp convert_owned_tokens_param({"contract", contract_id}) do

--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -54,8 +54,13 @@ defmodule AeMdw.Aex9 do
           {:ok, amounts()} | {:error, Error.t()}
   def fetch_balances(state, async_state, contract_pk, top?) do
     if top? do
-      {amounts, _height} = Db.aex9_balances!(contract_pk, true)
-      amounts
+      case Db.aex9_balances(contract_pk, Db.top_height_hash(true)) do
+        {:ok, amounts} ->
+          {:ok, amounts}
+
+        {:error, _reason} ->
+          {:error, ErrInput.ContractDryRun.exception(value: encode_contract(contract_pk))}
+      end
     else
       state = get_store_state(state, async_state, contract_pk)
 
@@ -135,10 +140,9 @@ defmodule AeMdw.Aex9 do
   end
 
   defp event_balances_streamer(state, contract_pk, creation_txi, cursor, %{block_hash: block_hash}) do
-    with {:ok, {height, mbi}} <- ensure_contract_at_block(state, creation_txi, block_hash) do
-      block_type = if mbi == -1, do: :key, else: :micro
-      {amounts, _height_hash} = Db.aex9_balances!(contract_pk, {block_type, height, block_hash})
-
+    with {:ok, {height, mbi}} <- ensure_contract_at_block(state, creation_txi, block_hash),
+         block_type = if(mbi == -1, do: :key, else: :micro),
+         {:ok, amounts} <- Db.aex9_balances(contract_pk, {block_type, height, block_hash}) do
       amounts =
         amounts
         |> Enum.reject(fn {{:address, _pk}, amount} -> amount == 0 end)

--- a/lib/ae_mdw/aex9.ex
+++ b/lib/ae_mdw/aex9.ex
@@ -339,11 +339,13 @@ defmodule AeMdw.Aex9 do
 
   defp deserialize_account_balance_cursor(cursor_bin64) do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64, padding: false),
-         {<<_pk1::256>>, <<_pk2::256>>} = cursor <- :erlang.binary_to_term(cursor_bin) do
+         {<<_pk1::256>>, <<_pk2::256>>} = cursor <- :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, cursor}
     else
       _invalid -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
   end
 
   #

--- a/lib/ae_mdw/aexn_tokens.ex
+++ b/lib/ae_mdw/aexn_tokens.ex
@@ -162,7 +162,7 @@ defmodule AeMdw.AexnTokens do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64, padding: false),
          {aexn_type, {txi, idx}} = cursor_term
          when aexn_type in ~w(aex9 aex141)a and is_integer(txi) and is_integer(idx) <-
-           :erlang.binary_to_term(cursor_bin) do
+           :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, cursor_term}
     else
       _invalid ->
@@ -176,7 +176,7 @@ defmodule AeMdw.AexnTokens do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64, padding: false),
          {aexn_type, _name_symbol_creation, pubkey} = cursor_term
          when aexn_type in ~w(aex9 aex141)a and is_binary(pubkey) <-
-           :erlang.binary_to_term(cursor_bin) do
+           :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, cursor_term}
     else
       _invalid ->

--- a/lib/ae_mdw/aexn_transfers.ex
+++ b/lib/ae_mdw/aexn_transfers.ex
@@ -256,7 +256,7 @@ defmodule AeMdw.AexnTransfers do
 
   defp deserialize_cursor(<<cursor_bin64::binary>>) do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64),
-         cursor_term <- :erlang.binary_to_term(cursor_bin),
+         cursor_term <- :erlang.binary_to_term(cursor_bin, [:safe]),
          true <-
            (elem(cursor_term, 0) in [:aex9, :aex141] or is_integer(elem(cursor_term, 0))) and
              (match?(
@@ -276,6 +276,8 @@ defmodule AeMdw.AexnTransfers do
       _invalid ->
         {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
   end
 
   defp deserialize_account_cursors(_state, nil, _account_pk), do: {:ok, {nil, nil}}

--- a/lib/ae_mdw/dex.ex
+++ b/lib/ae_mdw/dex.ex
@@ -270,12 +270,14 @@ defmodule AeMdw.Dex do
     with {:ok, cursor_bin} <- Base.hex_decode32(cursor_hex, padding: false),
          {<<_pk::256>>, create_txi, txi, log_idx} = cursor
          when is_integer(create_txi) and is_integer(txi) and is_integer(log_idx) <-
-           :erlang.binary_to_term(cursor_bin) do
+           :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, cursor}
     else
       _invalid_cursor ->
         {:error, ErrInput.Cursor.exception(value: cursor_hex)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_hex)}
   end
 
   defp deserialize_contract_swaps_cursor(nil), do: {:ok, nil}
@@ -284,12 +286,14 @@ defmodule AeMdw.Dex do
     with {:ok, cursor_bin} <- Base.hex_decode32(cursor_hex, padding: false),
          {create_txi, <<_pk::256>> = account_pk, txi, log_idx}
          when is_integer(create_txi) and is_integer(txi) and is_integer(log_idx) <-
-           :erlang.binary_to_term(cursor_bin) do
+           :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, {create_txi, account_pk, txi, log_idx}}
     else
       _invalid_cursor ->
         {:error, ErrInput.Cursor.exception(value: cursor_hex)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_hex)}
   end
 
   defp deserialize_debug_contract_swaps_cursor(nil), do: {:ok, nil}
@@ -299,12 +303,14 @@ defmodule AeMdw.Dex do
          {{create_txi, create_idx}, txi, log_idx} = cursor
          when is_integer(create_txi) and is_integer(create_idx) and is_integer(txi) and
                 is_integer(log_idx) <-
-           :erlang.binary_to_term(cursor_bin) do
+           :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, cursor}
     else
       _invalid_cursor ->
         {:error, ErrInput.Cursor.exception(value: cursor_bin)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_bin)}
   end
 
   defp serialize_cursor(cursor_tuple) do

--- a/lib/ae_mdw/hyperchain.ex
+++ b/lib/ae_mdw/hyperchain.ex
@@ -443,7 +443,9 @@ defmodule AeMdw.Hyperchain do
   defp deserialize_numeric_cursor(bin) do
     bin
     |> Base.decode64!()
-    |> :erlang.binary_to_term()
+    |> :erlang.binary_to_term([:safe])
+  rescue
+    ArgumentError -> nil
   end
 
   defp deserialize_validator_cursor(nil) do
@@ -453,7 +455,9 @@ defmodule AeMdw.Hyperchain do
   defp deserialize_validator_cursor(bin) do
     bin
     |> Base.decode64!()
-    |> :erlang.binary_to_term()
+    |> :erlang.binary_to_term([:safe])
+  rescue
+    ArgumentError -> nil
   end
 
   defp serialize_validator_cursor(nil) do
@@ -483,6 +487,8 @@ defmodule AeMdw.Hyperchain do
   defp deserialize_validator_delegates_cursor(bin) do
     bin
     |> Base.decode64!()
-    |> :erlang.binary_to_term()
+    |> :erlang.binary_to_term([:safe])
+  rescue
+    ArgumentError -> nil
   end
 end

--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -814,11 +814,13 @@ defmodule AeMdw.Names do
   defp deserialize_height_cursor(cursor_bin) do
     with {:ok, base64_decoded} <- Base.decode64(cursor_bin, padding: false),
          {height, name} when is_integer(height) and is_binary(name) <-
-           :erlang.binary_to_term(base64_decoded) do
+           :erlang.binary_to_term(base64_decoded, [:safe]) do
       {height, name}
     else
       _invalid -> nil
     end
+  rescue
+    ArgumentError -> nil
   end
 
   defp serialize_history_cursor(name, {height, txi_idx, _table}) do
@@ -831,12 +833,14 @@ defmodule AeMdw.Names do
 
   defp deserialize_history_cursor(name, cursor_str) do
     with {:ok, cursor_bin} <- Base.decode64(cursor_str, padding: false),
-         {^name, _height, _txi_idx} = name_op <- :erlang.binary_to_term(cursor_bin) do
+         {^name, _height, _txi_idx} = name_op <- :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, name_op}
     else
       _invalid ->
         {:error, ErrInput.Cursor.exception(value: cursor_str)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_str)}
   end
 
   defp expand_txi_idx(state, {_bi, {txi, idx}}, opts) do
@@ -1073,11 +1077,13 @@ defmodule AeMdw.Names do
 
   defp deserialize_claims_cursor(cursor_bin64) do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64, padding: false),
-         {_txi, _idx} = cursor <- :erlang.binary_to_term(cursor_bin) do
+         {_txi, _idx} = cursor <- :erlang.binary_to_term(cursor_bin, [:safe]) do
       {:ok, cursor}
     else
       _invalid -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_bin64)}
   end
 
   defp serialize_name_claims_cursor({height, {txi, idx}, _table}) do
@@ -1090,11 +1096,13 @@ defmodule AeMdw.Names do
 
   defp deserialize_name_claims_cursor(cursor_bin64) do
     with {:ok, cursor_bin} <- Base.decode64(cursor_bin64, padding: false),
-         {_height, {_txi, _idx}} = cursor <- :erlang.binary_to_term(cursor_bin) do
+         {_height, {_txi, _idx}} = cursor <- :erlang.binary_to_term(cursor_bin, [:safe]) do
       cursor
     else
       _invalid -> nil
     end
+  rescue
+    ArgumentError -> nil
   end
 
   defp validate_height_filters(filters, :activation) do

--- a/lib/ae_mdw/names.ex
+++ b/lib/ae_mdw/names.ex
@@ -806,21 +806,21 @@ defmodule AeMdw.Names do
   defp serialize_height_cursor({{height, name}, _tab}),
     do: serialize_height_cursor({height, name})
 
+  # Cursor format: "<height_integer>:<url-safe-base64-of-name>"
+  # Plain text avoids binary_to_term entirely — no atom injection risk.
   defp serialize_height_cursor({height, name}),
-    do: Base.encode64(:erlang.term_to_binary({height, name}), padding: false)
+    do: "#{height}:#{Base.url_encode64(name, padding: false)}"
 
   defp deserialize_height_cursor(nil), do: nil
 
   defp deserialize_height_cursor(cursor_bin) do
-    with {:ok, base64_decoded} <- Base.decode64(cursor_bin, padding: false),
-         {height, name} when is_integer(height) and is_binary(name) <-
-           :erlang.binary_to_term(base64_decoded, [:safe]) do
+    with [height_str, name_b64] <- String.split(cursor_bin, ":", parts: 2),
+         {height, ""} <- Integer.parse(height_str),
+         {:ok, name} <- Base.url_decode64(name_b64, padding: false) do
       {height, name}
     else
       _invalid -> nil
     end
-  rescue
-    ArgumentError -> nil
   end
 
   defp serialize_history_cursor(name, {height, txi_idx, _table}) do

--- a/lib/ae_mdw/stats.ex
+++ b/lib/ae_mdw/stats.ex
@@ -652,7 +652,7 @@ defmodule AeMdw.Stats do
   defp deserialize_top_miners_cursor(cursor_bin) do
     case Base.decode64(cursor_bin) do
       {:ok, bin} ->
-        case :erlang.binary_to_term(bin) do
+        case :erlang.binary_to_term(bin, [:safe]) do
           cursor when is_tuple(cursor) -> {:ok, cursor}
           _bad_cursor -> {:error, ErrInput.Cursor.exception(value: cursor_bin)}
         end
@@ -660,6 +660,8 @@ defmodule AeMdw.Stats do
       :error ->
         {:error, ErrInput.Cursor.exception(value: cursor_bin)}
     end
+  rescue
+    ArgumentError -> {:error, ErrInput.Cursor.exception(value: cursor_bin)}
   end
 
   defp render_delta_stats(state, gens), do: Enum.map(gens, &fetch_delta_stat!(state, &1))

--- a/lib/ae_mdw/txs.ex
+++ b/lib/ae_mdw/txs.ex
@@ -718,12 +718,14 @@ defmodule AeMdw.Txs do
     cursor =
       bin
       |> Base.decode64!()
-      |> :erlang.binary_to_term()
+      |> :erlang.binary_to_term([:safe])
 
     case match?({_neg_fee, _neg_gas_price, <<_::256>>, _nonce, <<_::256>>}, cursor) do
       true -> cursor
       false -> nil
     end
+  rescue
+    ArgumentError -> nil
   end
 
   defp render_pending_tx(%State{store: node_store}, mempool_key) do

--- a/test/ae_mdw_web/controllers/cursor_injection_test.exs
+++ b/test/ae_mdw_web/controllers/cursor_injection_test.exs
@@ -14,7 +14,7 @@ defmodule AeMdwWeb.CursorInjectionTest do
   """
 
   use AeMdwWeb.ConnCase
-  @moduletag skip_store: true
+  import AeMdw.TestUtil, only: [with_store: 2]
 
   # A 32-byte zeroed public key used in path segments.
   @zeroed_pk <<0::256>>
@@ -173,19 +173,24 @@ defmodule AeMdwWeb.CursorInjectionTest do
   # ---------------------------------------------------------------------------
 
   describe "names listing — base64 ETF cursor (invalid cursor treated as nil)" do
-    test "invalid base64 cursor is ignored — no atom created", %{conn: conn} do
+    test "invalid base64 cursor is ignored — no atom created", %{conn: conn, store: store} do
       unique = "ae_mdw_names_inject_#{System.unique_integer([:positive])}"
       refute atom_exists?(unique)
 
-      # names uses Base.decode64 with padding: false
+      # The names height cursor format is "height:url_base64(name)", not ETF.
+      # A crafted ETF payload (which WOULD contain an atom in ETF format) is
+      # treated as an unrecognisable cursor and silently ignored (treated as nil).
+      # No atom must ever be created regardless of how the cursor is encoded.
       cursor = unique |> novel_atom_etf() |> Base.encode64(padding: false)
 
-      # The endpoint silently ignores an invalid cursor and returns the first page.
-      # What matters is that no atom is created.
-      conn |> get("/v3/names", cursor: cursor)
+      # Use an empty in-memory store so last_gen_and_time returns :no_blocks
+      # (handled gracefully) without touching the chain DB / Mnesia.
+      conn
+      |> with_store(store)
+      |> get("/v3/names", cursor: cursor)
+      |> json_response(200)
 
       refute atom_exists?(unique)
     end
   end
-
 end

--- a/test/ae_mdw_web/controllers/cursor_injection_test.exs
+++ b/test/ae_mdw_web/controllers/cursor_injection_test.exs
@@ -1,0 +1,191 @@
+defmodule AeMdwWeb.CursorInjectionTest do
+  @moduledoc """
+  Security regression tests for C-1: atom table exhaustion via unsafe binary_to_term.
+
+  These tests verify that endpoints using ETF-based cursor deserialization:
+    1. Return 400 (or otherwise handle gracefully) for malformed cursor values.
+    2. Do NOT create new atoms in the atom table when given a crafted ETF payload
+       containing atoms not yet known to the runtime — the key property of the
+       [:safe] option added as the C-1 fix.
+
+  Payload construction avoids calling :erlang.binary_to_term or
+  String.to_atom/1 so that the novel atom genuinely does not exist in
+  the atom table before the request is made.
+  """
+
+  use AeMdwWeb.ConnCase
+  @moduletag skip_store: true
+
+  # A 32-byte zeroed public key used in path segments.
+  @zeroed_pk <<0::256>>
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Builds a valid ETF binary whose sole term is an atom with the given
+  # UTF-8 name. The binary is constructed byte-by-byte; no atom is created
+  # in the current process.
+  #
+  # ETF format: <<131, ATOM_UTF8_EXT(118), length::16-big, name_bytes>>
+  defp novel_atom_etf(atom_name) when is_binary(atom_name) do
+    len = byte_size(atom_name)
+    <<131, 118, len::16-big, atom_name::binary>>
+  end
+
+  # Returns true when the string already corresponds to an existing atom.
+  defp atom_exists?(name) when is_binary(name) do
+    _atom = String.to_existing_atom(name)
+    true
+  rescue
+    ArgumentError -> false
+  end
+
+  # ---------------------------------------------------------------------------
+  # Tests: endpoints that return 400 for invalid cursors
+  # ---------------------------------------------------------------------------
+
+  describe "aexn transfers — base64 ETF cursor" do
+    # Uses /v3/aex141/transfers which deserializes the cursor before any DB lookup
+    # (no required query params, validated in fetch_aex141_transfers/4).
+
+    test "random non-base64 string returns 400", %{conn: conn} do
+      cursor = "!!!not-valid-base64!!!"
+
+      assert %{"error" => "invalid cursor: " <> _} =
+               conn
+               |> get("/v3/aex141/transfers", cursor: cursor)
+               |> json_response(400)
+    end
+
+    test "base64 of random bytes returns 400", %{conn: conn} do
+      cursor = Base.encode64("not_valid_etf_at_all")
+
+      assert %{"error" => "invalid cursor: " <> _} =
+               conn
+               |> get("/v3/aex141/transfers", cursor: cursor)
+               |> json_response(400)
+    end
+
+    test "ETF with novel atom is rejected and does not grow the atom table", %{conn: conn} do
+      unique = "ae_mdw_aexn_transfer_inject_#{System.unique_integer([:positive])}"
+      refute atom_exists?(unique), "precondition: atom must not exist before the request"
+
+      cursor = unique |> novel_atom_etf() |> Base.encode64()
+
+      assert %{"error" => "invalid cursor: " <> _} =
+               conn
+               |> get("/v3/aex141/transfers", cursor: cursor)
+               |> json_response(400)
+
+      refute atom_exists?(unique), "novel atom MUST NOT be created after the request"
+    end
+  end
+
+  describe "aex141 owned tokens — base64 ETF cursor" do
+    # Uses /v3/accounts/:id/aex141/tokens which calls fetch_owned_tokens/5.
+    # The cursor is deserialized after account_pk validation but before any DB
+    # lookup, so it returns 400 for invalid cursors regardless of whether the
+    # account has any NFTs.
+
+    test "base64 of random bytes returns 400", %{conn: conn} do
+      account_id = encode_account(@zeroed_pk)
+      cursor = Base.encode64("not_etf")
+
+      assert %{"error" => "invalid cursor: " <> _} =
+               conn
+               |> get("/v3/accounts/#{account_id}/aex141/tokens", cursor: cursor)
+               |> json_response(400)
+    end
+
+    test "ETF with novel atom is rejected and does not grow the atom table", %{conn: conn} do
+      unique = "ae_mdw_aex141_tokens_inject_#{System.unique_integer([:positive])}"
+      refute atom_exists?(unique)
+
+      account_id = encode_account(@zeroed_pk)
+      cursor = unique |> novel_atom_etf() |> Base.encode64()
+
+      assert %{"error" => "invalid cursor: " <> _} =
+               conn
+               |> get("/v3/accounts/#{account_id}/aex141/tokens", cursor: cursor)
+               |> json_response(400)
+
+      refute atom_exists?(unique)
+    end
+  end
+
+  describe "account dex swaps — hex32 ETF cursor" do
+    test "random non-hex32 string returns 400", %{conn: conn} do
+      account_id = encode_account(@zeroed_pk)
+      cursor = "!!!not-hex32!!!"
+
+      assert %{"error" => "invalid cursor: " <> _} =
+               conn
+               |> get("/v3/accounts/#{account_id}/dex/swaps", cursor: cursor)
+               |> json_response(400)
+    end
+
+    test "hex32 of random bytes returns 400", %{conn: conn} do
+      account_id = encode_account(@zeroed_pk)
+      cursor = Base.hex_encode32("not_etf_data", padding: false)
+
+      assert %{"error" => "invalid cursor: " <> _} =
+               conn
+               |> get("/v3/accounts/#{account_id}/dex/swaps", cursor: cursor)
+               |> json_response(400)
+    end
+
+    test "ETF with novel atom is rejected and does not grow the atom table", %{conn: conn} do
+      unique = "ae_mdw_dex_acct_inject_#{System.unique_integer([:positive])}"
+      refute atom_exists?(unique)
+
+      account_id = encode_account(@zeroed_pk)
+      cursor = unique |> novel_atom_etf() |> Base.hex_encode32(padding: false)
+
+      assert %{"error" => "invalid cursor: " <> _} =
+               conn
+               |> get("/v3/accounts/#{account_id}/dex/swaps", cursor: cursor)
+               |> json_response(400)
+
+      refute atom_exists?(unique)
+    end
+  end
+
+  describe "global dex swaps — hex32 ETF cursor" do
+    test "ETF with novel atom is rejected and does not grow the atom table", %{conn: conn} do
+      unique = "ae_mdw_dex_global_inject_#{System.unique_integer([:positive])}"
+      refute atom_exists?(unique)
+
+      cursor = unique |> novel_atom_etf() |> Base.hex_encode32(padding: false)
+
+      assert %{"error" => "invalid cursor: " <> _} =
+               conn
+               |> get("/v3/dex/swaps", cursor: cursor)
+               |> json_response(400)
+
+      refute atom_exists?(unique)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Tests: endpoints where an invalid cursor is silently ignored (no 400),
+  # but the atom table must still not grow.
+  # ---------------------------------------------------------------------------
+
+  describe "names listing — base64 ETF cursor (invalid cursor treated as nil)" do
+    test "invalid base64 cursor is ignored — no atom created", %{conn: conn} do
+      unique = "ae_mdw_names_inject_#{System.unique_integer([:positive])}"
+      refute atom_exists?(unique)
+
+      # names uses Base.decode64 with padding: false
+      cursor = unique |> novel_atom_etf() |> Base.encode64(padding: false)
+
+      # The endpoint silently ignores an invalid cursor and returns the first page.
+      # What matters is that no atom is created.
+      conn |> get("/v3/names", cursor: cursor)
+
+      refute atom_exists?(unique)
+    end
+  end
+
+end


### PR DESCRIPTION
Project wise sanitization of params
This pull request focuses on improving the safety and robustness of cursor deserialization throughout the codebase. The main change is the consistent use of the `:safe` option with `:erlang.binary_to_term` to prevent unsafe term deserialization, along with enhanced error handling to catch and handle `ArgumentError` exceptions. This protects against malformed or malicious cursor input and ensures the application fails gracefully in those cases.

**Aex9 Module Improvements:**

* Refactored balance fetching logic to use the safer `Db.aex9_balances` function, improving error handling and consistency. [[1]](diffhunk://#diff-60b0f4b4088c2b73fbfae951ecb98db1cdc451cf8d7ebd38e6d4b05cddfefc81L57-R60) [[2]](diffhunk://#diff-60b0f4b4088c2b73fbfae951ecb98db1cdc451cf8d7ebd38e6d4b05cddfefc81L138-R142)

These changes collectively enhance the codebase's security posture and reliability when handling user-supplied cursor data.