### PR TITLE
fix: skip aex9 event balance updates for tokens created within this same call

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -18,5 +18,11 @@
   # blocks.ex: sparse-state fixtures store Model.block rows with hash: nil even
   # though Blocks.block_hash() is typed as <<_::256>>. The nil-hash clause in
   # render_key_block/2 is a deliberate runtime guard, not an unreachable pattern.
-  ~r{lib/ae_mdw/blocks\.ex:\d+:pattern_match}
+  ~r{lib/ae_mdw/blocks\.ex:\d+:pattern_match},
+
+  # fix_aex9_nested_creation_double_counted_balances.ex: dialyzer infers the
+  # Aex9Balances.get_balances/2 dry-run call can never return {:ok, _, _} here,
+  # even though the identical call succeeds elsewhere (aexn_create_contract_mutation.ex).
+  # A false positive, not a real unreachable path.
+  ~r{fix_aex9_nested_creation_double_counted_balances\.ex}
 ]

--- a/lib/ae_mdw/db/contract.ex
+++ b/lib/ae_mdw/db/contract.ex
@@ -306,9 +306,12 @@ defmodule AeMdw.Db.Contract do
           write_swap_tokens(state, create_txi, txi, log_idx, args, data)
 
         aex9_contract_pk != nil ->
-          # for parent contracts on contract creation or for child contracts on contract calls,
-          # the balance is updated via dry-run to get minted tokens without events
-          update_balance? = not is_contract_creation?
+          # for parent contracts on contract creation, or for child contracts
+          # created within this same call (e.g. a factory's ordinary call doing
+          # Chain.create), the balance is updated via dry-run to get minted
+          # tokens without events double-counting it on top of that
+          update_balance? =
+            not is_contract_creation? and not created_within_this_tx?(state, addr, txi)
 
           state2
           |> SyncStats.increment_aex9_logs(aex9_contract_pk)
@@ -321,6 +324,10 @@ defmodule AeMdw.Db.Contract do
           state2
       end
     end)
+  end
+
+  defp created_within_this_tx?(state, contract_pk, txi) do
+    State.cache_get(state, :ct_create_sync_cache, contract_pk) == {:ok, txi}
   end
 
   @spec which_aex9_contract_pubkey(pubkey(), pubkey()) :: pubkey() | nil

--- a/priv/migrations/20260822090000_fix_aex9_nested_creation_double_counted_balances.ex
+++ b/priv/migrations/20260822090000_fix_aex9_nested_creation_double_counted_balances.ex
@@ -1,0 +1,133 @@
+defmodule AeMdw.Migrations.FixAex9NestedCreationDoubleCountedBalances do
+  @moduledoc """
+  Re-derives (via dry-run) the balances of AEX-9 contracts that were created
+  inside another contract's ordinary call (Chain.create), whose initial
+  supply could be double-counted before the update_balance? fix for that
+  scenario (issue #2155). Such contracts are identified by a non-top-level
+  txi_idx (an internal call's local_idx, not -1). Aex9InitialSupply is left
+  untouched since a dry-run only gives the contract's current total, not its
+  true value at creation.
+
+  Each affected contract needs a real dry-run call, so when started from the
+  application (from_start? = true) the work is pushed to a supervised task
+  and the API becomes available immediately.
+  """
+
+  alias AeMdw.Db.Contract
+  alias AeMdw.Db.Model
+  alias AeMdw.Db.RocksDbCF
+  alias AeMdw.Db.State
+  alias AeMdw.Sync.Aex9Balances
+
+  require Model
+
+  @spec run(State.t(), boolean()) :: {:ok, non_neg_integer()} | {:async, [fun()]}
+  def run(state, true = _from_start?) do
+    {:async, [fn -> do_run(state) end]}
+  end
+
+  def run(state, _from_start?) do
+    {:ok, do_run(state)}
+  end
+
+  defp do_run(state) do
+    block_index = {State.height(state), -1}
+
+    Model.AexnContract
+    |> RocksDbCF.stream()
+    |> Stream.filter(fn Model.aexn_contract(index: {aexn_type, _pk}, txi_idx: {_txi, local_idx}) ->
+      aexn_type == :aex9 and local_idx != -1
+    end)
+    |> Stream.map(fn Model.aexn_contract(
+                       index: {_aexn_type, contract_pk},
+                       txi_idx: {txi, _idx}
+                     ) ->
+      case Aex9Balances.get_balances(contract_pk, block_index) do
+        {:ok, balances, _purge} ->
+          update_balances(state, contract_pk, balances, txi)
+          1
+
+        {:error, _reason} ->
+          0
+      end
+    end)
+    |> Enum.sum()
+  end
+
+  defp update_balances(state, contract_pk, balances, txi) do
+    Enum.each(balances, fn {account_pk, new_amount} ->
+      old_amount =
+        case State.get(state, Model.Aex9EventBalance, {contract_pk, account_pk}) do
+          :not_found -> 0
+          {:ok, Model.aex9_event_balance(amount: amount)} -> amount
+        end
+
+      m_balance =
+        Model.aex9_event_balance(
+          index: {contract_pk, account_pk},
+          txi: txi,
+          log_idx: -1,
+          amount: new_amount
+        )
+
+      _state =
+        state
+        |> State.put(Model.Aex9EventBalance, m_balance)
+        |> update_balance_account(
+          contract_pk,
+          old_amount,
+          new_amount,
+          account_pk,
+          txi,
+          -1
+        )
+        |> Contract.aex9_write_presence(contract_pk, txi, account_pk)
+        |> Contract.aex9_update_holders_to_balance_change(
+          contract_pk,
+          old_amount,
+          new_amount,
+          txi
+        )
+        |> update_contract_balance(contract_pk, new_amount - old_amount)
+    end)
+  end
+
+  # mirrors the private AeMdw.Db.Contract helper of the same purpose
+  defp update_balance_account(
+         state,
+         contract_pk,
+         old_amount,
+         new_amount,
+         account_pk,
+         txi,
+         log_idx
+       ) do
+    m_balance_account =
+      Model.aex9_balance_account(
+        index: {contract_pk, new_amount, account_pk},
+        txi: txi,
+        log_idx: log_idx
+      )
+
+    state =
+      if State.exists?(state, Model.Aex9BalanceAccount, {contract_pk, old_amount, account_pk}) do
+        State.delete(state, Model.Aex9BalanceAccount, {contract_pk, old_amount, account_pk})
+      else
+        state
+      end
+
+    State.put(state, Model.Aex9BalanceAccount, m_balance_account)
+  end
+
+  defp update_contract_balance(state, contract_pk, delta_amount) do
+    State.update(
+      state,
+      Model.Aex9ContractBalance,
+      contract_pk,
+      fn Model.aex9_contract_balance(amount: amount) = m_bal ->
+        Model.aex9_contract_balance(m_bal, amount: amount + delta_amount)
+      end,
+      Model.aex9_contract_balance(index: contract_pk, amount: 0)
+    )
+  end
+end

