### PR TITLE
fix: give the AEX-N metadata dry-runs an execution gas budget

### DIFF
--- a/lib/ae_mdw/db/hardfork_presets.ex
+++ b/lib/ae_mdw/db/hardfork_presets.ex
@@ -40,12 +40,8 @@ defmodule AeMdw.Db.HardforkPresets do
   @doc """
   Sum of the accounts migrated into the chain at a hardfork.
 
-  Only Roma, Minerva, Fortuna and Lima ever shipped migrated accounts; every
-  protocol since mints nothing at the fork itself. A protocol this module does
-  not name is treated the same way instead of raising, because
-  `AeMdw.Node.token_supply_delta/0` folds over every protocol the node reports
-  and feeds total supply on each generation - a node configured with a protocol
-  newer than the ones above must not take the sync down.
+  Protocols this module does not name return 0 rather than raising: the raise
+  would take sync down through `AeMdw.Node.token_supply_delta/0`.
   """
   @spec mint_sum(hardfork() | atom()) :: non_neg_integer()
   def mint_sum(hardfork) do

--- a/lib/ae_mdw/db/hardfork_presets.ex
+++ b/lib/ae_mdw/db/hardfork_presets.ex
@@ -37,7 +37,17 @@ defmodule AeMdw.Db.HardforkPresets do
     |> Map.get(hf_vsn)
   end
 
-  @spec mint_sum(hardfork()) :: pos_integer
+  @doc """
+  Sum of the accounts migrated into the chain at a hardfork.
+
+  Only Roma, Minerva, Fortuna and Lima ever shipped migrated accounts; every
+  protocol since mints nothing at the fork itself. A protocol this module does
+  not name is treated the same way instead of raising, because
+  `AeMdw.Node.token_supply_delta/0` folds over every protocol the node reports
+  and feeds total supply on each generation - a node configured with a protocol
+  newer than the ones above must not take the sync down.
+  """
+  @spec mint_sum(hardfork() | atom()) :: non_neg_integer()
   def mint_sum(hardfork) do
     hardfork
     |> accounts()
@@ -61,8 +71,8 @@ defmodule AeMdw.Db.HardforkPresets do
       Node.lima_extra_accounts()
   end
 
-  defp accounts(:iris), do: %{}
-  defp accounts(:ceres), do: %{}
+  # Iris, Ceres and anything after them migrate no accounts.
+  defp accounts(_hardfork), do: %{}
 
   defp do_import_account_presets() do
     if :aec_governance.get_network_id() in ["ae_uat", "ae_mainnet"] do

--- a/lib/ae_mdw/dry_run/contract.ex
+++ b/lib/ae_mdw/dry_run/contract.ex
@@ -42,12 +42,6 @@ defmodule AeMdw.DryRun.Contract do
     |> Util.ok!()
   end
 
-  @spec call_tx_base_gas(AeMdw.Blocks.height()) :: pos_integer()
-  def call_tx_base_gas(height) do
-    protocol = :aec_hard_forks.protocol_effective_at_height(height)
-    :aec_governance.tx_base_gas(:contract_call_tx, protocol, abi_version())
-  end
-
   defp min_gas_price do
     protocol = :aec_hard_forks.protocol_effective_at_height(1)
 

--- a/lib/ae_mdw/dry_run/runner.ex
+++ b/lib/ae_mdw/dry_run/runner.ex
@@ -26,16 +26,9 @@ defmodule AeMdw.DryRun.Runner do
   @amount trunc(:math.pow(10, 35))
   @extension_methods ["aex9_extensions", "aex141_extensions"]
 
-  # Execution budget for the AEX-N introspection calls. They return a
-  # fixed-size tuple and never iterate a collection, so the only input-dependent
-  # cost is loading the contract's state register, which is charged per byte.
-  # 6_000_000 is the protocol's default per-microblock gas limit: no contract
-  # call the chain itself would accept can consume more than this, so it is an
-  # upper bound on honest work while still capping a looping contract during
-  # sync. It is a constant rather than a read of
-  # `:aec_governance.block_gas_limit/0` so that a node configured with a lower
-  # gas limit cannot shrink it - the metadata is resolved once, at contract
-  # creation, and an `out_of_gas` result is written to the index permanently.
+  # The protocol's default per-microblock gas limit, so no call the chain would
+  # accept can exceed it. A literal and not `:aec_governance.block_gas_limit/0`
+  # because that is tunable, and an out_of_gas result here is indexed permanently.
   @introspection_gas 6_000_000
 
   @spec call_contract(DBN.pubkey(), method_name(), method_args()) ::

