### PR TITLE
feat: enhance migration progress tracking and status reporting

### DIFF
--- a/lib/ae_mdw/db/status.ex
+++ b/lib/ae_mdw/db/status.ex
@@ -19,7 +19,10 @@ defmodule AeMdw.Db.Status do
   @spec node_and_mdw_status(State.t()) :: map()
   def node_and_mdw_status(state) do
     node_status = node_status()
-    Map.merge(node_status, mdw_status(state, node_status.node_height))
+
+    node_status
+    |> Map.merge(mdw_status(state, node_status.node_height))
+    |> sort_map_deep()
   end
 
   @spec set_gens_per_min(gens_per_min()) :: :ok
@@ -74,6 +77,7 @@ defmodule AeMdw.Db.Status do
       mdw_height: mdw_height,
       mdw_tx_index: mdw_tx_index,
       mdw_async_tasks: async_tasks_counters,
+      mdw_pending_migrations: pending_migrations_progress(),
       mdw_synced: node_height == mdw_height,
       mdw_syncing: mdw_syncing?,
       mdw_gens_per_minute: round(gens_per_minute * 100) / 100
@@ -101,4 +105,31 @@ defmodule AeMdw.Db.Status do
   defp calculate_gens_per_min(prev_gens_per_min, gens_per_min),
     # exponential moving average
     do: (1 - @gens_per_min_weight) * prev_gens_per_min + @gens_per_min_weight * gens_per_min
+
+  defp sort_map_deep(map) when is_map(map) do
+    map
+    |> Enum.sort_by(fn {k, _v} -> to_string(k) end)
+    |> Map.new(fn {k, v} -> {k, sort_map_deep(v)} end)
+  end
+
+  defp sort_map_deep(list) when is_list(list), do: Enum.map(list, &sort_map_deep/1)
+
+  defp sort_map_deep(val), do: val
+
+  # Known async migrations keyed by their progress persistent_term key.
+  @async_migration_progress_keys [
+    {:ae_mdw, :migration_progress, :add_accounts_to_stats}
+  ]
+
+  defp pending_migrations_progress do
+    @async_migration_progress_keys
+    |> Enum.flat_map(fn key ->
+      case :persistent_term.get(key, :none) do
+        :none -> []
+        %{status: :done} -> []
+        info -> [{key |> Tuple.to_list() |> List.last(), info}]
+      end
+    end)
+    |> Map.new()
+  end
 end

--- a/lib/mix/tasks/migrate_db.ex
+++ b/lib/mix/tasks/migrate_db.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.MigrateDb do
   alias AeMdw.Db.Model
   alias AeMdw.Db.State
   alias AeMdw.Log
-  alias AeMdw.Sync.SyncingQueue
+  alias AeMdw.Sync.Server
 
   require Model
 
@@ -87,22 +87,20 @@ defmodule Mix.Tasks.MigrateDb do
         Log.info("applied version #{version}")
 
       {:async, async_migrations} ->
-        # Wrap the last task so the version record is written only after the
-        # task actually completes. A crash before that point leaves the version
-        # unrecorded and the migration will re-run on next boot.
-        {prefix, [last_fn]} = Enum.split(async_migrations, length(async_migrations) - 1)
-
-        Enum.each(prefix, &SyncingQueue.push(&1))
-
-        SyncingQueue.push(fn ->
-          last_fn.()
-          write_migration_record(version)
-          Log.info("async applied version #{version}")
-        end)
+        # Run migration in a supervised task so syncing can proceed concurrently.
+        # The version record is written only after all tasks complete; a crash
+        # leaves the version unrecorded and the migration re-runs on next boot.
+        {:ok, _pid} =
+          Server.task_supervisor()
+          |> Task.Supervisor.start_child(fn ->
+            Enum.each(async_migrations, & &1.())
+            write_migration_record(version)
+            Log.info("async applied version #{version}")
+          end)
 
         count = length(async_migrations)
         duration = DateTime.diff(DateTime.utc_now(), begin)
-        Log.info("total #{count} async tasks queued in #{duration} seconds")
+        Log.info("total #{count} async tasks started in #{duration} seconds")
     end
 
     :ok

--- a/priv/migrations/20260423120000_add_accounts_to_stats.ex
+++ b/priv/migrations/20260423120000_add_accounts_to_stats.ex
@@ -66,6 +66,7 @@ defmodule AeMdw.Migrations.AddAccountsToStats do
   ]
 
   @chunk_size 5_000
+  @progress_key {:ae_mdw, :migration_progress, :add_accounts_to_stats}
 
   # Crash safety: the migration runner wraps async tasks so the version record in
   # Model.Migrations is written only after the task lambda returns. A crash, OOM,
@@ -92,6 +93,8 @@ defmodule AeMdw.Migrations.AddAccountsToStats do
   # ---------------------------------------------------------------------------
 
   defp do_run(state) do
+    set_progress(%{status: :running, phase: 1, processed: 0, total: nil})
+
     # Phase 1: scan Model.KeyBlockTime — pure RocksDB, no Mnesia calls.
     # Index is kb_time_msecs, so a forward scan is already time-ordered.
     # We need height-ordered pairs for Phase 3, so sort by height after.
@@ -103,6 +106,8 @@ defmodule AeMdw.Migrations.AddAccountsToStats do
       end)
       |> Enum.sort_by(fn {height, _t} -> height end)
 