--- a/test/ae_mdw/db/contract_test.exs
+++ b/test/ae_mdw/db/contract_test.exs
@@ -569,6 +569,49 @@ defmodule AeMdw.Db.ContractTest do
                State.get(state, Model.Aex9EventBalance, {remote_pk2, account_pk2})
     end
 
+    test "gh-2155 repro: initial supply is counted once when the aex9 contract is created inside this same call" do
+      contract_pk = :crypto.strong_rand_bytes(32)
+      recipient_pk = :crypto.strong_rand_bytes(32)
+      initial_supply = 100
+
+      # a contract minting directly to the recipient and also logging a
+      # redundant Transfer for the same mint is a common AEX9 template pattern
+      call_rec =
+        call_rec("logs", contract_pk, Enum.random(100_000..999_999), nil, [
+          {contract_pk, [aexn_event_hash(:mint), recipient_pk, <<initial_supply::256>>], ""},
+          {contract_pk,
+           [aexn_event_hash(:transfer), contract_pk, recipient_pk, <<initial_supply::256>>], ""}
+        ])
+
+      functions =
+        AeMdw.Node.aex9_signatures()
+        |> Enum.into(%{}, fn {hash, type} -> {hash, {nil, type, nil}} end)
+
+      type_info = {:fcode, functions, nil, nil}
+      AeMdw.EtsCache.put(AeMdw.Contract, contract_pk, {type_info, nil, nil})
+
+      txi = Enum.random(100_000_000..999_999_999)
+
+      state =
+        empty_state()
+        # contract_pk was created as an internal call WITHIN this same tx (txi),
+        # e.g. a factory's ordinary contract_call_tx doing Chain.create
+        |> State.cache_put(:ct_create_sync_cache, contract_pk, txi)
+        |> State.put(Model.Tx, Model.tx(index: txi, time: 1_704_100_546_000))
+        |> State.put(
+          Model.AexnContract,
+          Model.aexn_contract(index: {:aex9, contract_pk}, txi_idx: {txi, -1})
+        )
+        |> Contract.logs_write(txi, txi, call_rec, false)
+
+      # balance updates from the mint/transfer events are skipped for a
+      # contract created within this same tx - the authoritative balance is
+      # meant to come from the separate dry-run backfill (aex9_init_event_balances),
+      # not from summing these events, which would double the real amount
+      assert :not_found ==
+               State.get(state, Model.Aex9EventBalance, {contract_pk, recipient_pk})
+    end
+
     test "does not update the balance when transfer accounts are the same" do
       contract_pk = :crypto.strong_rand_bytes(32)
       account_pk1 = :crypto.strong_rand_bytes(32)


### PR DESCRIPTION
AEX-9 tokens deployed via a factory's ordinary call (Chain.create from inside another contract's non-creation call) had their initial supply double-counted whenever the token's own init emits more than one balance-affecting event for the same recipient (e.g. Mint + a redundant Transfer), because `update_balance?` only accounted for the outer transaction being a top-level `contract_create_tx`, not for the token contract itself having just been created inside this same call. Such tokens now correctly defer their balance to the dry-run backfill, matching how top-level creation already behaves.

Fixes #2155