--- a/lib/ae_mdw/dry_run/runner.ex
+++ b/lib/ae_mdw/dry_run/runner.ex
@@ -26,6 +26,18 @@ defmodule AeMdw.DryRun.Runner do
   @amount trunc(:math.pow(10, 35))
   @extension_methods ["aex9_extensions", "aex141_extensions"]
 
+  # Execution budget for the AEX-N introspection calls. They return a
+  # fixed-size tuple and never iterate a collection, so the only input-dependent
+  # cost is loading the contract's state register, which is charged per byte.
+  # 6_000_000 is the protocol's default per-microblock gas limit: no contract
+  # call the chain itself would accept can consume more than this, so it is an
+  # upper bound on honest work while still capping a looping contract during
+  # sync. It is a constant rather than a read of
+  # `:aec_governance.block_gas_limit/0` so that a node configured with a lower
+  # gas limit cannot shrink it - the metadata is resolved once, at contract
+  # creation, and an `out_of_gas` result is written to the index permanently.
+  @introspection_gas 6_000_000
+
   @spec call_contract(DBN.pubkey(), method_name(), method_args()) ::
           {:ok, call_return()} | {:error, call_error()} | :revert
   def call_contract(contract_pk, function_name, args),
@@ -33,9 +45,9 @@ defmodule AeMdw.DryRun.Runner do
 
   @spec call_contract(DBN.pubkey(), DBN.height_hash(), method_name(), method_args()) ::
           {:ok, call_return()} | {:error, call_error()} | :revert
-  def call_contract(contract_pk, {_type, height, block_hash}, function_name, args) do
+  def call_contract(contract_pk, {_type, _height, block_hash}, function_name, args) do
     contract_pk
-    |> new_contract_call_tx(height, function_name, args)
+    |> new_contract_call_tx(function_name, args)
     |> dry_run(block_hash)
     |> case do
       {:ok, {[contract_call_tx: {:ok, call_res}], _events}} ->
@@ -70,20 +82,18 @@ defmodule AeMdw.DryRun.Runner do
     :aec_dry_run.dry_run(block_hash, accounts, txs, tx_events: false)
   end
 
-  defp new_contract_call_tx(contract_pk, height, function_name, args)
+  defp new_contract_call_tx(contract_pk, function_name, args)
        when function_name == "meta_info" or function_name in @extension_methods do
-    base_gas = Contract.call_tx_base_gas(height)
-
     Contract.new_call_tx(
       @runner_pk,
       contract_pk,
       function_name,
       args,
-      base_gas
+      @introspection_gas
     )
   end
 
-  defp new_contract_call_tx(contract_pk, _height, function_name, args) do
+  defp new_contract_call_tx(contract_pk, function_name, args) do
     Contract.new_call_tx(@runner_pk, contract_pk, function_name, args)
   end
 end

--- a/priv/migrations/20260821170000_reresolve_out_of_gas_aexn_meta_info.ex
+++ b/priv/migrations/20260821170000_reresolve_out_of_gas_aexn_meta_info.ex
@@ -1,0 +1,55 @@
+defmodule AeMdw.Migrations.ReresolveOutOfGasAexnMetaInfo do
+  @moduledoc """
+  Re-resolves the meta_info of AEX-9/AEX-141 contracts stuck with the
+  out_of_gas_error sentinel from before the meta_info/extensions dry-run gas
+  budget fix. Only contracts with that exact sentinel are re-dry-run; a
+  format_error is a decode mismatch, not a gas problem, and retrying it would
+  fail identically.
+  """
+
+  alias AeMdw.AexnContracts
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.RocksDbCF
+  alias AeMdw.Db.State
+  alias AeMdw.Db.WriteMutation
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    Model.AexnContract
+    |> RocksDbCF.stream()
+    |> Stream.filter(fn Model.aexn_contract(meta_info: meta_info) ->
+      elem(meta_info, 0) == :out_of_gas_error
+    end)
+    |> Stream.flat_map(fn Model.aexn_contract(
+                            index: {aexn_type, contract_pk},
+                            txi_idx: {txi, _idx}
+                          ) = aexn_contract ->
+      Model.tx(block_index: bi) = State.fetch!(state, Model.Tx, txi)
+      Model.block(hash: block_hash) = State.fetch!(state, Model.Block, bi)
+
+      aexn_type
+      |> AexnContracts.call_meta_info(contract_pk, block_hash)
+      |> case do
+        {:ok, new_meta_info} ->
+          [
+            WriteMutation.new(
+              Model.AexnContract,
+              Model.aexn_contract(aexn_contract, meta_info: new_meta_info)
+            )
+          ]
+
+        :error ->
+          []
+      end
+    end)
+    |> Stream.chunk_every(1000)
+    |> Stream.map(fn mutations ->
+      _state = State.commit_db(state, mutations)
+      length(mutations)
+    end)
+    |> Enum.sum()
+    |> then(fn count -> {:ok, count} end)
+  end
+end