+    n_heights = length(sorted_height_times)
+
     # Build a tuple of {kb_time, height} for O(1) indexed binary search.
     times_tuple =
       sorted_height_times
@@ -110,6 +115,8 @@ defmodule AeMdw.Migrations.AddAccountsToStats do
       |> List.to_tuple()
 
     n = tuple_size(times_tuple)
+
+    set_progress(%{status: :running, phase: 2, processed: 0, total: nil})
 
     # Phase 2: single forward scan of AccountCreation.
     # For each account, binary-search its creation_time into the heights list
@@ -125,6 +132,8 @@ defmodule AeMdw.Migrations.AddAccountsToStats do
         end
       end)
 
+    set_progress(%{status: :running, phase: 3, processed: 0, total: n_heights})
+
     # Phase 3: write updated DeltaStat records in chunks.
     delta_count =
       sorted_height_times
@@ -137,8 +146,12 @@ defmodule AeMdw.Migrations.AddAccountsToStats do
           end)
 
         _state = State.commit_db(state, mutations)
-        total + length(mutations)
+        new_total = total + length(mutations)
+        set_progress(%{status: :running, phase: 3, processed: new_total, total: n_heights})
+        new_total
       end)
+
+    set_progress(%{status: :running, phase: 4, processed: 0, total: n_heights})
 
     # Phase 4: sequential TotalStat accumulation.
     # Uses delta_counts directly so we don't depend on Phase 3 writes being
@@ -160,7 +173,9 @@ defmodule AeMdw.Migrations.AddAccountsToStats do
 
         if length(buf) >= @chunk_size do
           _state = State.commit_db(state, buf)
-          {accounts_count, written + length(buf), []}
+          new_written = written + length(buf)
+          set_progress(%{status: :running, phase: 4, processed: new_written, total: n_heights})
+          {accounts_count, new_written, []}
         else
           {accounts_count, written, buf}
         end
@@ -170,7 +185,17 @@ defmodule AeMdw.Migrations.AddAccountsToStats do
         written + length(buf)
       end)
 
-    delta_count + total_stat_count
+    result = delta_count + total_stat_count
+    set_progress(%{status: :done, phase: 4, processed: result, total: result})
+    result
+  end
+
+  # ---------------------------------------------------------------------------
+  # Progress tracking
+  # ---------------------------------------------------------------------------
+
+  defp set_progress(info) do
+    :persistent_term.put(@progress_key, info)
   end
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces improvements to the database migration process, particularly around tracking and reporting the progress of asynchronous migrations. The changes add a mechanism to expose migration progress in the system status and refactor how async migrations are run and monitored. The most important changes are grouped below.

**Migration Progress Tracking and Reporting:**

* Added a new field `mdw_pending_migrations` to the status map returned by `AeMdw.Db.Status.node_and_mdw_status/1`, which reports the progress of any ongoing asynchronous migrations using data from `:persistent_term`. The status map is now deeply sorted for consistent output. [[1]](diffhunk://#diff-fe32886f3a19512a3b8839302aa3a31bc3260647767acdad2677ecc767b04687L22-R25) [[2]](diffhunk://#diff-fe32886f3a19512a3b8839302aa3a31bc3260647767acdad2677ecc767b04687R80) [[3]](diffhunk://#diff-fe32886f3a19512a3b8839302aa3a31bc3260647767acdad2677ecc767b04687R108-R134)
* The `AddAccountsToStats` migration now tracks and persists its progress at each phase using a new `@progress_key` and a `set_progress/1` helper. This allows external systems to monitor migration progress in real time. [[1]](diffhunk://#diff-a50579ec725e49101a6d25d821cc65e19efb17675acc015cd66d0d3d4075ab49R69) [[2]](diffhunk://#diff-a50579ec725e49101a6d25d821cc65e19efb17675acc015cd66d0d3d4075ab49R96-R97) [[3]](diffhunk://#diff-a50579ec725e49101a6d25d821cc65e19efb17675acc015cd66d0d3d4075ab49R109-R110) [[4]](diffhunk://#diff-a50579ec725e49101a6d25d821cc65e19efb17675acc015cd66d0d3d4075ab49R119-R120) [[5]](diffhunk://#diff-a50579ec725e49101a6d25d821cc65e19efb17675acc015cd66d0d3d4075ab49R135-R136) [[6]](diffhunk://#diff-a50579ec725e49101a6d25d821cc65e19efb17675acc015cd66d0d3d4075ab49L140-R155) [[7]](diffhunk://#diff-a50579ec725e49101a6d25d821cc65e19efb17675acc015cd66d0d3d4075ab49L163-R178) [[8]](diffhunk://#diff-a50579ec725e49101a6d25d821cc65e19efb17675acc015cd66d0d3d4075ab49L173-R198)

**Async Migration Execution Improvements:**

* Refactored the async migration runner in `Mix.Tasks.MigrateDb` to use a supervised task (`Task.Supervisor`), ensuring the migration version is only recorded after all tasks complete, and logging is updated to reflect when tasks are started rather than queued. [[1]](diffhunk://#diff-200299bbc76c91b3fc5b2744b50edb176a454f5dce6e638f54d5fe88ddd53fc9L11-R11) [[2]](diffhunk://#diff-200299bbc76c91b3fc5b2744b50edb176a454f5dce6e638f54d5fe88ddd53fc9L90-R103)