### PR TITLE
feat: websocket performance and security

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,7 +1,5 @@
 [
   # The "does not exist" warning happens because of all of the functions
   # created during runtime that belong to the AE core code.
-  ~r/does not exist/,
-  # Following warnings are due to bad implementation of riverside.
-  {"deps/phoenix/lib/phoenix/router.ex", :pattern_match, 405}
+  ~r/does not exist/
 ]

--- a/README.md
+++ b/README.md
@@ -3625,14 +3625,31 @@ In order to differentiate, please check the "source" field on [Publishing Messag
 ```
 {
   "op": <subscription operation>,
-  "payload": "<message payload>",
+  "payload": "<message payload>"
 }
 ```
 
+The `payload` field is required for `Subscribe` and `Unsubscribe`. It is **not** used by `Ping`.
+
 ### Supported subscription operations
 
-  * Subscribe
-  * Unsubscribe
+  * `Subscribe` — subscribe to a channel. Response: a list containing only the newly subscribed channel.
+  * `Unsubscribe` — unsubscribe from a channel. Response: a list containing only the removed channel.
+  * `Ping` — retrieve the full list of currently active subscriptions. No `payload` field needed.
+
+### Ping response format
+
+```
+{"op":"Ping"}
+```
+
+Response:
+
+```
+{"subscriptions": ["KeyBlocks", "Transactions"], "payload": "Pong"}
+```
+
+Send `Ping` any time to get an authoritative snapshot of all active subscriptions for the current connection.
 
 ### Supported payloads
 
@@ -3643,7 +3660,7 @@ In order to differentiate, please check the "source" field on [Publishing Messag
 
 ### `/websocket`
 
-The V1 websocket interface accepts JSON - encoded commands to subscribe and unsubscribe, and answers these with the list of subscriptions. A session will look like this:
+The V1 websocket interface accepts JSON-encoded commands to subscribe and unsubscribe. Each `Subscribe` response contains only the newly subscribed channel; each `Unsubscribe` response contains only the removed channel. Use `Ping` to retrieve the full list of active subscriptions at any time. A session will look like this:
 
 ```
 wscat -c wss://mainnet.aeternity.io/mdw/websocket
@@ -3654,15 +3671,15 @@ connected (press CTRL+C to quit)
 > {"op":"Ping"}
 < {"subscriptions":["KeyBlocks"],"payload":"Pong"}
 > {"op":"Subscribe", "payload": "MicroBlocks"}
-< ["KeyBlocks","MicroBlocks"]
+< ["MicroBlocks"]
 > {"op":"Unsubscribe", "payload": "MicroBlocks"}
-< ["KeyBlocks"]
+< ["MicroBlocks"]
 > {"op":"Subscribe", "payload": "Transactions"}
-< ["KeyBlocks","Transactions"]
+< ["Transactions"]
 > {"op":"Unsubscribe", "payload": "Transactions"}
-< ["KeyBlocks"]
+< ["Transactions"]
 > {"op":"Subscribe", "payload": "Object", "target":"ak_KHfXhF2J6VBt3sUgFygdbpEkWi6AKBkr9jNKUCHbpwwagzHUs"}
-< ["KeyBlocks","ak_KHfXhF2J6VBt3sUgFygdbpEkWi6AKBkr9jNKUCHbpwwagzHUs"]
+< ["ak_KHfXhF2J6VBt3sUgFygdbpEkWi6AKBkr9jNKUCHbpwwagzHUs"]
 < {"subscription":"KeyBlocks","payload":{"version":4,"time":1588935852368,"target":505727522,"state_hash":"bs_6PKt6GXM9Nu3As4XYr3kjmMiuJoTzkHUPDAwm21GBtjbpfWyL","prev_key_hash":"kh_2Dtcpq9ZdB7AJK1aeEwQtoSncDhFejSdzgTTwuNyscFzJrnsnJ","prev_hash":"mh_2H9cAZHHbyMzPwd4vjQHZpxXsrggG54VCryh6k1BTk511At8Bs","pow":[895666,52781556,66367943,73040389,83465124,91957344,137512183,139025150,145635838,147496688,174889700,196453040,223464154,236816295,249867489,251365348,253234990,284153380,309504789,316268731,337440038,348735058,352371122,367534696,378716232,396258628,400918205,407082251,424187867,427465210,430070369,430312387,432729464,438115994,440444207,442136189,473766117,478006149,482575574,489211700,498083855,518253098],"nonce":567855076671752,"miner":"ak_2Go59eRMNcdiq5uUvVAKjSRoxtREtJe6QvNdcAAPh9GiE5ekQi","info":"cb_AAACHMKhM24=","height":252274,"hash":"kh_FProa64FL423f3xok2fKTfbsuEP2QtdUM4idN7GidQ279zgZ1","beneficiary":"ak_2kHmiJN1RzQL6zXZVuoTuFaVLTCeH3BKyDMZKmixCV3QSWs3dd"}}
 < {"subscription":"Object","payload":{"tx":{"version":1,"type":"SpendTx","ttl":252284,"sender_id":"ak_KHfXhF2J6VBt3sUgFygdbpEkWi6AKBkr9jNKUCHbpwwagzHUs","recipient_id":"ak_KHfXhF2J6VBt3sUgFygdbpEkWi6AKBkr9jNKUCHbpwwagzHUs","payload":"ba_MjUyMjc0OmtoX0ZQcm9hNjRGTDQyM2YzeG9rMmZLVGZic3VFUDJRdGRVTTRpZE43R2lkUTI3OXpnWjE6bWhfMmJTcFlDRVRzZ3hMZDd3eEx2Rkw5Wlp5V1ZqaEtNQXF6aGc3eVB6ZUNraThySFVTbzI6MTU4ODkzNTkwMjSozR4=","nonce":2044360,"fee":19320000000000,"amount":20000},"signatures":["sg_Kdh2uaoaiDEHoehDZsRHk7LvqUm5kPqyKR3RD71utjkkh5DTqoJeNWqYv4gRePL9FyBcU7oeL8nsT39zQg4ydCmiKUuhN"],"hash":"th_rGmoP9FCJMQMJKmwDE8gCk7i63vX33St3UiqGQsRGG1twHD7R","block_height":252274,"block_hash":"mh_2gYb8Pv1yLpdsPjxkzq8g9zzBVy42ZLDRvWH6aKYXhb8QjxdvU"}}
 ```
@@ -3683,7 +3700,7 @@ If it's "mdw", it indicates that it's already available through AeMdw Api.
 
 ### `/v3/websocket`
 
-The V3 websocket interface behaves the same way as the V1 interface, but when the published message has source `mdw` it returns the rendered representation of the object as it would be rendered by the middleware (e.g. the returned object for the `Transactions` subscription will be the same object as returned by the `/v3/transactions` endpoint).
+The V3 websocket interface supports the same operations (`Subscribe`, `Unsubscribe`, `Ping`) and the same lean-reply protocol as the V1 interface. The difference is that when the published message has source `mdw` it returns the rendered representation of the object as it would be rendered by the middleware (e.g. the returned object for the `Transactions` subscription will be the same object as returned by the `/v3/transactions` endpoint).
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -3616,6 +3616,16 @@ $ curl https://mainnet.aeternity.io/mdw/v3/accounts/ak_2nVdbZTBVTbAet8j2hQhLmfNm
 
 ## Websocket interface
 
+> **Migration note for clients upgrading to v1.105+**
+>
+> The WebSocket subscription protocol changed in two ways. Both are described in detail in the [Migration guide](#websocket-migration-guide-v1104--v1105) below.
+>
+> **1. Subscribe/Unsubscribe replies are now lean (breaking)**
+> Previously, every `Subscribe` and `Unsubscribe` reply returned the **full accumulated list** of active subscriptions. Now each reply returns a **single-element list** containing only the channel that was just subscribed or unsubscribed. Send `Ping` to retrieve the full list.
+>
+> **2. Ping reply has new fields (additive, non-breaking)**
+> The Pong response now always includes `"count"` (total subscriptions) and, when results are truncated, `"has_more": true`. Existing clients ignoring unknown fields are unaffected.
+
 The websocket interface, which listens by default on port `4001`, gives asynchronous notifications when various events occur.
 Each event is notified twice: firstly when the Node has synced the block or transaction and after when AeMdw indexation is done.
 In order to differentiate, please check the "source" field on [Publishing Message format](#pub-message-format).
@@ -3635,21 +3645,28 @@ The `payload` field is required for `Subscribe` and `Unsubscribe`. It is **not**
 
   * `Subscribe` — subscribe to a channel. Response: a list containing only the newly subscribed channel.
   * `Unsubscribe` — unsubscribe from a channel. Response: a list containing only the removed channel.
-  * `Ping` — retrieve the full list of currently active subscriptions. No `payload` field needed.
+  * `Ping` — check liveness and get the total subscription count plus a fixed-size sample of active subscriptions. No `payload` field needed. There is no pagination — see [Ping response format](#ping-response-format) for details.
 
 ### Ping response format
 
+Request:
 ```
 {"op":"Ping"}
 ```
 
-Response:
-
+Response (total fits within the sample limit):
+```json
+{"subscriptions": ["KeyBlocks", "Transactions"], "count": 2, "payload": "Pong"}
 ```
-{"subscriptions": ["KeyBlocks", "Transactions"], "payload": "Pong"}
+
+Response when total exceeds the sample limit (e.g. a 100k-account monitoring service):
+```json
+{"subscriptions": ["ak_abc...", "ak_def...", ...], "count": 100000, "has_more": true, "payload": "Pong"}
 ```
 
-Send `Ping` any time to get an authoritative snapshot of all active subscriptions for the current connection.
+`count` is always the true total. `subscriptions` is a fixed-size sample of up to `MAX_PING_LIMIT` entries (default 1000, ~60 KB at that size). **There is no cursor or offset — the full subscription list cannot be enumerated via Ping.** This is intentional: Ping is a liveness and count-verification tool. Clients that need to enumerate their subscriptions should track them locally as they subscribe. When `has_more` is `true`, use `count` to verify the total matches your local record.
+
+> **Keepalive:** The server idle timeout and most reverse proxies will close connections that carry no traffic for extended periods. Long-running monitoring clients should send `Ping` every **~10 minutes** to keep both the proxy and the server connection alive. The Pong response counts as traffic on both sides.
 
 ### Supported payloads
 
@@ -3669,7 +3686,7 @@ connected (press CTRL+C to quit)
 > {"op":"Subscribe", "payload": "KeyBlocks"}
 < ["KeyBlocks"]
 > {"op":"Ping"}
-< {"subscriptions":["KeyBlocks"],"payload":"Pong"}
+< {"subscriptions":["KeyBlocks"],"count":1,"payload":"Pong"}
 > {"op":"Subscribe", "payload": "MicroBlocks"}
 < ["MicroBlocks"]
 > {"op":"Unsubscribe", "payload": "MicroBlocks"}
@@ -3701,6 +3718,79 @@ If it's "mdw", it indicates that it's already available through AeMdw Api.
 ### `/v3/websocket`
 
 The V3 websocket interface supports the same operations (`Subscribe`, `Unsubscribe`, `Ping`) and the same lean-reply protocol as the V1 interface. The difference is that when the published message has source `mdw` it returns the rendered representation of the object as it would be rendered by the middleware (e.g. the returned object for the `Transactions` subscription will be the same object as returned by the `/v3/transactions` endpoint).
+
+### WebSocket migration guide: v1.104 → v1.105
+
+#### Breaking: Subscribe and Unsubscribe responses
+
+**Before (v1.104 and earlier)**
+
+Every `Subscribe` and `Unsubscribe` reply returned the full accumulated list of all active subscriptions for the connection:
+
+```
+> {"op":"Subscribe", "payload": "KeyBlocks"}
+< ["KeyBlocks"]
+> {"op":"Subscribe", "payload": "MicroBlocks"}
+< ["KeyBlocks","MicroBlocks"]          ← full accumulated list
+> {"op":"Unsubscribe", "payload": "KeyBlocks"}
+< ["MicroBlocks"]                       ← remaining list
+```
+
+**After (v1.105+)**
+
+Each reply contains only the single channel that was just subscribed or unsubscribed:
+
+```
+> {"op":"Subscribe", "payload": "KeyBlocks"}
+< ["KeyBlocks"]
+> {"op":"Subscribe", "payload": "MicroBlocks"}
+< ["MicroBlocks"]                       ← only the new channel
+> {"op":"Unsubscribe", "payload": "KeyBlocks"}
+< ["KeyBlocks"]                         ← only the removed channel
+```
+
+**How to migrate**
+
+If your client used the subscribe/unsubscribe reply to maintain a local list of active subscriptions, switch to one of these patterns:
+
+1. **Maintain local state yourself.** You know what you subscribed and unsubscribed — track it client-side and don't rely on the server echoing it back.
+
+2. **Use `Ping` to get the authoritative list.** Send `{"op":"Ping"}` at any time; the reply contains the server-side truth:
+   ```
+   > {"op":"Ping"}
+   < {"subscriptions":["MicroBlocks"],"count":1,"payload":"Pong"}
+   ```
+
+If you cannot update clients immediately, operators can enable the legacy behaviour by setting `WS_SUBS_FULL_LIST_REPLY=true` on the server (see [Middleware Environment Variables](#middleware-environment-variables)). This is a temporary compatibility shim and will be removed in a future version.
+
+#### Additive: Ping response fields
+
+The Pong response now always includes `"count"` (the true total number of active subscriptions for this connection) and, when the subscription list exceeds the server-side sample limit, `"has_more": true`:
+
+```json
+{"subscriptions": ["ak_abc...", ...], "count": 100000, "has_more": true, "payload": "Pong"}
+```
+
+This is additive — clients that already ignore unknown fields are unaffected.
+
+The sample limit is 1000 entries by default (configurable via `MAX_PING_LIMIT`). **Ping does not support pagination** — it returns a fixed sample, not a page cursor. Use `"count"` to verify your total subscription count rather than attempting to enumerate all subscriptions from Ping responses.
+
+#### New: connection and subscription limits
+
+Connections may now be rejected at the WebSocket handshake stage if server-configured limits are exceeded (total connections, connections per IP). The server closes the socket with a normal closure in this case. Clients should handle `CLOSE` frames and apply exponential back-off before reconnecting.
+
+Default limits (all configurable — see [Middleware Environment Variables](#middleware-environment-variables)):
+
+| Limit | Default |
+|---|---|
+| Total connections | 1 000 |
+| Connections per IP | 50 |
+| Subscriptions per connection | 100 000 |
+| Total subscriptions across all connections | 2 000 000 |
+
+#### Idle timeout
+
+Long-lived monitoring connections should still send `{"op":"Ping"}` every **~10 minutes** to reset reverse-proxy idle timers that may be stricter than the server.
 
 ## Tests
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -57,8 +57,6 @@ config :ae_mdw, AeMdwWeb.WebsocketEndpoint,
   watchers: [],
   check_origin: false
 
-config :ae_mdw, AeMdwWeb.Websocket.Subscriptions, max_subs_per_conn: 10_000
-
 config :logger_json, :backend, json_encoder: Jason
 
 # API

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -5,8 +5,19 @@ env = config_env()
 config :ae_mdw, :wealth_rank_size, String.to_integer(System.get_env("WEALTH_RANK_SIZE", "200"))
 
 config :ae_mdw, AeMdwWeb.Websocket.Subscriptions,
-  max_subs_per_conn: String.to_integer(System.get_env("MAX_SUBS_PER_CONN", "10000")),
-  subs_full_list_reply: System.get_env("WS_SUBS_FULL_LIST_REPLY", "false") in ["true", "1"]
+  # 100k per connection lets a single service monitor 100k accounts without multiplexing
+  max_subs_per_conn: String.to_integer(System.get_env("MAX_SUBS_PER_CONN", "100000")),
+  subs_full_list_reply: System.get_env("WS_SUBS_FULL_LIST_REPLY", "false") in ["true", "1"],
+  max_total_connections: String.to_integer(System.get_env("MAX_WS_CONNECTIONS", "1000")),
+  # 50 allows services with many pods/workers behind shared egress NAT
+  max_connections_per_ip: String.to_integer(System.get_env("MAX_WS_CONNECTIONS_PER_IP", "50")),
+  # 2M rows x ~150 bytes ≈ 300 MB; bounded by max tx/s throughput, not size
+  max_total_subs: String.to_integer(System.get_env("MAX_TOTAL_WS_SUBS", "2000000"))
+
+config :ae_mdw, AeMdwWeb.Websocket.SocketHandler,
+  # At ~55 bytes/entry a limit of 1000 produces ~60 KB; 100k entries uncapped would be ~5.5 MB.
+  max_client_backlog: String.to_integer(System.get_env("MAX_WS_CLIENT_BACKLOG", "2000")),
+  max_ping_limit: String.to_integer(System.get_env("MAX_PING_LIMIT", "1000"))
 
 #
 # Telemetry

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -5,7 +5,8 @@ env = config_env()
 config :ae_mdw, :wealth_rank_size, String.to_integer(System.get_env("WEALTH_RANK_SIZE", "200"))
 
 config :ae_mdw, AeMdwWeb.Websocket.Subscriptions,
-  max_subs_per_conn: String.to_integer(System.get_env("MAX_SUBS_PER_CONN", "10000"))
+  max_subs_per_conn: String.to_integer(System.get_env("MAX_SUBS_PER_CONN", "10000")),
+  subs_full_list_reply: System.get_env("WS_SUBS_FULL_LIST_REPLY", "false") in ["true", "1"]
 
 #
 # Telemetry

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -4,6 +4,9 @@ env = config_env()
 
 config :ae_mdw, :wealth_rank_size, String.to_integer(System.get_env("WEALTH_RANK_SIZE", "200"))
 
+config :ae_mdw, AeMdwWeb.Websocket.Subscriptions,
+  max_subs_per_conn: String.to_integer(System.get_env("MAX_SUBS_PER_CONN", "10000"))
+
 #
 # Telemetry
 #

--- a/config/test.exs
+++ b/config/test.exs
@@ -35,7 +35,11 @@ config :ae_mdw, AeMdwWeb.WebsocketEndpoint,
   ],
   server: true
 
-config :ae_mdw, AeMdwWeb.Websocket.Subscriptions, max_subs_per_conn: 10
+config :ae_mdw, AeMdwWeb.Websocket.Subscriptions,
+  max_subs_per_conn: 10,
+  max_connections_per_ip: 10_000,
+  max_total_connections: 10_000,
+  max_total_subs: 10_000_000
 
 # Logging
 config :logger, level: :warn

--- a/docs/middleware_setup.md
+++ b/docs/middleware_setup.md
@@ -147,7 +147,12 @@ The following environment variables configure the middleware itself (not the und
 | `ENABLE_JSON_LOG` | `false` | Set to `true` to emit logs in JSON format |
 | `ENABLE_CONSOLE_LOG` | `false` | Set to `true` to also log to stdout |
 | `WEALTH_RANK_SIZE` | `200` | Number of top accounts tracked for the wealth rank endpoint |
-| `MAX_SUBS_PER_CONN` | `10000` | Maximum WebSocket subscriptions allowed per connection |
+| `MAX_SUBS_PER_CONN` | `100000` | Maximum WebSocket subscriptions per connection. 100k covers monitoring 100k accounts on a single connection; ETS cost is ~15 MB at that size |
+| `MAX_WS_CONNECTIONS` | `1000` | Total simultaneous WebSocket connections across all clients |
+| `MAX_WS_CONNECTIONS_PER_IP` | `50` | Maximum simultaneous connections from a single IP. 50 accommodates services with many workers behind shared egress NAT |
+| `MAX_TOTAL_WS_SUBS` | `2000000` | Global cap on active subscription rows. At ~150 bytes/row this is ~300 MB |
+| `MAX_WS_CLIENT_BACKLOG` | `2000` | Pending-message queue depth above which a slow client's messages are dropped. At peak ~750 object messages/s this is ~2.7 s of buffer |
+| `MAX_PING_LIMIT` | `1000` | Maximum number of subscription entries included in a Ping response sample. When the total exceeds this, the response includes `"has_more": true` and `"count": N`. There is no cursor — Ping is a liveness and count-verification tool, not an enumerator. At 1000 entries the JSON payload is ~60 KB |
 | `WS_SUBS_FULL_LIST_REPLY` | `false` | Set to `true` to return the full subscription list on every subscribe/unsubscribe response (legacy behaviour; use `Ping` to retrieve the full list instead) |
 | `ENABLE_TELEMETRY` | `false` | Set to `true` to enable StatsD telemetry reporting |
 | `TELEMETRY_STATSD_HOST` | hostname | StatsD host (used when `ENABLE_TELEMETRY=true`) |

--- a/docs/middleware_setup.md
+++ b/docs/middleware_setup.md
@@ -133,6 +133,26 @@ You can also pass environment variables to configure the node, similar to standa
 
 Refer to [Aeternity Configuration Docs](https://docs.aeternity.io/en/stable/configuration/) for more details.
 
+### Middleware Environment Variables
+
+The following environment variables configure the middleware itself (not the underlying node):
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `4000` | HTTP API port |
+| `WS_PORT` | `4001` | WebSocket port |
+| `DISABLE_IPV6` | `false` | Set to `true` to bind on IPv4 only (`0.0.0.0` instead of `::`) |
+| `LOG_LEVEL` | `debug` | Log verbosity: `debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`, `none` |
+| `LOG_FILE_PATH` | `log/info.log` | Path for the log file |
+| `ENABLE_JSON_LOG` | `false` | Set to `true` to emit logs in JSON format |
+| `ENABLE_CONSOLE_LOG` | `false` | Set to `true` to also log to stdout |
+| `WEALTH_RANK_SIZE` | `200` | Number of top accounts tracked for the wealth rank endpoint |
+| `MAX_SUBS_PER_CONN` | `10000` | Maximum WebSocket subscriptions allowed per connection |
+| `ENABLE_TELEMETRY` | `false` | Set to `true` to enable StatsD telemetry reporting |
+| `TELEMETRY_STATSD_HOST` | hostname | StatsD host (used when `ENABLE_TELEMETRY=true`) |
+| `TELEMETRY_STATSD_PORT` | `8125` | StatsD port |
+| `TELEMETRY_POLLER_PERIOD` | `10000` | VM metrics polling interval in milliseconds |
+
 ## Additional Resources
 
 - [Aeternity Node Configuration](https://docs.aeternity.io/en/stable/configuration/)

--- a/docs/middleware_setup.md
+++ b/docs/middleware_setup.md
@@ -148,6 +148,7 @@ The following environment variables configure the middleware itself (not the und
 | `ENABLE_CONSOLE_LOG` | `false` | Set to `true` to also log to stdout |
 | `WEALTH_RANK_SIZE` | `200` | Number of top accounts tracked for the wealth rank endpoint |
 | `MAX_SUBS_PER_CONN` | `10000` | Maximum WebSocket subscriptions allowed per connection |
+| `WS_SUBS_FULL_LIST_REPLY` | `false` | Set to `true` to return the full subscription list on every subscribe/unsubscribe response (legacy behaviour; use `Ping` to retrieve the full list instead) |
 | `ENABLE_TELEMETRY` | `false` | Set to `true` to enable StatsD telemetry reporting |
 | `TELEMETRY_STATSD_HOST` | hostname | StatsD host (used when `ENABLE_TELEMETRY=true`) |
 | `TELEMETRY_STATSD_PORT` | `8125` | StatsD port |

--- a/lib/ae_mdw_web/websocket/broadcaster.ex
+++ b/lib/ae_mdw_web/websocket/broadcaster.ex
@@ -90,25 +90,36 @@ defmodule AeMdwWeb.Websocket.Broadcaster do
 
   @impl GenServer
   def handle_cast({:broadcast_key_block, header, source, version, mbs_count, txs_count}, state) do
-    _result =
-      do_broadcast_block(header, source, version, %{
-        micro_blocks_count: mbs_count,
-        transactions_count: txs_count
-      })
+    {:ok, _pid} =
+      Task.start(fn ->
+        do_broadcast_block(header, source, version, %{
+          micro_blocks_count: mbs_count,
+          transactions_count: txs_count
+        })
+      end)
 
     {:noreply, state}
   end
 
   @impl GenServer
   def handle_cast({:broadcast_micro_block, header, source, versions, txs_count}, state) do
-    Enum.each(versions, &do_broadcast_block(header, source, &1, %{transactions_count: txs_count}))
+    {:ok, _pid} =
+      Task.start(fn ->
+        Enum.each(
+          versions,
+          &do_broadcast_block(header, source, &1, %{transactions_count: txs_count})
+        )
+      end)
 
     {:noreply, state}
   end
 
   @impl GenServer
   def handle_cast({:broadcast_txs, micro_block, source, versions}, state) do
-    Enum.each(versions, &do_broadcast_txs(micro_block, source, &1))
+    {:ok, _pid} =
+      Task.start(fn ->
+        Enum.each(versions, &do_broadcast_txs(micro_block, source, &1))
+      end)
 
     {:noreply, state}
   end

--- a/lib/ae_mdw_web/websocket/socket_handler.ex
+++ b/lib/ae_mdw_web/websocket/socket_handler.ex
@@ -7,6 +7,16 @@ defmodule AeMdwWeb.Websocket.SocketHandler do
   alias AeMdwWeb.Websocket.Subscriptions
   alias AeMdwWeb.Util
 
+  # Messages queued beyond this threshold indicate a slow/dead client; drop to protect broadcaster.
+  @max_client_backlog Application.compile_env(:ae_mdw, __MODULE__, [])[:max_client_backlog] ||
+                        2_000
+
+  # Hard upper bound on the number of subscription entries returned in a single Ping response.
+  # Clients monitoring large numbers of accounts already track their own state; Ping is a liveness
+  # check. At 1000 x ~55 bytes/pubkey the JSON payload is ~60 KB, well within one WS frame.
+  defp ping_limit,
+    do: Application.get_env(:ae_mdw, __MODULE__, [])[:max_ping_limit] || 1_000
+
   @impl Phoenix.Socket.Transport
   def child_spec(_opts) do
     # Won't spawn any additional process for the handler then returns a dummy task
@@ -14,23 +24,54 @@ defmodule AeMdwWeb.Websocket.SocketHandler do
   end
 
   @impl Phoenix.Socket.Transport
-  def connect(%{connect_info: %{version: version}}) when version in [:v1, :v2, :v3] do
-    {:ok, %{version: version}}
+  def connect(%{connect_info: %{version: version} = connect_info})
+      when version in [:v1, :v2, :v3] do
+    ip =
+      case connect_info do
+        %{peer_data: %{address: addr}} -> addr |> :inet.ntoa() |> to_string()
+        _other -> "unknown"
+      end
+
+    {:ok, %{version: version, peer_ip: ip}}
   end
 
   @impl Phoenix.Socket.Transport
-  def init(state) do
-    {:ok, state}
+  def init(%{peer_ip: peer_ip} = state) do
+    case Subscriptions.register_connection(self(), peer_ip) do
+      :ok ->
+        {:ok, state}
+
+      {:error, reason} ->
+        Process.send(self(), {:close_connection, reason}, [])
+        {:ok, state}
+    end
   end
 
   @spec send(pid(), binary()) :: :ok
   def send(pid, msg) do
-    Process.send(pid, {:push, msg}, [:noconnect])
+    case Process.info(pid, :message_queue_len) do
+      {:message_queue_len, len} when len < @max_client_backlog ->
+        Process.send(pid, {:push, msg}, [:noconnect])
+
+      nil ->
+        # Process already dead
+        :ok
+
+      _above_limit ->
+        # Slow or dead client — drop message to protect the broadcaster
+        :ok
+    end
   end
 
   @impl Phoenix.Socket.Transport
   def handle_info({:push, msg}, state) do
     {:push, {:text, msg}, state}
+  end
+
+  def handle_info({:close_connection, reason}, state) do
+    require Logger
+    Logger.warning("[ws] connection rejected: #{inspect(reason)}")
+    {:stop, :normal, state}
   end
 
   def handle_info(_ignored_msg, state) do
@@ -39,6 +80,7 @@ defmodule AeMdwWeb.Websocket.SocketHandler do
 
   @impl Phoenix.Socket.Transport
   def terminate(_reason, _state) do
+    Subscriptions.deregister_connection(self())
     :ok
   end
 
@@ -151,8 +193,14 @@ defmodule AeMdwWeb.Websocket.SocketHandler do
   end
 
   defp handle_message(%{"op" => "Ping"}, state) do
-    channels = Subscriptions.subscribed_channels(self())
-    reply(%{"subscriptions" => channels, "payload" => "Pong"}, state)
+    limit = ping_limit()
+    {channels, total} = Subscriptions.subscribed_channels_sample(self(), limit)
+
+    response =
+      %{"subscriptions" => channels, "count" => total, "payload" => "Pong"}
+      |> then(fn r -> if total > limit, do: Map.put(r, "has_more", true), else: r end)
+
+    reply(response, state)
   end
 
   defp handle_message(msg, state) do

--- a/lib/ae_mdw_web/websocket/subscriptions.ex
+++ b/lib/ae_mdw_web/websocket/subscriptions.ex
@@ -60,7 +60,7 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
       :ets.insert(@subs_pid_channel, {pid, channel_key, channel})
       :ets.insert(@subs_channel_pid, {channel_key, pid})
 
-      {:ok, subscribed_channels(pid)}
+      {:ok, reply_channels(pid, channel)}
     end
   end
 
@@ -72,7 +72,7 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
       :ets.delete_object(@subs_channel_pid, {channel_key, pid})
       :ets.match_delete(@subs_pid_channel, {pid, channel_key, :_})
 
-      {:ok, subscribed_channels(pid)}
+      {:ok, reply_channels(pid, channel)}
     end
   end
 
@@ -164,12 +164,13 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
   end
 
   defp unsubscribe_all(pid) do
-    @subs_pid_channel
-    |> :ets.match_object({pid, :_, :_})
-    |> Enum.each(fn {^pid, channel_key, channel} ->
-      :ets.delete_object(@subs_pid_channel, {pid, channel_key, channel})
-      :ets.delete_object(@subs_channel_pid, {channel_key, pid})
-    end)
+    channel_keys =
+      @subs_pid_channel
+      |> :ets.match({pid, :"$1", :_})
+      |> List.flatten()
+
+    :ets.match_delete(@subs_pid_channel, {pid, :_, :_})
+    Enum.each(channel_keys, &:ets.delete_object(@subs_channel_pid, {&1, pid}))
   end
 
   defp validate_subscribe(pid, source, version, channel) do
@@ -181,6 +182,14 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
       {:error, _reason} -> {:error, :invalid_channel}
       true -> {:error, :already_subscribed}
       _above_limit -> {:error, :limit_reached}
+    end
+  end
+
+  defp reply_channels(pid, channel) do
+    if Application.get_env(:ae_mdw, __MODULE__)[:subs_full_list_reply] do
+      subscribed_channels(pid)
+    else
+      [channel]
     end
   end
 

--- a/lib/ae_mdw_web/websocket/subscriptions.ex
+++ b/lib/ae_mdw_web/websocket/subscriptions.ex
@@ -16,6 +16,8 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
   @subs_pids :subs_pids
   @subs_channel_pid :subs_channel_pid
   @subs_pid_channel :subs_pid_channel
+  @ws_connections :ws_connections
+  @ws_ip_counts :ws_ip_counts
   @eot :"$end_of_table"
   @counter_pos 3
 
@@ -32,10 +34,20 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
       :subs_pids = :ets.new(@subs_pids, [:public, :set, :named_table])
       :subs_channel_pid = :ets.new(@subs_channel_pid, [:public, :duplicate_bag, :named_table])
       :subs_pid_channel = :ets.new(@subs_pid_channel, [:public, :duplicate_bag, :named_table])
+      :ws_connections = :ets.new(@ws_connections, [:public, :set, :named_table])
+      :ws_ip_counts = :ets.new(@ws_ip_counts, [:public, :set, :named_table])
     end
 
     :ok
   end
+
+  @spec register_connection(pid(), String.t()) ::
+          :ok | {:error, :too_many_connections | :too_many_connections_from_ip}
+  def register_connection(pid, ip),
+    do: GenServer.call(__MODULE__, {:register_connection, pid, ip})
+
+  @spec deregister_connection(pid()) :: :ok
+  def deregister_connection(pid), do: GenServer.cast(__MODULE__, {:deregister_connection, pid})
 
   @spec start_link(any()) :: GenServer.on_start()
   def start_link(_arg), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
@@ -49,7 +61,52 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
       :ets.insert(@subs_pids, {pid, ref, count})
     end)
 
+    @ws_connections
+    |> :ets.tab2list()
+    |> Enum.each(fn {pid, _ref, ip} ->
+      ref = Process.monitor(pid)
+      :ets.insert(@ws_connections, {pid, ref, ip})
+    end)
+
     {:ok, :no_state}
+  end
+
+  @impl GenServer
+  def handle_call({:register_connection, pid, ip}, _from, state) do
+    total = :ets.info(@ws_connections, :size)
+
+    ip_count =
+      case :ets.lookup(@ws_ip_counts, ip) do
+        [{^ip, count}] -> count
+        [] -> 0
+      end
+
+    cond do
+      total >= limit_total_connections() ->
+        {:reply, {:error, :too_many_connections}, state}
+
+      ip_count >= limit_per_ip_connections() ->
+        {:reply, {:error, :too_many_connections_from_ip}, state}
+
+      true ->
+        ref = Process.monitor(pid)
+        :ets.insert(@ws_connections, {pid, ref, ip})
+        :ets.update_counter(@ws_ip_counts, ip, {2, 1}, {ip, 0})
+        {:reply, :ok, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_cast({:deregister_connection, pid}, state) do
+    cleanup_connection(pid)
+    {:noreply, state}
+  end
+
+  def handle_cast({:monitor, pid}, state) do
+    ref = Process.monitor(pid)
+    :ets.insert(@subs_pids, {pid, ref, 1})
+
+    {:noreply, state}
   end
 
   @spec subscribe(pid(), source(), version(), channel()) ::
@@ -117,32 +174,34 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
     |> List.flatten()
   end
 
+  @spec subscribed_channels_sample(pid(), pos_integer()) :: {[channel()], non_neg_integer()}
+  def subscribed_channels_sample(pid, limit) do
+    total = subscriptions_count(pid)
+
+    channels =
+      case :ets.match(@subs_pid_channel, {pid, :_, :"$1"}, limit) do
+        {rows, _cont} -> List.flatten(rows)
+        @eot -> []
+      end
+
+    {channels, total}
+  end
+
   @impl GenServer
   def handle_info({:DOWN, _ref, _type, pid, _info}, state) do
-    # last connection down
-    if :ets.info(@subs_pids, :size) <= 1 do
-      Enum.each(
-        [@subs_pids, @subs_channel_pid, @subs_pid_channel],
-        &:ets.delete_all_objects/1
-      )
-    else
+    # Subscription cleanup
+    if :ets.member(@subs_pids, pid) do
       unsubscribe_all(pid)
+      maybe_demonitor(pid)
     end
 
-    maybe_demonitor(pid)
+    # Connection cleanup (idempotent — :ets.take/2 returns [] if already gone)
+    cleanup_connection(pid)
 
     {:noreply, state}
   end
 
   def handle_info(_other_message, state), do: {:noreply, state}
-
-  @impl GenServer
-  def handle_cast({:monitor, pid}, state) do
-    ref = Process.monitor(pid)
-    :ets.insert(@subs_pids, {pid, ref, 1})
-
-    {:noreply, state}
-  end
 
   defp maybe_monitor(pid) do
     if :ets.member(@subs_pids, pid) do
@@ -174,9 +233,13 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
   end
 
   defp validate_subscribe(pid, source, version, channel) do
+    per_pid_limit = limit_per_pid()
+    total_subs_limit = limit_total_subs()
+
     with {:ok, channel_key} <- channel_key(source, version, channel),
          false <- exists?(pid, channel_key),
-         count when count < limit_per_pid() <- subscriptions_count(pid) do
+         count when count < per_pid_limit <- subscriptions_count(pid),
+         total_rows when total_rows < total_subs_limit <- :ets.info(@subs_pid_channel, :size) do
       {:ok, channel_key}
     else
       {:error, _reason} -> {:error, :invalid_channel}
@@ -195,6 +258,30 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
 
   defp limit_per_pid do
     Application.get_env(:ae_mdw, __MODULE__)[:max_subs_per_conn]
+  end
+
+  defp limit_total_connections do
+    Application.get_env(:ae_mdw, __MODULE__)[:max_total_connections] || 1_000
+  end
+
+  defp limit_per_ip_connections do
+    Application.get_env(:ae_mdw, __MODULE__)[:max_connections_per_ip] || 10
+  end
+
+  defp limit_total_subs do
+    Application.get_env(:ae_mdw, __MODULE__)[:max_total_subs] || 500_000
+  end
+
+  defp cleanup_connection(pid) do
+    case :ets.take(@ws_connections, pid) do
+      [{^pid, ref, ip}] ->
+        Process.demonitor(ref, [:flush])
+        new_count = :ets.update_counter(@ws_ip_counts, ip, {2, -1}, {ip, 0})
+        if new_count <= 0, do: :ets.delete(@ws_ip_counts, ip)
+
+      [] ->
+        :ok
+    end
   end
 
   defp validate_unsubscribe(pid, source, version, channel) do

--- a/lib/ae_mdw_web/websocket/subscriptions.ex
+++ b/lib/ae_mdw_web/websocket/subscriptions.ex
@@ -16,7 +16,6 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
   @subs_pids :subs_pids
   @subs_channel_pid :subs_channel_pid
   @subs_pid_channel :subs_pid_channel
-  @limit_per_pid Application.compile_env(:ae_mdw, [__MODULE__, :max_subs_per_conn])
   @eot :"$end_of_table"
   @counter_pos 3
 
@@ -166,7 +165,7 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
 
   defp unsubscribe_all(pid) do
     @subs_pid_channel
-    |> :ets.match_object({pid, :"$1"})
+    |> :ets.match_object({pid, :_, :_})
     |> Enum.each(fn {^pid, channel_key, channel} ->
       :ets.delete_object(@subs_pid_channel, {pid, channel_key, channel})
       :ets.delete_object(@subs_channel_pid, {channel_key, pid})
@@ -176,13 +175,17 @@ defmodule AeMdwWeb.Websocket.Subscriptions do
   defp validate_subscribe(pid, source, version, channel) do
     with {:ok, channel_key} <- channel_key(source, version, channel),
          false <- exists?(pid, channel_key),
-         count when count < @limit_per_pid <- subscriptions_count(pid) do
+         count when count < limit_per_pid() <- subscriptions_count(pid) do
       {:ok, channel_key}
     else
       {:error, _reason} -> {:error, :invalid_channel}
       true -> {:error, :already_subscribed}
       _above_limit -> {:error, :limit_reached}
     end
+  end
+
+  defp limit_per_pid do
+    Application.get_env(:ae_mdw, __MODULE__)[:max_subs_per_conn]
   end
 
   defp validate_unsubscribe(pid, source, version, channel) do

--- a/lib/ae_mdw_web/websocket_endpoint.ex
+++ b/lib/ae_mdw_web/websocket_endpoint.ex
@@ -13,27 +13,31 @@ defmodule AeMdwWeb.WebsocketEndpoint do
     signing_salt: "1cOf/zsp"
   ]
 
+  # Idle timeout matches a typical 3-hour reverse-proxy keepalive window.
+  # Clients should send Ping every ~10 minutes to keep the proxy connection alive.
+  @ws_idle_timeout 10_800_000
+
   socket "/websocket", AeMdwWeb.Websocket.SocketHandler,
     websocket: [
-      connect_info: [session: @session_options, version: :v1],
+      connect_info: [session: @session_options, peer_data: [], version: :v1],
       path: "/",
-      timeout: 660_000,
+      timeout: @ws_idle_timeout,
       max_frame_size: 128_000
     ]
 
   socket "/v2/websocket", AeMdwWeb.Websocket.SocketHandler,
     websocket: [
-      connect_info: [session: @session_options, version: :v2],
+      connect_info: [session: @session_options, peer_data: [], version: :v2],
       path: "/",
-      timeout: 660_000,
+      timeout: @ws_idle_timeout,
       max_frame_size: 128_000
     ]
 
   socket "/v3/websocket", AeMdwWeb.Websocket.SocketHandler,
     websocket: [
-      connect_info: [session: @session_options, version: :v3],
+      connect_info: [session: @session_options, peer_data: [], version: :v3],
       path: "/",
-      timeout: 660_000,
+      timeout: @ws_idle_timeout,
       max_frame_size: 128_000
     ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule AeMdw.MixProject do
         warnings_as_errors: true
       ],
       aliases: aliases(),
-      compilers: [:phoenix] ++ Mix.compilers(),
+      compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       xref: [

--- a/test/ae_mdw/websocket/broadcaster_test.exs
+++ b/test/ae_mdw/websocket/broadcaster_test.exs
@@ -526,7 +526,7 @@ defmodule AeMdw.Websocket.BroadcasterTest do
     ])
 
     Enum.each(clients, &WsClient.subscribe(&1, :transactions, :mdw))
-    assert_websocket_receive(clients, :subs, ["Transactions", "Transactions"])
+    assert_websocket_receive(clients, :subs, ["Transactions"])
 
     Enum.each(clients, &WsClient.delete_transactions/1)
     Broadcaster.broadcast_txs(block0, :mdw)

--- a/test/ae_mdw/websocket/socket_handler_test.exs
+++ b/test/ae_mdw/websocket/socket_handler_test.exs
@@ -21,20 +21,24 @@ defmodule AeMdw.Websocket.SocketHandlerTest do
       WsClient.subscribe(client_v2, :key_blocks, :mdw)
       WsClient.unsubscribe(client, :key_blocks, :mdw)
 
-      Process.send_after(client, {:subs, self()}, 100)
+      WsClient.ping(client)
+      Process.send_after(client, {:ping_subs, self()}, 100)
       assert_receive [], 300
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
       assert_receive ["KeyBlocks"], 300
 
       WsClient.unsubscribe(client_v2, :key_blocks, :mdw)
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
       assert_receive [], 300
 
       WsClient.subscribe(client_v2, :key_blocks, :node)
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
       assert_receive ["KeyBlocks"], 300
 
       Process.send_after(client, {:error, self()}, 100)
@@ -56,10 +60,12 @@ defmodule AeMdw.Websocket.SocketHandlerTest do
       WsClient.subscribe(client_v2, :key_blocks)
       WsClient.unsubscribe(client, :key_blocks, :mdw)
 
-      Process.send_after(client, {:subs, self()}, 100)
+      WsClient.ping(client)
+      Process.send_after(client, {:ping_subs, self()}, 100)
       assert_receive [], 300
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
       assert_receive ["KeyBlocks"], 300
 
       Process.send_after(client, {:error, self()}, 100)
@@ -95,20 +101,24 @@ defmodule AeMdw.Websocket.SocketHandlerTest do
       WsClient.subscribe(client_v2, :micro_blocks)
       WsClient.unsubscribe(client, :micro_blocks)
 
-      Process.send_after(client, {:subs, self()}, 100)
+      WsClient.ping(client)
+      Process.send_after(client, {:ping_subs, self()}, 100)
       assert_receive [], 300
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
       assert_receive ["MicroBlocks"], 300
 
       WsClient.unsubscribe(client_v2, :micro_blocks, :mdw)
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
       assert_receive [], 300
 
       WsClient.subscribe(client_v2, :micro_blocks, :node)
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
       assert_receive ["MicroBlocks"], 300
 
       Process.send_after(client, {:error, self()}, 100)
@@ -144,10 +154,12 @@ defmodule AeMdw.Websocket.SocketHandlerTest do
       WsClient.subscribe(client_v2, :transactions)
       WsClient.unsubscribe(client, :transactions)
 
-      Process.send_after(client, {:subs, self()}, 100)
+      WsClient.ping(client)
+      Process.send_after(client, {:ping_subs, self()}, 100)
       assert_receive [], 300
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
       assert_receive ["Transactions"], 300
 
       Process.send_after(client, {:error, self()}, 100)
@@ -184,10 +196,15 @@ defmodule AeMdw.Websocket.SocketHandlerTest do
       WsClient.subscribe(client, name_id)
       WsClient.subscribe(client, channel_id)
 
-      Process.send_after(client, {:subs, self()}, 100)
-      assert_receive [^account_id, ^contract_id, ^oracle_id, ^name_id, ^channel_id], 300
+      WsClient.ping(client)
+      Process.send_after(client, {:ping_subs, self()}, 100)
+      assert_receive ping_subs, 300
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
+      assert Enum.sort(ping_subs) ==
+               Enum.sort([account_id, contract_id, oracle_id, name_id, channel_id])
+
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
       assert_receive [], 300
 
       WsClient.subscribe(client_v2, name_id)
@@ -196,11 +213,15 @@ defmodule AeMdw.Websocket.SocketHandlerTest do
       WsClient.unsubscribe(client, account_id)
       WsClient.unsubscribe(client, channel_id)
 
-      Process.send_after(client, {:subs, self()}, 100)
-      assert_receive [^contract_id, ^oracle_id, ^name_id], 300
+      WsClient.ping(client)
+      Process.send_after(client, {:ping_subs, self()}, 100)
+      assert_receive ping_subs, 300
+      assert Enum.sort(ping_subs) == Enum.sort([contract_id, oracle_id, name_id])
 
-      Process.send_after(client_v2, {:subs, self()}, 100)
-      assert_receive [^name_id, ^channel_id], 300
+      WsClient.ping(client_v2)
+      Process.send_after(client_v2, {:ping_subs, self()}, 100)
+      assert_receive ping_subs_v2, 300
+      assert Enum.sort(ping_subs_v2) == Enum.sort([name_id, channel_id])
 
       Process.send_after(client, {:error, self()}, 100)
       assert_receive nil, 300

--- a/test/ae_mdw/websocket/subscriptions_test.exs
+++ b/test/ae_mdw/websocket/subscriptions_test.exs
@@ -8,7 +8,7 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
   import Support.WsUtil
 
   describe "subscribe/2" do
-    test "returns all subscribed channels on success" do
+    test "returns the subscribed channel on success" do
       pid1 = new_pid()
       pid2 = new_pid()
       pid3 = new_pid()
@@ -17,31 +17,24 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
       assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, :node, :v1, "KeyBlocks")
       assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, :node, :v1, "MicroBlocks")
-
-      assert {:ok, ["KeyBlocks", "Transactions"]} =
-               Subscriptions.subscribe(pid1, :node, :v1, "Transactions")
+      assert {:ok, ["Transactions"]} = Subscriptions.subscribe(pid1, :node, :v1, "Transactions")
 
       channel = encode(:account_pubkey, :crypto.strong_rand_bytes(32))
       assert {:ok, [^channel]} = Subscriptions.subscribe(pid3, :node, :v1, channel)
 
       channel = encode(:oracle_pubkey, :crypto.strong_rand_bytes(32))
-      assert {:ok, subs} = Subscriptions.subscribe(pid3, :node, :v1, channel)
-      assert channel in subs
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid3, :node, :v1, channel)
 
       channel = encode(:contract_pubkey, :crypto.strong_rand_bytes(32))
-      assert {:ok, subs} = Subscriptions.subscribe(pid3, :node, :v1, channel)
-      assert channel in subs
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid3, :node, :v1, channel)
 
       channel = encode(:channel, :crypto.strong_rand_bytes(32))
-      assert {:ok, subs} = Subscriptions.subscribe(pid3, :node, :v1, channel)
-      assert channel in subs
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid3, :node, :v1, channel)
 
       channel = encode(:name, :crypto.strong_rand_bytes(32))
-      assert {:ok, subs} = Subscriptions.subscribe(pid3, :node, :v1, channel)
-      assert channel in subs
+      assert {:ok, [^channel]} = Subscriptions.subscribe(pid3, :node, :v1, channel)
 
-      assert {:ok, subs} = Subscriptions.subscribe(pid3, :node, :v1, "Transactions")
-      assert channel in subs
+      assert {:ok, ["Transactions"]} = Subscriptions.subscribe(pid3, :node, :v1, "Transactions")
     end
 
     test "returns invalid channel when unknown and not a valid id" do
@@ -91,21 +84,18 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
   end
 
   describe "unsubscribe/2" do
-    test "returns remaining subscribed channels" do
+    test "returns the unsubscribed channel" do
       pid1 = new_pid()
       pid2 = new_pid()
 
       on_exit(fn -> unsubscribe_all([pid1, pid2]) end)
 
       assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, :node, :v1, "KeyBlocks")
-
-      assert {:ok, ["KeyBlocks", "Transactions"]} =
-               Subscriptions.subscribe(pid1, :node, :v1, "Transactions")
-
+      assert {:ok, ["Transactions"]} = Subscriptions.subscribe(pid1, :node, :v1, "Transactions")
       assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, :node, :v1, "MicroBlocks")
 
-      assert {:ok, ["Transactions"]} = Subscriptions.unsubscribe(pid1, :node, :v1, "KeyBlocks")
-      assert {:ok, []} = Subscriptions.unsubscribe(pid2, :node, :v1, "MicroBlocks")
+      assert {:ok, ["KeyBlocks"]} = Subscriptions.unsubscribe(pid1, :node, :v1, "KeyBlocks")
+      assert {:ok, ["MicroBlocks"]} = Subscriptions.unsubscribe(pid2, :node, :v1, "MicroBlocks")
     end
 
     test "returns error when channel is unknown and not a valid id" do
@@ -127,7 +117,7 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
       assert {:ok, [^channel]} = Subscriptions.subscribe(pid, :mdw, :v2, channel)
 
       channel = encode(:oracle_pubkey, <<14::256>>)
-      assert {:ok, []} = Subscriptions.unsubscribe(pid, :mdw, :v2, channel)
+      assert {:ok, [^channel]} = Subscriptions.unsubscribe(pid, :mdw, :v2, channel)
       assert {:error, :not_subscribed} = Subscriptions.unsubscribe(pid, :mdw, :v2, channel)
     end
   end
@@ -145,10 +135,7 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
 
       channel = encode(:oracle_pubkey, :crypto.strong_rand_bytes(32))
       assert {:ok, [^channel]} = Subscriptions.subscribe(pid1, :mdw, :v2, channel)
-
-      assert {:ok, [^channel, "KeyBlocks"]} =
-               Subscriptions.subscribe(pid1, :node, :v1, "KeyBlocks")
-
+      assert {:ok, ["KeyBlocks"]} = Subscriptions.subscribe(pid1, :node, :v1, "KeyBlocks")
       assert {:ok, ["MicroBlocks"]} = Subscriptions.subscribe(pid2, :mdw, :v2, "MicroBlocks")
       assert {:ok, ["Transactions"]} = Subscriptions.subscribe(pid3, :mdw, :v2, "Transactions")
 

--- a/test/ae_mdw/websocket/subscriptions_test.exs
+++ b/test/ae_mdw/websocket/subscriptions_test.exs
@@ -62,6 +62,9 @@ defmodule AeMdw.Websocket.SubscriptionsTest do
     end
 
     test "returns error on subscriptions limit is reached" do
+      test_pid = self()
+      on_exit(fn -> unsubscribe_all([test_pid]) end)
+
       max_subs =
         Application.get_env(:ae_mdw, AeMdwWeb.Websocket.Subscriptions)[:max_subs_per_conn]
 

--- a/test/support/ws_client.ex
+++ b/test/support/ws_client.ex
@@ -32,6 +32,10 @@ defmodule Support.WsClient do
     WebSockex.send_frame(client, {:text, Jason.encode!(request)})
   end
 
+  def ping(client) do
+    WebSockex.send_frame(client, {:text, Jason.encode!(%{op: "Ping"})})
+  end
+
   def unsubscribe(client, payload, source) when is_atom(payload) do
     request = %{payload: to_subs(payload), op: "Unsubscribe", source: source}
     WebSockex.send_frame(client, {:text, Jason.encode!(request)})
@@ -59,11 +63,13 @@ defmodule Support.WsClient do
           state
           |> Map.put(:mb, msg)
           |> Map.update(:msgs, [msg], &(&1 ++ [msg]))
+          |> notify_waiters(:mb, msg)
 
         %{"subscription" => "KeyBlocks"} = msg ->
           state
           |> Map.put(:kb, msg)
           |> Map.update(:msgs, [msg], &(&1 ++ [msg]))
+          |> notify_waiters(:kb, msg)
 
         %{"subscription" => "Transactions", "payload" => %{"hash" => @mock_hash}} = msg ->
           Map.put(state, :tx, msg)
@@ -86,6 +92,9 @@ defmodule Support.WsClient do
         subs when is_list(subs) ->
           Map.put(state, :subs, subs)
 
+        %{"subscriptions" => subs, "payload" => "Pong"} ->
+          Map.put(state, :ping_subs, subs)
+
         msg ->
           Map.put(state, :error, msg)
       end
@@ -97,6 +106,19 @@ defmodule Support.WsClient do
     {:ok, Map.put(state, list_key, [])}
   end
 
+  # :kb and :mb are populated by async Tasks inside the broadcaster GenServer.
+  # Defer the reply until the WS frame actually arrives instead of returning nil.
+  def handle_info({request, from}, state) when request in [:kb, :mb] do
+    case Map.get(state, request) do
+      nil ->
+        {:ok, Map.update(state, {:waiting, request}, [from], &[from | &1])}
+
+      data ->
+        send(from, data)
+        {:ok, state}
+    end
+  end
+
   def handle_info({request, from}, state) do
     data = Map.get(state, request)
     send(from, data)
@@ -105,6 +127,14 @@ defmodule Support.WsClient do
 
   def handle_disconnect(disconnect_map, state) do
     super(disconnect_map, state)
+  end
+
+  defp notify_waiters(state, key, data) do
+    state
+    |> Map.get({:waiting, key}, [])
+    |> Enum.each(&send(&1, data))
+
+    Map.delete(state, {:waiting, key})
   end
 
   defp to_subs(subs) when is_atom(subs), do: "#{subs}" |> Macro.camelize()

--- a/test/support/ws_util.ex
+++ b/test/support/ws_util.ex
@@ -12,11 +12,12 @@ defmodule Support.WsUtil do
   defp do_unsubscribe_all(pid) do
     :ets.delete(:subs_pids, pid)
 
-    :subs_pid_channel
-    |> :ets.match_object({pid, :"$1", :_})
-    |> Enum.each(fn {^pid, channel_key, _channel} ->
-      :ets.delete_object(:subs_pid_channel, {pid, channel_key})
-      :ets.delete_object(:subs_channel_pid, {channel_key, pid})
-    end)
+    channel_keys =
+      :subs_pid_channel
+      |> :ets.match({pid, :"$1", :_})
+      |> List.flatten()
+
+    :ets.match_delete(:subs_pid_channel, {pid, :_, :_})
+    Enum.each(channel_keys, &:ets.delete_object(:subs_channel_pid, {&1, pid}))
   end
 end


### PR DESCRIPTION
## WebSocket DoS hardening and protocol improvements

### Breaking change

Subscribe/Unsubscribe responses now return a **single-element list** containing only the channel that was just subscribed or unsubscribed, instead of the full accumulated list. Use `{"op":"Ping"}` to retrieve the complete server-side list at any time.

A temporary compatibility escape hatch is available: set `WS_SUBS_FULL_LIST_REPLY=true` to restore the old behaviour while migrating clients.

### New: connection and subscription limits

Four new configurable limits guard against connection/memory exhaustion:

| Variable | Default | Purpose |
|---|---|---|
| `MAX_WS_CONNECTIONS` | 1000 | Total simultaneous connections |
| `MAX_WS_CONNECTIONS_PER_IP` | 50 | Per-IP connection cap |
| `MAX_TOTAL_WS_SUBS` | 2 000 000 | Global ETS subscription row cap (~300 MB) |
| `MAX_WS_CLIENT_BACKLOG` | 2000 | Per-client message queue drop threshold |

Connections exceeding the limits are rejected at handshake time with a normal WebSocket close. The per-connection subscription limit (`MAX_SUBS_PER_CONN`) is now runtime-configurable (was compile-time) and raised to 100 000 to support large-scale account monitoring.

### New: Ping improvements

The `Ping` response now always includes `"count"` (true total) and `"has_more": true` when the subscription list exceeds `MAX_PING_LIMIT` (default 1000 entries, ~60 KB). Ping is a liveness/count-verification tool — there is no pagination cursor by design.

### Other fixes

- **Broadcaster backpressure**: all three `handle_cast` bodies now dispatch work via `Task.start/1`, returning immediately so the GenServer inbox stays clear under load.
- **Idle timeout**: raised from 11 min to 3 h to match typical reverse-proxy limits. Clients should still send `Ping` every ~10 min to keep proxy connections alive.
- **`unsubscribe_all` ETS arity bug** (H-3): fixed pattern match arity in bulk unsubscribe path.