--- a/priv/migrations/20260821180000_index_missing_aexn_contracts.ex
+++ b/priv/migrations/20260821180000_index_missing_aexn_contracts.ex
@@ -1,0 +1,74 @@
+defmodule AeMdw.Migrations.IndexMissingAexnContracts do
+  @moduledoc """
+  Re-indexes AEX-9/AEX-141 contracts that were silently skipped entirely at
+  creation time (never written to Model.AexnContract) because
+  aexn_create_contract_mutation/4's `with` chain returns nil on any failed
+  step - including the aex9_extensions/aex141_extensions dry-run running out
+  of gas before the meta_info/extensions gas budget fix. Every still-unindexed
+  contract_create_tx contract is cheaply classified first, so the actual
+  dry-run calls only run for the ones that are AEX-9/AEX-141-shaped.
+  """
+
+  alias AeMdw.AexnContracts
+  alias AeMdw.Contract
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.RocksDbCF
+  alias AeMdw.Db.State
+  alias AeMdw.Db.Sync.Contract, as: SyncContract
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()}
+  def run(state, _from_start?) do
+    count =
+      Model.Origin
+      |> RocksDbCF.stream()
+      |> Stream.filter(fn Model.origin(index: {tx_type, _contract_pk}) ->
+        tx_type == :contract_create_tx
+      end)
+      |> Stream.reject(fn Model.origin(index: {_tx_type, contract_pk}) ->
+        State.exists?(state, Model.AexnContract, {:aex9, contract_pk}) or
+          State.exists?(state, Model.AexnContract, {:aex141, contract_pk})
+      end)
+      |> Stream.flat_map(fn Model.origin(
+                              index: {_tx_type, contract_pk},
+                              txi_idx: {txi, _idx} = txi_idx
+                            ) ->
+        Model.tx(block_index: {height, _mbi} = block_index) = State.fetch!(state, Model.Tx, txi)
+
+        if aexn_shaped?(height, contract_pk) do
+          Model.block(hash: block_hash) = State.fetch!(state, Model.Block, block_index)
+
+          case SyncContract.aexn_create_contract_mutation(
+                 contract_pk,
+                 block_hash,
+                 block_index,
+                 txi_idx
+               ) do
+            nil -> []
+            mutation -> [mutation]
+          end
+        else
+          []
+        end
+      end)
+      |> Stream.chunk_every(100)
+      |> Stream.map(fn mutations ->
+        _state = State.commit_db(state, mutations)
+        length(mutations)
+      end)
+      |> Enum.sum()
+
+    {:ok, count}
+  end
+
+  defp aexn_shaped?(height, contract_pk) do
+    case Contract.get_info(contract_pk) do
+      {:ok, {type_info, _compiler_vsn, _source_hash}} ->
+        AexnContracts.aex9?(type_info) or AexnContracts.has_aex141_signatures?(height, type_info)
+
+      {:error, _reason} ->
+        false
+    end
+  end
+end

--- a/test/ae_mdw/db/hardfork_presets_test.exs
+++ b/test/ae_mdw/db/hardfork_presets_test.exs
@@ -114,6 +114,15 @@ defmodule AeMdw.Db.HardforkPresetsTest do
       assert HardforkPresets.mint_sum(:fortuna) == 72_681_157_406_723_951_132_840_970
       assert HardforkPresets.mint_sum(:lima) == 86_948_638_040_240_004_719_633_952
     end
+
+    test "returns zero for a hardfork that migrates no accounts" do
+      assert HardforkPresets.mint_sum(:iris) == 0
+      assert HardforkPresets.mint_sum(:ceres) == 0
+    end
+
+    test "returns zero instead of raising for a protocol newer than the ones listed" do
+      assert HardforkPresets.mint_sum(:protocol_not_listed_here) == 0
+    end
   end
 
   defp clear_import do

--- a/test/ae_mdw/db/node_store_test.exs
+++ b/test/ae_mdw/db/node_store_test.exs
@@ -10,8 +10,12 @@ defmodule AeMdw.Db.NodeStoreTest do
   @table Model.Mempool
 
   setup do
+    # a previous run's table can outlive its owning process; clear it first
+    if :ets.whereis(:mempool) != :undefined, do: :ets.delete(:mempool)
+
     # create a mnesia table
     table = :ets.new(:mempool, [:set, :named_table, :ordered_set])
+    on_exit(fn -> if :ets.whereis(:mempool) != :undefined, do: :ets.delete(:mempool) end)
 
     # insert some data
     true = :ets.insert(table, {1, {:val1, :val2}})

--- a/test/ae_mdw/dry_run/runner_test.exs
+++ b/test/ae_mdw/dry_run/runner_test.exs
@@ -1,8 +1,15 @@
 defmodule AeMdw.DryRun.RunnerTest do
   use ExUnit.Case
 
+  import Mock
+
   alias AeMdw.Node.Db, as: DBN
   alias AeMdw.DryRun.Runner
+
+  @contract_pk <<1::256>>
+  @block_hash <<2::256>>
+  @height 500_000
+  @introspection_methods ["meta_info", "aex9_extensions", "aex141_extensions"]
 
   setup_all do
     # Maintenance-mode boot skips aec_db:put_backend_module/1, so any test
@@ -16,6 +23,38 @@ defmodule AeMdw.DryRun.RunnerTest do
     test "returs error when contract does not exist" do
       assert {:error, :contract_does_not_exist} =
                Runner.call_contract(<<123_456::256>>, DBN.top_height_hash(false), "balances", [])
+    end
+
+    test "gives the AEX-N introspection calls an execution budget, not the call tx base gas" do
+      test_pid = self()
+
+      protocol = :aec_hard_forks.protocol_effective_at_height(@height)
+      call_tx_base_gas = :aec_governance.tx_base_gas(:contract_call_tx, protocol, 3)
+
+      with_mock :aec_dry_run, [:passthrough],
+        dry_run: fn _block_hash, _accounts, [{:tx, aetx}], _opts ->
+          send(test_pid, {:dry_run_tx, aetx})
+
+          {:error, "not executed"}
+        end do
+        for function_name <- @introspection_methods do
+          assert {:error, :dry_run_error} =
+                   Runner.call_contract(
+                     @contract_pk,
+                     {:key, @height, @block_hash},
+                     function_name,
+                     []
+                   )
+
+          assert_received {:dry_run_tx, aetx}
+          assert {:contract_call_tx, call_tx} = :aetx.specialize_type(aetx)
+
+          gas = :aect_call_tx.gas(call_tx)
+
+          assert gas == 6_000_000
+          assert gas > call_tx_base_gas
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Fix AEX-9/AEX-141 metadata indexing dry-runs so `meta_info`,
`aex9_extensions`, and `aex141_extensions` get a real execution gas budget:
`6_000_000` instead of contract-call base gas.

Without this, contracts with large stores can make metadata dry-runs return
`out_of_gas`, and ae_mdw can store that error as token metadata permanently.

Also make `HardforkPresets.mint_sum/1` return `0` for protocols this module
does not list, so a newer node protocol does not crash total-supply calculation.

## Tests

- Added regression coverage for the three metadata dry-runs using `6_000_000` gas.
- Added coverage for Iris, Ceres, and unknown hardforks returning `0`.
- Branch evidence: format, compile, credo, targeted tests, and full `mix test`
  passed in the ae_mdw test image.